### PR TITLE
Add Initial GitHub Actions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 14.x
+    - name: Use Node.js 12.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 12.x
     - run: npm ci
     - run: npm run build:ci --if-present
     - run: npm test
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 14.x
+    - name: Use Node.js 12.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 12.x
     - run: npm ci
     - run: npm run build:ci --if-present


### PR DESCRIPTION
Production builds still go through ADO Pipelines. This adds basic build and linting gates via GitHub