### PR TITLE
Update CODEOWNERS to team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @southpolesteve @ato9000
+* @Azure/cosmos-explorer-owners


### PR DESCRIPTION
Changes CODEOWNERS to point to a team rather than individuals