### PR TITLE
Fix graph tab height issue

### DIFF
--- a/src/Explorer/Controls/Tabs/TabComponent.less
+++ b/src/Explorer/Controls/Tabs/TabComponent.less
@@ -1,6 +1,7 @@
 @import "../../../../less/Common/Constants";
 
 .tabComponentContainer {
+    overflow: hidden;
     height: 100%;
     .flex-display();
     .flex-direction();


### PR DESCRIPTION
This is a regression most likely due to my change in Tab containers.

Unit testing this isn't straightforward, as the entire data explorer UI must be rendered to check that "Load More" isn't occluded by the notification console. The easiest is probably to add an integration test that creates 101 nodes (which hopefully could be done in 1 query) and checks. I will add this in a subsequent change.