### PR TITLE
Switch to Graph explorer gremlin queries to use id and pk inside single quoted strings

### DIFF
--- a/src/Explorer/Graph/GraphExplorerComponent/GraphExplorer.tsx
+++ b/src/Explorer/Graph/GraphExplorerComponent/GraphExplorer.tsx
@@ -1361,15 +1361,34 @@ export class GraphExplorer extends React.Component<GraphExplorerProps, GraphExpl
   /**
    * If collection is not partitioned, return 'id'.
    * If collection is partitioned, return pk-id pair.
+   * public for testing purposes
    * @param vertex
    * @return id
    */
-  private getPkIdFromDocumentId(d: DataModels.DocumentId): string {
-    if (this.props.collectionPartitionKeyProperty && d.hasOwnProperty(this.props.collectionPartitionKeyProperty)) {
-      const pk = (d as any)[this.props.collectionPartitionKeyProperty];
-      return GraphExplorer.generatePkIdPair(pk, d.id);
+  public static getPkIdFromDocumentId(d: DataModels.DocumentId, collectionPartitionKeyProperty: string): string {
+    let { id } = d;
+    if (typeof id !== "string") {
+      const error = `Vertex id is not a string: ${JSON.stringify(id)}.`;
+      NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.Error, error);
+      throw new Error(error);
+    }
+
+    if (collectionPartitionKeyProperty && d.hasOwnProperty(collectionPartitionKeyProperty)) {
+      let pk = (d as any)[collectionPartitionKeyProperty];
+      if (typeof pk !== "string") {
+        if (Array.isArray(pk) && pk.length > 0) {
+          // pk is [{ id: 'id', _value: 'value' }]
+          pk = pk[0]["_value"];
+        } else {
+          const error = `Vertex pk is not a string nor a non-empty array: ${JSON.stringify(pk)}.`;
+          NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.Error, error);
+          throw new Error(error);
+        }
+      }
+
+      return GraphExplorer.generatePkIdPair(pk, id);
     } else {
-      return `'${GraphUtil.escapeSingleQuotes(d.id)}'`;
+      return `'${GraphUtil.escapeSingleQuotes(id)}'`;
     }
   }
 
@@ -1769,7 +1788,7 @@ export class GraphExplorer extends React.Component<GraphExplorerProps, GraphExpl
         const documents = results.documents || [];
         return documents.map(
           (item: DataModels.DocumentId) => {
-            return this.getPkIdFromDocumentId(item);
+            return GraphExplorer.getPkIdFromDocumentId(item, this.props.collectionPartitionKeyProperty);
           },
           (reason: any) => {
             // Failure


### PR DESCRIPTION
This query currently returns a `ScriptEval` error from the gremlin backend: `g.V("foo$bar")`. That's because in TinkerPop, the `$` sign is used for string interpolation as in `g.V("${variable}")`. The proper way is to use single-quoted strings for string literals as in `g.V('foo$bar')`.

All graph operations executed from the UI, GraphExplorer wrap the node vertex id with `g.V(" ")` which trigger the `ScriptEval` error even though the vertex id has a valid name.

This change switches all GraphExplorer's internal queries to single-quoted strings for handling id's and pk values.

It also fixes a bug where the pk value is not a string, but an array of objects which wasn't properly handled.