### PR TITLE
Ability to skip resource validation with RP calls

### DIFF
--- a/src/NotebookWorkspaceManager/NotebookWorkspaceManager.ts
+++ b/src/NotebookWorkspaceManager/NotebookWorkspaceManager.ts
@@ -83,12 +83,9 @@ export class NotebookWorkspaceManager implements ViewModels.NotebookWorkspaceMan
   public async startNotebookWorkspaceAsync(cosmosdbResourceId: string, notebookWorkspaceId: string): Promise<void> {
     const uri = `${cosmosdbResourceId}/notebookWorkspaces/${notebookWorkspaceId}/start`;
     try {
-      return await this.rpClient(uri).postAsync(
-        uri,
-        ArmApiVersions.documentDB,
-        undefined,
-        true /** skip resource validation **/
-      );
+      return await this.rpClient(uri).postAsync(uri, ArmApiVersions.documentDB, undefined, {
+        skipResourceValidation: true
+      });
     } catch (error) {
       Logger.logError(error, "NotebookWorkspaceManager/startNotebookWorkspaceAsync");
       throw error;

--- a/src/ResourceProvider/IResourceProviderClient.ts
+++ b/src/ResourceProvider/IResourceProviderClient.ts
@@ -1,14 +1,28 @@
 export interface IResourceProviderClient<TResource> {
-  deleteAsync(url: string, apiVersion: string, skipResourceValidation?: boolean): Promise<void>;
+  deleteAsync(url: string, apiVersion: string, requestOptions?: IResourceProviderRequestOptions): Promise<void>;
   getAsync(
     url: string,
     apiVersion: string,
     queryString?: string,
-    skipResourceValidation?: boolean
+    requestOptions?: IResourceProviderRequestOptions
   ): Promise<TResource | TResource[]>;
-  postAsync(url: string, apiVersion: string, body: any, skipResourceValidation?: boolean): Promise<any>;
-  putAsync(url: string, apiVersion: string, body: any, skipResourceValidation?: boolean): Promise<TResource>;
-  patchAsync(url: string, apiVersion: string, body: any, skipResourceValidation?: boolean): Promise<TResource>;
+  postAsync(url: string, apiVersion: string, body: any, requestOptions?: IResourceProviderRequestOptions): Promise<any>;
+  putAsync(
+    url: string,
+    apiVersion: string,
+    body: any,
+    requestOptions?: IResourceProviderRequestOptions
+  ): Promise<TResource>;
+  patchAsync(
+    url: string,
+    apiVersion: string,
+    body: any,
+    requestOptions?: IResourceProviderRequestOptions
+  ): Promise<TResource>;
+}
+
+export interface IResourceProviderRequestOptions {
+  skipResourceValidation: boolean;
 }
 
 export interface IResourceProviderClientFactory<TResult> {


### PR DESCRIPTION
This change adds more flexibility in the RP client to skip resource validation when necessary, given we now have some calls that are not limited to CRUD operations on an ARM resource (container restarts for example).