### PR TITLE
Make explicit any a linting error

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 **/node_modules/
 dist/
+Contracts/
 src/Api/Apis.ts
 src/AuthType.ts
 src/Bindings/BindingHandlersRegisterer.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,7 @@ module.exports = {
     curly: "error",
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/no-extraneous-class": "error",
-    "no-null/no-null": "error"
+    "no-null/no-null": "error",
+    "@typescript-eslint/no-explicit-any": "error"
   }
 };


### PR DESCRIPTION
Explicit `any` types is currently a warning, but this turns it into an error. We should avoid using any. Here are some good primers:

https://itnext.io/avoiding-any-in-typescript-advanced-types-and-their-usage-691b02ac345a
https://43081j.com/2019/02/typescript-avoid-using-any

In many cases where `any` is required,  `unknown` is a better type. If `any` is truly needed, we can add an eslint line exception with a comment justifying the exception.