### PR TITLE
Fix styling issues with tabs manager

### DIFF
--- a/less/documentDB.less
+++ b/less/documentDB.less
@@ -2351,6 +2351,7 @@ a:link {
 
 .tabsContainer {
     height: 100%;
+    width: 100%;
     overflow: hidden;
 }
 

--- a/src/explorer.html
+++ b/src/explorer.html
@@ -193,7 +193,11 @@
               <div class="connectExplorer" data-bind="react: splashScreenAdapter"></div>
             </form>
           </div>
-          <tabs-manager class="tabsContainer" params="{data: tabsManager}"></tabs-manager>
+          <tabs-manager
+            class="tabsContainer"
+            params="{data: tabsManager}"
+            data-bind="visible: tabsManager.openedTabs().length > 0"
+          ></tabs-manager>
         </div>
         <!-- Collections Tree and Tabs - End -->
         <div


### PR DESCRIPTION
Currently if I open settings tab, it will only take up half of the screen. This is caused by the last commit of my previous PR: https://github.com/Azure/cosmos-explorer/pull/66.

I'm reverting part of the commit that's causing this bug to unblock the deployment to MPAC.