### PR TITLE
Fix gallery card list disappear bug

### DIFF
--- a/src/Explorer/Controls/NotebookGallery/GalleryViewerComponent.tsx
+++ b/src/Explorer/Controls/NotebookGallery/GalleryViewerComponent.tsx
@@ -389,8 +389,10 @@ export class GalleryViewerComponent extends React.Component<GalleryViewerCompone
   }
 
   private getPageSpecification = (itemIndex?: number, visibleRect?: IRectangle): IPageSpecification => {
-    this.columnCount = Math.floor(visibleRect.width / GalleryCardComponent.CARD_WIDTH);
-    this.rowCount = Math.floor(visibleRect.height / GalleryCardComponent.CARD_HEIGHT);
+    if (itemIndex === 0) {
+      this.columnCount = Math.floor(visibleRect.width / GalleryCardComponent.CARD_WIDTH) || this.columnCount;
+      this.rowCount = Math.ceil(visibleRect.height / GalleryCardComponent.CARD_HEIGHT) || this.rowCount;
+    }
 
     return {
       height: visibleRect.height,


### PR DESCRIPTION
Repro steps for bug:
1. Open official samples in gallery (in DE)
2. Click "Download" button on one of the notebook cards
3. Complete the download and switch back to gallery tab

Expected behavior:
Gallery tab opens with the card list and updated download count on the notebook card

Current behavior:
Gallery tab opens with empty card list

This bug is happening because when download is complete we open a new tab which puts the Gallery tab in background and thus when trying to render the gallery tab to update download count we get `visibleRect` as zero in `getPageSpecification` callback. This leads to us calculating wrong page size. Since we're anyway caching `columnCount` and `rowCount` this change just uses the cached value if the new value results in zero (which should ideally never happen).