### PR TITLE
Use /gallery.html instead of /gallery/index.html as Notebooks Gallery endpoint

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -148,7 +148,7 @@ module.exports = function(env = {}, argv = {}) {
       chunks: ["notebookViewer"]
     }),
     new HtmlWebpackPlugin({
-      filename: "gallery/index.html",
+      filename: "gallery.html",
       template: "src/GalleryViewer/galleryViewer.html",
       chunks: ["galleryViewer"]
     }),


### PR DESCRIPTION
In order to use `https://cosmos.azure.com/gallery` as endpoint for Notebooks Gallery we used `/gallery/index.html` as the path. However this breaks all relative http paths originating from that page (like images, config.json, and other resource files). Using `/gallery.html` instead fixes this issue. If needed we'll need to investigate how we can get `/gallery` path in the future without breaking other things.