### PR TITLE
Fix tabs sizing issue

### DIFF
--- a/less/documentDB.less
+++ b/less/documentDB.less
@@ -2349,9 +2349,9 @@ a:link {
     text-decoration: none;
 }
 
-.tabsContainer {
+.tabsManagerContainer {
     height: 100%;
-    width: 100%;
+    flex-grow: 1;
     overflow: hidden;
 }
 

--- a/src/explorer.html
+++ b/src/explorer.html
@@ -194,7 +194,7 @@
             </form>
           </div>
           <tabs-manager
-            class="tabsContainer"
+            class="tabsManagerContainer"
             params="{data: tabsManager}"
             data-bind="visible: tabsManager.openedTabs().length > 0"
           ></tabs-manager>


### PR DESCRIPTION
Customers are seeing issues in prod where the document tab is only taking up half of the screen. This is our best guess to fix the issue since we are not able to reproduce it.