### PR TITLE
Added support for custom image upload during publish to Gallery

### DIFF
--- a/src/Explorer/Panes/PublishNotebookPaneAdapter.tsx
+++ b/src/Explorer/Panes/PublishNotebookPaneAdapter.tsx
@@ -1,5 +1,4 @@
 import ko from "knockout";
-import { Stack, Text } from "office-ui-fabric-react";
 import * as React from "react";
 import { ReactAdapter } from "../../Bindings/ReactBindingHandler";
 import * as Logger from "../../Common/Logger";

--- a/src/Explorer/Panes/PublishNotebookPaneAdapter.tsx
+++ b/src/Explorer/Panes/PublishNotebookPaneAdapter.tsx
@@ -133,6 +133,7 @@ export class PublishNotebookPaneAdapter implements ReactAdapter {
       notebookDescription: "",
       notebookTags: "",
       notebookAuthor: this.author,
+      notebookCreatedDate: new Date().toISOString(),
       onChangeDescription: (newValue: string) => (this.description = newValue),
       onChangeTags: (newValue: string) => (this.tags = newValue),
       onChangeImageSrc: (newValue: string) => (this.imageSrc = newValue),

--- a/src/Explorer/Panes/PublishNotebookPaneAdapter.tsx
+++ b/src/Explorer/Panes/PublishNotebookPaneAdapter.tsx
@@ -111,7 +111,7 @@ export class PublishNotebookPaneAdapter implements ReactAdapter {
     this.close();
   }
 
-  private createFormErrorForLargeImageSelection = (formError: string, formErrorDetail: string, area: string) => {
+  private createFormErrorForLargeImageSelection = (formError: string, formErrorDetail: string, area: string): void => {
     this.formError = formError;
     this.formErrorDetail = formErrorDetail;
 
@@ -121,7 +121,7 @@ export class PublishNotebookPaneAdapter implements ReactAdapter {
     this.triggerRender();
   };
 
-  private clearFormError = () => {
+  private clearFormError = (): void => {
     this.formError = undefined;
     this.formErrorDetail = undefined;
     this.triggerRender();

--- a/src/Explorer/Panes/PublishNotebookPaneComponent.less
+++ b/src/Explorer/Panes/PublishNotebookPaneComponent.less
@@ -1,0 +1,6 @@
+.publishNotebookPanelContent {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow-y: auto;
+}

--- a/src/Explorer/Panes/PublishNotebookPaneComponent.test.tsx
+++ b/src/Explorer/Panes/PublishNotebookPaneComponent.test.tsx
@@ -1,0 +1,22 @@
+import { shallow } from "enzyme";
+import React from "react";
+import { PublishNotebookPaneComponent, PublishNotebookPaneProps } from "./PublishNotebookPaneComponent";
+
+describe("PublishNotebookPaneComponent", () => {
+  it("renders", () => {
+    const props: PublishNotebookPaneProps = {
+      notebookName: "SampleNotebook.ipynb",
+      notebookDescription: "sample description",
+      notebookTags: "tag1, tag2",
+      notebookAuthor: "CosmosDB",
+      onChangeDescription: undefined,
+      onChangeTags: undefined,
+      onChangeImageSrc: undefined,
+      onError: undefined,
+      clearFormError: undefined
+    };
+
+    const wrapper = shallow(<PublishNotebookPaneComponent {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/Explorer/Panes/PublishNotebookPaneComponent.test.tsx
+++ b/src/Explorer/Panes/PublishNotebookPaneComponent.test.tsx
@@ -9,6 +9,7 @@ describe("PublishNotebookPaneComponent", () => {
       notebookDescription: "sample description",
       notebookTags: "tag1, tag2",
       notebookAuthor: "CosmosDB",
+      notebookCreatedDate: "2020-07-17T00:00:00Z",
       onChangeDescription: undefined,
       onChangeTags: undefined,
       onChangeImageSrc: undefined,

--- a/src/Explorer/Panes/PublishNotebookPaneComponent.tsx
+++ b/src/Explorer/Panes/PublishNotebookPaneComponent.tsx
@@ -24,8 +24,8 @@ interface PublishNotebookPaneState {
 }
 
 export class PublishNotebookPaneComponent extends React.Component<PublishNotebookPaneProps, PublishNotebookPaneState> {
-  private readonly maxImageSizeInMib = 1.5;
-  private readonly ImageTypes = ["URL", "Custom Image"];
+  private static readonly maxImageSizeInMib = 1.5;
+  private static readonly ImageTypes = ["URL", "Custom Image"];
   private descriptionPara1: string;
   private descriptionPara2: string;
   private descriptionProps: ITextFieldProps;
@@ -39,7 +39,7 @@ export class PublishNotebookPaneComponent extends React.Component<PublishNoteboo
     super(props);
 
     this.state = {
-      type: this.ImageTypes[0],
+      type: PublishNotebookPaneComponent.ImageTypes[0],
       notebookDescription: "",
       notebookTags: "",
       imageSrc: undefined
@@ -64,10 +64,10 @@ export class PublishNotebookPaneComponent extends React.Component<PublishNoteboo
     this.descriptionPara1 =
       "This notebook has your data. Please make sure you delete any sensitive data/output before publishing.";
 
-    this.descriptionPara2 = `Would you like to publish and share ${FileSystemUtil.stripExtension(
+    this.descriptionPara2 = `Would you like to publish and share "${FileSystemUtil.stripExtension(
       this.props.notebookName,
       "ipynb"
-    )} to the gallery?`;
+    )}" to the gallery?`;
 
     this.thumbnailUrlProps = {
       label: "Cover image url",
@@ -80,11 +80,9 @@ export class PublishNotebookPaneComponent extends React.Component<PublishNoteboo
 
     this.thumbnailSelectorProps = {
       label: "Cover image",
-      defaultSelectedKey: this.ImageTypes[0],
+      defaultSelectedKey: PublishNotebookPaneComponent.ImageTypes[0],
       ariaLabel: "Cover image",
-      options: this.ImageTypes.map((value: string) => {
-        return { text: value, key: value };
-      }),
+      options: PublishNotebookPaneComponent.ImageTypes.map((value: string) => ({ text: value, key: value })),
       onChange: (event, options) => {
         this.setState({ type: options.text });
       }
@@ -139,7 +137,7 @@ export class PublishNotebookPaneComponent extends React.Component<PublishNoteboo
             <Dropdown {...this.thumbnailSelectorProps} />
           </Stack.Item>
 
-          {this.state.type === this.ImageTypes[0] ? (
+          {this.state.type === PublishNotebookPaneComponent.ImageTypes[0] ? (
             <Stack.Item>
               <TextField {...this.thumbnailUrlProps} />
             </Stack.Item>
@@ -151,10 +149,10 @@ export class PublishNotebookPaneComponent extends React.Component<PublishNoteboo
                 accept="image/*"
                 onChange={event => {
                   const file = event.target.files[0];
-                  if (file.size / 1024 ** 2 > this.maxImageSizeInMib) {
+                  if (file.size / 1024 ** 2 > PublishNotebookPaneComponent.maxImageSizeInMib) {
                     event.target.value = "";
                     const formError = `Failed to upload ${file.name}`;
-                    const formErrorDetail = `Image is larger than ${this.maxImageSizeInMib} MiB. Please Choose a different image.`;
+                    const formErrorDetail = `Image is larger than ${PublishNotebookPaneComponent.maxImageSizeInMib} MiB. Please Choose a different image.`;
                     const area = "PublishNotebookPaneComponent/selectImageFile";
 
                     this.props.onError(formError, formErrorDetail, area);

--- a/src/Explorer/Panes/PublishNotebookPaneComponent.tsx
+++ b/src/Explorer/Panes/PublishNotebookPaneComponent.tsx
@@ -1,4 +1,4 @@
-import { ITextFieldProps, Stack, Text, TextField, Dropdown, IDropdownProps, Button } from "office-ui-fabric-react";
+import { ITextFieldProps, Stack, Text, TextField, Dropdown, IDropdownProps } from "office-ui-fabric-react";
 import * as React from "react";
 import { GalleryCardComponent } from "../Controls/NotebookGallery/Cards/GalleryCardComponent";
 import { FileSystemUtil } from "../Notebook/FileSystemUtil";
@@ -46,7 +46,7 @@ export class PublishNotebookPaneComponent extends React.Component<PublishNoteboo
     };
 
     this.imageToBase64 = (file: File, updateImageSrc: (result: string) => void) => {
-      var reader = new FileReader();
+      const reader = new FileReader();
       reader.readAsDataURL(file);
       reader.onload = function() {
         updateImageSrc(reader.result.toString());
@@ -57,7 +57,7 @@ export class PublishNotebookPaneComponent extends React.Component<PublishNoteboo
         const formError = `Failed to convert ${file.name} to base64 format`;
         const formErrorDetail = `${error}`;
         const area = "PublishNotebookPaneComponent/selectImageFile";
-        onError(formErrorDetail, formErrorDetail, area);
+        onError(formError, formErrorDetail, area);
       };
     };
 
@@ -152,7 +152,7 @@ export class PublishNotebookPaneComponent extends React.Component<PublishNoteboo
                 onChange={event => {
                   const file = event.target.files[0];
                   if (file.size / 1024 ** 2 > this.maxImageSizeInMib) {
-                    event.target.value = null;
+                    event.target.value = "";
                     const formError = `Failed to upload ${file.name}`;
                     const formErrorDetail = `Image is larger than ${this.maxImageSizeInMib} MiB. Please Choose a different image.`;
                     const area = "PublishNotebookPaneComponent/selectImageFile";

--- a/src/Explorer/Panes/PublishNotebookPaneComponent.tsx
+++ b/src/Explorer/Panes/PublishNotebookPaneComponent.tsx
@@ -1,0 +1,209 @@
+import { ITextFieldProps, Stack, Text, TextField, Dropdown, IDropdownProps, Button } from "office-ui-fabric-react";
+import * as React from "react";
+import { GalleryCardComponent } from "../Controls/NotebookGallery/Cards/GalleryCardComponent";
+import { FileSystemUtil } from "../Notebook/FileSystemUtil";
+import "./PublishNotebookPaneComponent.less";
+
+export interface PublishNotebookPaneProps {
+  notebookName: string;
+  notebookDescription: string;
+  notebookTags: string;
+  notebookAuthor: string;
+  onChangeDescription: (newValue: string) => void;
+  onChangeTags: (newValue: string) => void;
+  onChangeImageSrc: (newValue: string) => void;
+  onError: (formError: string, formErrorDetail: string, area: string) => void;
+  clearFormError: () => void;
+}
+
+interface PublishNotebookPaneState {
+  type: string;
+  notebookDescription: string;
+  notebookTags: string;
+  imageSrc: string;
+}
+
+export class PublishNotebookPaneComponent extends React.Component<PublishNotebookPaneProps, PublishNotebookPaneState> {
+  private readonly maxImageSizeInMib = 1.5;
+  private readonly ImageTypes = ["URL", "Custom Image"];
+  private descriptionPara1: string;
+  private descriptionPara2: string;
+  private descriptionProps: ITextFieldProps;
+  private tagsProps: ITextFieldProps;
+  private thumbnailUrlProps: ITextFieldProps;
+  private thumbnailSelectorProps: IDropdownProps;
+  private dateString: string;
+  private imageToBase64: (file: File, updateImageSrc: (result: string) => void) => void;
+
+  constructor(props: PublishNotebookPaneProps) {
+    super(props);
+
+    this.state = {
+      type: this.ImageTypes[0],
+      notebookDescription: "",
+      notebookTags: "",
+      imageSrc: undefined
+    };
+
+    this.imageToBase64 = (file: File, updateImageSrc: (result: string) => void) => {
+      var reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onload = function() {
+        updateImageSrc(reader.result.toString());
+      };
+
+      const onError = this.props.onError;
+      reader.onerror = function(error) {
+        const formError = `Failed to convert ${file.name} to base64 format`;
+        const formErrorDetail = `${error}`;
+        const area = "PublishNotebookPaneComponent/selectImageFile";
+        onError(formErrorDetail, formErrorDetail, area);
+      };
+    };
+
+    this.descriptionPara1 =
+      "This notebook has your data. Please make sure you delete any sensitive data/output before publishing.";
+
+    this.descriptionPara2 = `Would you like to publish and share ${FileSystemUtil.stripExtension(
+      this.props.notebookName,
+      "ipynb"
+    )} to the gallery?`;
+
+    this.thumbnailUrlProps = {
+      label: "Cover image url",
+      ariaLabel: "Cover image url",
+      onChange: (event, newValue) => {
+        this.props.onChangeImageSrc(newValue);
+        this.setState({ imageSrc: newValue });
+      }
+    };
+
+    this.thumbnailSelectorProps = {
+      label: "Cover image",
+      defaultSelectedKey: this.ImageTypes[0],
+      ariaLabel: "Cover image",
+      options: this.ImageTypes.map((value: string) => {
+        return { text: value, key: value };
+      }),
+      onChange: (event, options) => {
+        this.setState({ type: options.text });
+      }
+    };
+
+    this.descriptionProps = {
+      label: "Description",
+      ariaLabel: "Description",
+      multiline: true,
+      rows: 3,
+      required: true,
+      onChange: (event, newValue) => {
+        this.props.onChangeDescription(newValue);
+        this.setState({ notebookDescription: newValue });
+      }
+    };
+
+    this.tagsProps = {
+      label: "Tags",
+      ariaLabel: "Tags",
+      placeholder: "Optional tag 1, Optional tag 2",
+      onChange: (event, newValue) => {
+        this.props.onChangeTags(newValue);
+        this.setState({ notebookTags: newValue });
+      }
+    };
+
+    this.dateString = new Date().toISOString();
+  }
+
+  public render(): JSX.Element {
+    return (
+      <div className="publishNotebookPanelContent">
+        <Stack className="panelMainContent" tokens={{ childrenGap: 20 }}>
+          <Stack.Item>
+            <Text>{this.descriptionPara1}</Text>
+          </Stack.Item>
+
+          <Stack.Item>
+            <Text>{this.descriptionPara2}</Text>
+          </Stack.Item>
+
+          <Stack.Item>
+            <TextField {...this.descriptionProps} />
+          </Stack.Item>
+
+          <Stack.Item>
+            <TextField {...this.tagsProps} />
+          </Stack.Item>
+
+          <Stack.Item>
+            <Dropdown {...this.thumbnailSelectorProps} />
+          </Stack.Item>
+
+          {this.state.type === this.ImageTypes[0] ? (
+            <Stack.Item>
+              <TextField {...this.thumbnailUrlProps} />
+            </Stack.Item>
+          ) : (
+            <Stack.Item>
+              <input
+                id="selectImageFile"
+                type="file"
+                accept="image/*"
+                onChange={event => {
+                  const file = event.target.files[0];
+                  if (file.size / 1024 ** 2 > this.maxImageSizeInMib) {
+                    event.target.value = null;
+                    const formError = `Failed to upload ${file.name}`;
+                    const formErrorDetail = `Image is larger than ${this.maxImageSizeInMib} MiB. Please Choose a different image.`;
+                    const area = "PublishNotebookPaneComponent/selectImageFile";
+
+                    this.props.onError(formError, formErrorDetail, area);
+                    this.props.onChangeImageSrc(undefined);
+                    this.setState({ imageSrc: undefined });
+                    return;
+                  } else {
+                    this.props.clearFormError();
+                  }
+                  this.imageToBase64(file, (result: string) => {
+                    this.props.onChangeImageSrc(result);
+                    this.setState({ imageSrc: result });
+                  });
+                }}
+              />
+            </Stack.Item>
+          )}
+          <Stack.Item>
+            <Text>Preview</Text>
+          </Stack.Item>
+          <Stack.Item>
+            <GalleryCardComponent
+              data={{
+                id: undefined,
+                name: this.props.notebookName,
+                description: this.state.notebookDescription,
+                gitSha: undefined,
+                tags: this.state.notebookTags.split(","),
+                author: this.props.notebookAuthor,
+                thumbnailUrl: this.state.imageSrc,
+                created: this.dateString,
+                isSample: false,
+                downloads: 0,
+                favorites: 0,
+                views: 0
+              }}
+              isFavorite={false}
+              showDownload={true}
+              showDelete={true}
+              onClick={undefined}
+              onTagClick={undefined}
+              onFavoriteClick={undefined}
+              onUnfavoriteClick={undefined}
+              onDownloadClick={undefined}
+              onDeleteClick={undefined}
+            />
+          </Stack.Item>
+        </Stack>
+      </div>
+    );
+  }
+}

--- a/src/Explorer/Panes/PublishNotebookPaneComponent.tsx
+++ b/src/Explorer/Panes/PublishNotebookPaneComponent.tsx
@@ -9,6 +9,7 @@ export interface PublishNotebookPaneProps {
   notebookDescription: string;
   notebookTags: string;
   notebookAuthor: string;
+  notebookCreatedDate: string;
   onChangeDescription: (newValue: string) => void;
   onChangeTags: (newValue: string) => void;
   onChangeImageSrc: (newValue: string) => void;
@@ -32,7 +33,6 @@ export class PublishNotebookPaneComponent extends React.Component<PublishNoteboo
   private tagsProps: ITextFieldProps;
   private thumbnailUrlProps: ITextFieldProps;
   private thumbnailSelectorProps: IDropdownProps;
-  private dateString: string;
   private imageToBase64: (file: File, updateImageSrc: (result: string) => void) => void;
 
   constructor(props: PublishNotebookPaneProps) {
@@ -109,8 +109,6 @@ export class PublishNotebookPaneComponent extends React.Component<PublishNoteboo
         this.setState({ notebookTags: newValue });
       }
     };
-
-    this.dateString = new Date().toISOString();
   }
 
   public render(): JSX.Element {
@@ -183,7 +181,7 @@ export class PublishNotebookPaneComponent extends React.Component<PublishNoteboo
                 tags: this.state.notebookTags.split(","),
                 author: this.props.notebookAuthor,
                 thumbnailUrl: this.state.imageSrc,
-                created: this.dateString,
+                created: this.props.notebookCreatedDate,
                 isSample: false,
                 downloads: 0,
                 favorites: 0,

--- a/src/Explorer/Panes/__snapshots__/PublishNotebookPaneComponent.test.tsx.snap
+++ b/src/Explorer/Panes/__snapshots__/PublishNotebookPaneComponent.test.tsx.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PublishNotebookPaneComponent renders 1`] = `
+<div
+  className="publishNotebookPanelContent"
+>
+  <Stack
+    className="panelMainContent"
+    tokens={
+      Object {
+        "childrenGap": 20,
+      }
+    }
+  >
+    <StackItem>
+      <Text>
+        This notebook has your data. Please make sure you delete any sensitive data/output before publishing.
+      </Text>
+    </StackItem>
+    <StackItem>
+      <Text>
+        Would you like to publish and share "SampleNotebook" to the gallery?
+      </Text>
+    </StackItem>
+    <StackItem>
+      <StyledTextFieldBase
+        ariaLabel="Description"
+        label="Description"
+        multiline={true}
+        onChange={[Function]}
+        required={true}
+        rows={3}
+      />
+    </StackItem>
+    <StackItem>
+      <StyledTextFieldBase
+        ariaLabel="Tags"
+        label="Tags"
+        onChange={[Function]}
+        placeholder="Optional tag 1, Optional tag 2"
+      />
+    </StackItem>
+    <StackItem>
+      <StyledWithResponsiveMode
+        ariaLabel="Cover image"
+        defaultSelectedKey="URL"
+        label="Cover image"
+        onChange={[Function]}
+        options={
+          Array [
+            Object {
+              "key": "URL",
+              "text": "URL",
+            },
+            Object {
+              "key": "Custom Image",
+              "text": "Custom Image",
+            },
+          ]
+        }
+      />
+    </StackItem>
+    <StackItem>
+      <StyledTextFieldBase
+        ariaLabel="Cover image url"
+        label="Cover image url"
+        onChange={[Function]}
+      />
+    </StackItem>
+    <StackItem>
+      <Text>
+        Preview
+      </Text>
+    </StackItem>
+    <StackItem>
+      <GalleryCardComponent
+        data={
+          Object {
+            "author": "CosmosDB",
+            "created": "2020-07-17T14:33:06.100Z",
+            "description": "",
+            "downloads": 0,
+            "favorites": 0,
+            "gitSha": undefined,
+            "id": undefined,
+            "isSample": false,
+            "name": "SampleNotebook.ipynb",
+            "tags": Array [
+              "",
+            ],
+            "thumbnailUrl": undefined,
+            "views": 0,
+          }
+        }
+        isFavorite={false}
+        showDelete={true}
+        showDownload={true}
+      />
+    </StackItem>
+  </Stack>
+</div>
+`;

--- a/src/Explorer/Panes/__snapshots__/PublishNotebookPaneComponent.test.tsx.snap
+++ b/src/Explorer/Panes/__snapshots__/PublishNotebookPaneComponent.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`PublishNotebookPaneComponent renders 1`] = `
         data={
           Object {
             "author": "CosmosDB",
-            "created": "2020-07-17T14:33:06.100Z",
+            "created": "2020-07-17T00:00:00Z",
             "description": "",
             "downloads": 0,
             "favorites": 0,


### PR DESCRIPTION
- Dropdown gives an option for URL or image upload
- Preview shows how the card will be displayed in the gallery, updated in real time including preview of the cover image
- base64 converted image stored in metadata document
- Max limit is 1.5MiB for the image (As max document size for cosmos db is 2 MB)
- If an image with size > 1.5Mib is selected, failure message is shown and state is reset

Future work includes providing an option for 
- Adding the first visualization in the notebook
- Adding screenshot of the notebook in the desired aspect ratio

![custom image upload](https://user-images.githubusercontent.com/13487215/87739076-d374f980-c793-11ea-929b-365a2e0d52a6.gif)
