### PR TITLE
Support cosmos readers in Cosmos Explorer

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -351,6 +351,7 @@ export class HttpStatusCodes {
   public static readonly Created: number = 201;
   public static readonly Accepted: number = 202;
   public static readonly NoContent: number = 204;
+  public static readonly NotModified: number = 304;
   public static readonly Unauthorized: number = 401;
   public static readonly Forbidden: number = 403;
   public static readonly NotFound: number = 404;

--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -437,10 +437,8 @@ export interface Tenant {
 export interface AccountKeys {
   primaryMasterKey: string;
   secondaryMasterKey: string;
-  properties: {
-    primaryReadonlyMasterKey: string;
-    secondaryReadonlyMasterKey: string;
-  };
+  primaryReadonlyMasterKey: string;
+  secondaryReadonlyMasterKey: string;
 }
 
 export interface AfecFeature {

--- a/src/Platform/Hosted/Main.ts
+++ b/src/Platform/Hosted/Main.ts
@@ -568,8 +568,9 @@ export default class Main {
 
     this._explorer.hideConnectExplorerForm();
 
+    const masterKey = Main._getMasterKey(keys);
     HostedExplorerFactory.reInitializeDocumentClientUtilityForExplorer(this._explorer);
-    Main._setExplorerReady(this._explorer, keys.primaryMasterKey, account, authorizationToken);
+    Main._setExplorerReady(this._explorer, masterKey, account, authorizationToken);
   }
 
   private static _handleGetAccessAadSucceed(response: [DatabaseAccount, AccountKeys, string]) {
@@ -577,10 +578,19 @@ export default class Main {
       return;
     }
     const account = response[0];
-    const keys = response[1];
+    const masterKey = Main._getMasterKey(response[1]);
     const authorizationToken = response[2];
-    Main._setExplorerReady(this._explorer, keys.primaryMasterKey, account, authorizationToken);
+    Main._setExplorerReady(this._explorer, masterKey, account, authorizationToken);
     this._getAadAccessDeferred.resolve(this._explorer);
+  }
+
+  private static _getMasterKey(keys: AccountKeys): string {
+    return (
+      keys?.primaryMasterKey ??
+      keys?.secondaryMasterKey ??
+      keys?.primaryReadonlyMasterKey ??
+      keys?.secondaryReadonlyMasterKey
+    );
   }
 
   private static _handleGetAccessAadFailed(error: any) {


### PR DESCRIPTION
Cosmos DB readers cannot use the same API that is used by contributors to fetch Cosmos DB keys, so this change falls back to this other API to fetch read only keys for readers.