### PR TITLE
Fix handling numeric partition keys

### DIFF
--- a/src/Explorer/Graph/GraphExplorerComponent/GraphExplorer.test.tsx
+++ b/src/Explorer/Graph/GraphExplorerComponent/GraphExplorer.test.tsx
@@ -86,13 +86,26 @@ describe("getPkIdFromDocumentId", () => {
     expect(GraphExplorer.getPkIdFromDocumentId(doc, "mypk")).toEqual("['pkvalue', 'id']");
   });
 
+  it("should create pkid pair from partitioned graph (pk as number)", () => {
+    const doc = createFakeDoc({ id: "id", mypk: 234 });
+    expect(GraphExplorer.getPkIdFromDocumentId(doc, "mypk")).toEqual("[234, 'id']");
+  });
+
   it("should create pkid pair from partitioned graph (pk as valid array value)", () => {
     const doc = createFakeDoc({ id: "id", mypk: [{ id: "someid", _value: "pkvalue" }] });
     expect(GraphExplorer.getPkIdFromDocumentId(doc, "mypk")).toEqual("['pkvalue', 'id']");
   });
 
-  it("should error if id is not a string", () => {
-    const doc = createFakeDoc({ id: { foo: 1 } });
+  it("should error if id is not a string or number", () => {
+    let doc = createFakeDoc({ id: { foo: 1 } });
+    try {
+      GraphExplorer.getPkIdFromDocumentId(doc, undefined);
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(true).toBe(true);
+    }
+
+    doc = createFakeDoc({ id: true });
     try {
       GraphExplorer.getPkIdFromDocumentId(doc, undefined);
       expect(true).toBe(false);
@@ -101,16 +114,8 @@ describe("getPkIdFromDocumentId", () => {
     }
   });
 
-  it("should error if pk not string nor non-empty array", () => {
-    let doc = createFakeDoc({ mypk: { foo: 1 } });
-
-    try {
-      GraphExplorer.getPkIdFromDocumentId(doc, "mypk");
-    } catch (e) {
-      expect(true).toBe(true);
-    }
-
-    doc = createFakeDoc({ mypk: [] });
+  it("should error if pk is empty array", () => {
+    let doc = createFakeDoc({ mypk: [] });
     try {
       GraphExplorer.getPkIdFromDocumentId(doc, "mypk");
       expect(true).toBe(false);

--- a/src/Explorer/Graph/GraphExplorerComponent/GraphExplorer.tsx
+++ b/src/Explorer/Graph/GraphExplorerComponent/GraphExplorer.tsx
@@ -1375,7 +1375,7 @@ export class GraphExplorer extends React.Component<GraphExplorerProps, GraphExpl
 
     if (collectionPartitionKeyProperty && d.hasOwnProperty(collectionPartitionKeyProperty)) {
       let pk = (d as any)[collectionPartitionKeyProperty];
-      if (typeof pk !== "string") {
+      if (typeof pk !== "string" && typeof pk !== "number") {
         if (Array.isArray(pk) && pk.length > 0) {
           // pk is [{ id: 'id', _value: 'value' }]
           pk = pk[0]["_value"];


### PR DESCRIPTION
Rather than being sent as a gremlin query, the `g.V()` query is intercepted by GraphExplorer and processed as a sql query: this allows paging and the code path involves processing the response and issuing more (gremlin) queries to display the node's neighbors.

This change fixes a bug that incorrectly errors when processing the `g.V()` results and encountering numeric partition key value.