### PR TITLE
Refactor DocumentClientUtilityBase to not be a class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - run: npm run test
   build:
     runs-on: ubuntu-latest
+    needs: [lint, format, compile, unittest]
     name: "Build"
     steps:
       - uses: actions/checkout@v2
@@ -75,6 +76,7 @@ jobs:
           path: dist/
   endtoendemulator:
     name: "End To End Tests | Emulator | SQL"
+    needs: [lint, format, compile, unittest]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
@@ -101,6 +103,7 @@ jobs:
           CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
   endtoendsql:
     name: "End To End Tests | SQL"
+    needs: [lint, format, compile, unittest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -129,6 +132,7 @@ jobs:
           CYPRESS_CONNECTION_STRING: ${{ secrets.CONNECTION_STRING_SQL }}
   endtoendmongo:
     name: "End To End Tests | Mongo"
+    needs: [lint, format, compile, unittest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -157,6 +161,7 @@ jobs:
           CYPRESS_CONNECTION_STRING: ${{ secrets.CONNECTION_STRING_MONGO }}
   accessibility:
     name: "Accessibility | Hosted"
+    needs: [lint, format, compile, unittest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/jest.config.js
+++ b/jest.config.js
@@ -39,10 +39,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 18,
-      functions: 22,
-      lines: 28,
-      statements: 27
+      branches: 19.5,
+      functions: 24,
+      lines: 29.5,
+      statements: 28.5
     }
   },
 

--- a/src/Common/DocumentClientUtilityBase.ts
+++ b/src/Common/DocumentClientUtilityBase.ts
@@ -15,1134 +15,1143 @@ import { RequestOptions } from "@azure/cosmos/dist-esm";
 import StoredProcedure from "../Explorer/Tree/StoredProcedure";
 
 // TODO: Log all promise resolutions and errors with verbosity levels
-export default class DocumentClientUtilityBase {
-  public queryDocuments(
-    databaseId: string,
-    containerId: string,
-    query: string,
-    options: any
-  ): Q.Promise<QueryIterator<ItemDefinition & Resource>> {
-    return DataAccessUtilityBase.queryDocuments(databaseId, containerId, query, options);
+export function queryDocuments(
+  databaseId: string,
+  containerId: string,
+  query: string,
+  options: any
+): Q.Promise<QueryIterator<ItemDefinition & Resource>> {
+  return DataAccessUtilityBase.queryDocuments(databaseId, containerId, query, options);
+}
+
+export function queryConflicts(
+  databaseId: string,
+  containerId: string,
+  query: string,
+  options: any
+): Q.Promise<QueryIterator<ConflictDefinition & Resource>> {
+  return DataAccessUtilityBase.queryConflicts(databaseId, containerId, query, options);
+}
+
+export function getEntityName() {
+  const defaultExperience =
+    window.dataExplorer && window.dataExplorer.defaultExperience && window.dataExplorer.defaultExperience();
+  if (defaultExperience === Constants.DefaultAccountExperience.MongoDB) {
+    return "document";
   }
-
-  public queryConflicts(
-    databaseId: string,
-    containerId: string,
-    query: string,
-    options: any
-  ): Q.Promise<QueryIterator<ConflictDefinition & Resource>> {
-    return DataAccessUtilityBase.queryConflicts(databaseId, containerId, query, options);
-  }
-
-  public getEntityName() {
-    const defaultExperience =
-      window.dataExplorer && window.dataExplorer.defaultExperience && window.dataExplorer.defaultExperience();
-    if (defaultExperience === Constants.DefaultAccountExperience.MongoDB) {
-      return "document";
-    }
-    return "item";
-  }
-
-  public readStoredProcedures(
-    collection: ViewModels.Collection,
-    options: any = {}
-  ): Q.Promise<DataModels.StoredProcedure[]> {
-    var deferred = Q.defer<DataModels.StoredProcedure[]>();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Querying stored procedures for container ${collection.id()}`
-    );
-    DataAccessUtilityBase.readStoredProcedures(collection, options)
-      .then(
-        (storedProcedures: DataModels.StoredProcedure[]) => {
-          deferred.resolve(storedProcedures);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Failed to query stored procedures for container ${collection.id()}: ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "ReadStoredProcedures", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public readStoredProcedure(
-    collection: ViewModels.Collection,
-    requestedResource: DataModels.Resource,
-    options?: any
-  ): Q.Promise<DataModels.StoredProcedure> {
-    return DataAccessUtilityBase.readStoredProcedure(collection, requestedResource, options);
-  }
-
-  public readUserDefinedFunctions(
-    collection: ViewModels.Collection,
-    options: any = {}
-  ): Q.Promise<DataModels.UserDefinedFunction[]> {
-    var deferred = Q.defer<DataModels.UserDefinedFunction[]>();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Querying user defined functions for collection ${collection.id()}`
-    );
-    DataAccessUtilityBase.readUserDefinedFunctions(collection, options)
-      .then(
-        (userDefinedFunctions: DataModels.UserDefinedFunction[]) => {
-          deferred.resolve(userDefinedFunctions);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Failed to query user defined functions for container ${collection.id()}: ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "ReadUDFs", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public readUserDefinedFunction(
-    collection: ViewModels.Collection,
-    requestedResource: DataModels.Resource,
-    options: any
-  ): Q.Promise<DataModels.UserDefinedFunction> {
-    return DataAccessUtilityBase.readUserDefinedFunction(collection, requestedResource, options);
-  }
-
-  public readTriggers(collection: ViewModels.Collection, options: any): Q.Promise<DataModels.Trigger[]> {
-    var deferred = Q.defer<DataModels.Trigger[]>();
-
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Querying triggers for container ${collection.id()}`
-    );
-    DataAccessUtilityBase.readTriggers(collection, options)
-      .then(
-        (triggers: DataModels.Trigger[]) => {
-          deferred.resolve(triggers);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Failed to query triggers for container ${collection.id()}: ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "ReadTriggers", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public readTrigger(
-    collection: ViewModels.Collection,
-    requestedResource: DataModels.Resource,
-    options?: any
-  ): Q.Promise<DataModels.Trigger> {
-    return DataAccessUtilityBase.readTrigger(collection, requestedResource, options);
-  }
-
-  public executeStoredProcedure(
-    collection: ViewModels.Collection,
-    storedProcedure: StoredProcedure,
-    partitionKeyValue: any,
-    params: any[]
-  ): Q.Promise<any> {
-    var deferred = Q.defer<any>();
-
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Executing stored procedure ${storedProcedure.id()}`
-    );
-    DataAccessUtilityBase.executeStoredProcedure(collection, storedProcedure, partitionKeyValue, params)
-      .then(
-        (response: any) => {
-          deferred.resolve(response);
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Finished executing stored procedure ${storedProcedure.id()} for container ${storedProcedure.collection.id()}`
-          );
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Failed to execute stored procedure ${storedProcedure.id()} for container ${storedProcedure.collection.id()}: ${JSON.stringify(
-              error
-            )}`
-          );
-          Logger.logError(JSON.stringify(error), "ExecuteStoredProcedure", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public queryDocumentsPage(
-    resourceName: string,
-    documentsIterator: MinimalQueryIterator,
-    firstItemIndex: number,
-    options: any
-  ): Q.Promise<ViewModels.QueryResults> {
-    var deferred = Q.defer<ViewModels.QueryResults>();
-    const entityName = this.getEntityName();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Querying ${entityName} for container ${resourceName}`
-    );
-    Q(nextPage(documentsIterator, firstItemIndex))
-      .then(
-        (result: ViewModels.QueryResults) => {
-          const itemCount = (result.documents && result.documents.length) || 0;
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully fetched ${itemCount} ${entityName} for container ${resourceName}`
-          );
-          deferred.resolve(result);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Failed to query ${entityName} for container ${resourceName}: ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "QueryDocumentsPage", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public readDocument(collection: ViewModels.CollectionBase, documentId: ViewModels.DocumentId): Q.Promise<any> {
-    var deferred = Q.defer<any>();
-    const entityName = this.getEntityName();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Reading ${entityName} ${documentId.id()}`
-    );
-    DataAccessUtilityBase.readDocument(collection, documentId)
-      .then(
-        (document: any) => {
-          deferred.resolve(document);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Failed to read ${entityName} ${documentId.id()}: ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "ReadDocument", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public updateCollection(
-    databaseId: string,
-    collection: ViewModels.Collection,
-    newCollection: DataModels.Collection
-  ): Q.Promise<DataModels.Collection> {
-    var deferred = Q.defer<any>();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Updating container ${collection.id()}`
-    );
-    DataAccessUtilityBase.updateCollection(databaseId, collection.id(), newCollection)
-      .then(
-        (replacedCollection: DataModels.Collection) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully updated container ${collection.id()}`
-          );
-          deferred.resolve(replacedCollection);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Failed to update container ${collection.id()}: ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "UpdateCollection", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public updateDocument(
-    collection: ViewModels.CollectionBase,
-    documentId: ViewModels.DocumentId,
-    newDocument: any
-  ): Q.Promise<any> {
-    var deferred = Q.defer<any>();
-    const entityName = this.getEntityName();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Updating ${entityName} ${documentId.id()}`
-    );
-    DataAccessUtilityBase.updateDocument(collection, documentId, newDocument)
-      .then(
-        (updatedDocument: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully updated ${entityName} ${documentId.id()}`
-          );
-          deferred.resolve(updatedDocument);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Failed to update ${entityName} ${documentId.id()}: ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "UpdateDocument", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public updateOffer(
-    offer: DataModels.Offer,
-    newOffer: DataModels.Offer,
-    options: RequestOptions
-  ): Q.Promise<DataModels.Offer> {
-    var deferred = Q.defer<any>();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Updating offer for resource ${offer.resource}`
-    );
-    DataAccessUtilityBase.updateOffer(offer, newOffer, options)
-      .then(
-        (replacedOffer: DataModels.Offer) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully updated offer for resource ${offer.resource}`
-          );
-          deferred.resolve(replacedOffer);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error updating offer for resource ${offer.resource}: ${JSON.stringify(error)}`
-          );
-          Logger.logError(
-            JSON.stringify({
-              oldOffer: offer,
-              newOffer: newOffer,
-              error: error
-            }),
-            "UpdateOffer",
-            error.code
-          );
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public updateOfferThroughputBeyondLimit(requestPayload: DataModels.UpdateOfferThroughputRequest): Q.Promise<void> {
-    const deferred: Q.Deferred<void> = Q.defer<void>();
-    const resourceDescriptionInfo: string = requestPayload.collectionName
-      ? `database ${requestPayload.databaseName} and container ${requestPayload.collectionName}`
-      : `database ${requestPayload.databaseName}`;
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Requesting increase in throughput to ${requestPayload.throughput} for ${resourceDescriptionInfo}`
-    );
-    DataAccessUtilityBase.updateOfferThroughputBeyondLimit(requestPayload)
-      .then(
-        () => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully requested an increase in throughput to ${requestPayload.throughput} for ${resourceDescriptionInfo}`
-          );
-          deferred.resolve();
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Failed to request an increase in throughput for ${requestPayload.throughput}: ${JSON.stringify(error)}`
-          );
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => NotificationConsoleUtils.clearInProgressMessageWithId(id));
-
-    return deferred.promise.timeout(Constants.ClientDefaults.requestTimeoutMs);
-  }
-
-  public updateStoredProcedure(
-    collection: ViewModels.Collection,
-    storedProcedure: DataModels.StoredProcedure,
-    options?: any
-  ): Q.Promise<DataModels.StoredProcedure> {
-    var deferred = Q.defer<any>();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Updating stored procedure ${storedProcedure.id}`
-    );
-    DataAccessUtilityBase.updateStoredProcedure(collection, storedProcedure, options)
-      .then(
-        (updatedStoredProcedure: DataModels.StoredProcedure) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully updated stored procedure ${storedProcedure.id}`
-          );
-          deferred.resolve(updatedStoredProcedure);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while updating stored procedure ${storedProcedure.id}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "UpdateStoredProcedure", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public updateUserDefinedFunction(
-    collection: ViewModels.Collection,
-    userDefinedFunction: DataModels.UserDefinedFunction,
-    options: any = {}
-  ): Q.Promise<DataModels.UserDefinedFunction> {
-    var deferred = Q.defer<any>();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Updating user defined function ${userDefinedFunction.id}`
-    );
-    DataAccessUtilityBase.updateUserDefinedFunction(collection, userDefinedFunction, options)
-      .then(
-        (updatedUserDefinedFunction: DataModels.UserDefinedFunction) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully updated user defined function ${userDefinedFunction.id}`
-          );
-          deferred.resolve(updatedUserDefinedFunction);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while updating user defined function ${userDefinedFunction.id}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "UpdateUDF", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public updateTrigger(collection: ViewModels.Collection, trigger: DataModels.Trigger): Q.Promise<DataModels.Trigger> {
-    var deferred = Q.defer<any>();
-    const id = NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.InProgress, `Updating trigger ${trigger.id}`);
-    DataAccessUtilityBase.updateTrigger(collection, trigger)
-      .then(
-        (updatedTrigger: DataModels.Trigger) => {
-          NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.Info, `Updated trigger ${trigger.id}`);
-          deferred.resolve(updatedTrigger);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while updating trigger ${trigger.id}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "UpdateTrigger", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public createDocument(collection: ViewModels.CollectionBase, newDocument: any): Q.Promise<any> {
-    var deferred = Q.defer<any>();
-    const entityName = this.getEntityName();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Creating new ${entityName} for container ${collection.id()}`
-    );
-    DataAccessUtilityBase.createDocument(collection, newDocument)
-      .then(
-        (savedDocument: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully created new ${entityName} for container ${collection.id()}`
-          );
-          deferred.resolve(savedDocument);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while creating new ${entityName} for container ${collection.id()}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "CreateDocument", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public createStoredProcedure(
-    collection: ViewModels.Collection,
-    newStoredProcedure: DataModels.StoredProcedure,
-    options?: any
-  ): Q.Promise<DataModels.StoredProcedure> {
-    var deferred = Q.defer<any>();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Creating stored procedure for container ${collection.id()}`
-    );
-    DataAccessUtilityBase.createStoredProcedure(collection, newStoredProcedure, options)
-      .then(
-        (createdStoredProcedure: DataModels.StoredProcedure) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully created stored procedure for container ${collection.id()}`
-          );
-          deferred.resolve(createdStoredProcedure);
-        },
-        error => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while creating stored procedure for container ${collection.id()}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "CreateStoredProcedure", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public createUserDefinedFunction(
-    collection: ViewModels.Collection,
-    newUserDefinedFunction: DataModels.UserDefinedFunction,
-    options?: any
-  ): Q.Promise<DataModels.UserDefinedFunction> {
-    var deferred = Q.defer<any>();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Creating user defined function for container ${collection.id()}`
-    );
-    DataAccessUtilityBase.createUserDefinedFunction(collection, newUserDefinedFunction, options)
-      .then(
-        (createdUserDefinedFunction: DataModels.UserDefinedFunction) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully created user defined function for container ${collection.id()}`
-          );
-          deferred.resolve(createdUserDefinedFunction);
-        },
-        error => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while creating user defined function for container ${collection.id()}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "CreateUDF", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public createTrigger(
-    collection: ViewModels.Collection,
-    newTrigger: DataModels.Trigger,
-    options: any = {}
-  ): Q.Promise<DataModels.Trigger> {
-    var deferred = Q.defer<any>();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Creating trigger for container ${collection.id()}`
-    );
-    DataAccessUtilityBase.createTrigger(collection, newTrigger, options)
-      .then(
-        (createdTrigger: DataModels.Trigger) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully created trigger for container ${collection.id()}`
-          );
-          deferred.resolve(createdTrigger);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while creating trigger for container ${collection.id()}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "CreateTrigger", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public deleteDocument(collection: ViewModels.CollectionBase, documentId: ViewModels.DocumentId): Q.Promise<any> {
-    var deferred = Q.defer<any>();
-    const entityName = this.getEntityName();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Deleting ${entityName} ${documentId.id()}`
-    );
-    DataAccessUtilityBase.deleteDocument(collection, documentId)
-      .then(
-        (response: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully deleted ${entityName} ${documentId.id()}`
-          );
-          deferred.resolve(response);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while deleting ${entityName} ${documentId.id()}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "DeleteDocument", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public deleteConflict(
-    collection: ViewModels.CollectionBase,
-    conflictId: ViewModels.ConflictId,
-    options?: any
-  ): Q.Promise<any> {
-    var deferred = Q.defer<any>();
-
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Deleting conflict ${conflictId.id()}`
-    );
-    DataAccessUtilityBase.deleteConflict(collection, conflictId, options)
-      .then(
-        (response: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully deleted conflict ${conflictId.id()}`
-          );
-          deferred.resolve(response);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while deleting conflict ${conflictId.id()}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "DeleteConflict", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public deleteCollection(collection: ViewModels.Collection, options: any = {}): Q.Promise<any> {
-    var deferred = Q.defer<any>();
-
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Deleting container ${collection.id()}`
-    );
-    DataAccessUtilityBase.deleteCollection(collection, options)
-      .then(
-        (response: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully deleted container ${collection.id()}`
-          );
-          deferred.resolve(response);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while deleting container ${collection.id()}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "DeleteCollection", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public deleteDatabase(database: ViewModels.Database, options: any = {}): Q.Promise<any> {
-    var deferred = Q.defer<any>();
-
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Deleting database ${database.id()}`
-    );
-    DataAccessUtilityBase.deleteDatabase(database, options)
-      .then(
-        (response: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully deleted database ${database.id()}`
-          );
-          deferred.resolve(response);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while deleting database ${database.id()}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "DeleteDatabase", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public deleteStoredProcedure(
-    collection: ViewModels.Collection,
-    storedProcedure: DataModels.StoredProcedure,
-    options: any = {}
-  ): Q.Promise<DataModels.StoredProcedure> {
-    var deferred = Q.defer<any>();
-
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Deleting stored procedure ${storedProcedure.id}`
-    );
-    DataAccessUtilityBase.deleteStoredProcedure(collection, storedProcedure, options)
-      .then(
-        (response: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully deleted stored procedure ${storedProcedure.id}`
-          );
-          deferred.resolve(response);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while deleting stored procedure ${storedProcedure.id}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "DeleteStoredProcedure", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public deleteUserDefinedFunction(
-    collection: ViewModels.Collection,
-    userDefinedFunction: DataModels.UserDefinedFunction,
-    options: any = {}
-  ): Q.Promise<DataModels.UserDefinedFunction> {
-    var deferred = Q.defer<any>();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Deleting user defined function ${userDefinedFunction.id}`
-    );
-    DataAccessUtilityBase.deleteUserDefinedFunction(collection, userDefinedFunction, options)
-      .then(
-        (response: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully deleted user defined function ${userDefinedFunction.id}`
-          );
-          deferred.resolve(response);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while deleting user defined function ${userDefinedFunction.id}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "DeleteUDF", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public deleteTrigger(
-    collection: ViewModels.Collection,
-    trigger: DataModels.Trigger,
-    options: any = {}
-  ): Q.Promise<DataModels.Trigger> {
-    var deferred = Q.defer<any>();
-    const id = NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.InProgress, `Deleting trigger ${trigger.id}`);
-    DataAccessUtilityBase.deleteTrigger(collection, trigger, options)
-      .then(
-        (response: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully deleted trigger ${trigger.id}`
-          );
-          deferred.resolve(response);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while deleting trigger ${trigger.id}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "DeleteTrigger", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public refreshCachedResources(options: any = {}): Q.Promise<void> {
-    return DataAccessUtilityBase.refreshCachedResources(options);
-  }
-
-  public refreshCachedOffers(): Q.Promise<void> {
-    return DataAccessUtilityBase.refreshCachedOffers();
-  }
-
-  public readCollections(database: ViewModels.Database, options: any = {}): Q.Promise<DataModels.Collection[]> {
-    var deferred = Q.defer<DataModels.Collection[]>();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Querying containers for database ${database.id()}`
-    );
-    DataAccessUtilityBase.readCollections(database, options)
-      .then(
-        (collections: DataModels.Collection[]) => {
-          deferred.resolve(collections);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while querying containers for database ${database.id()}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "ReadCollections", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public readCollection(databaseId: string, collectionId: string): Q.Promise<DataModels.Collection> {
-    const deferred = Q.defer<DataModels.Collection>();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Querying container ${collectionId}`
-    );
-
-    DataAccessUtilityBase.readCollection(databaseId, collectionId)
-      .then(
-        (collection: DataModels.Collection) => {
-          deferred.resolve(collection);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while querying containers for database ${databaseId}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "ReadCollections", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public readCollectionQuotaInfo(
-    collection: ViewModels.Collection,
-    options?: any
-  ): Q.Promise<DataModels.CollectionQuotaInfo> {
-    var deferred = Q.defer<DataModels.CollectionQuotaInfo>();
-
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Querying quota info for container ${collection.id}`
-    );
-    DataAccessUtilityBase.readCollectionQuotaInfo(collection, options)
-      .then(
-        (quota: DataModels.CollectionQuotaInfo) => {
-          deferred.resolve(quota);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while querying quota info for container ${collection.id}:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "ReadCollectionQuotaInfo", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public readOffers(options: any = {}): Q.Promise<DataModels.Offer[]> {
-    var deferred = Q.defer<DataModels.Offer[]>();
-
-    const id = NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.InProgress, "Querying offers");
-    DataAccessUtilityBase.readOffers(options)
-      .then(
-        (offers: DataModels.Offer[]) => {
-          deferred.resolve(offers);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while querying offers:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "ReadOffers", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public readOffer(requestedResource: DataModels.Offer, options: any = {}): Q.Promise<DataModels.OfferWithHeaders> {
-    var deferred = Q.defer<DataModels.OfferWithHeaders>();
-
-    const id = NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.InProgress, "Querying offer");
-    DataAccessUtilityBase.readOffer(requestedResource, options)
-      .then(
-        (offer: DataModels.OfferWithHeaders) => {
-          deferred.resolve(offer);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while querying offer:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "ReadOffer", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public readDatabases(options: any): Q.Promise<DataModels.Database[]> {
-    var deferred = Q.defer<any>();
-    const id = NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.InProgress, "Querying databases");
-    DataAccessUtilityBase.readDatabases(options)
-      .then(
-        (databases: DataModels.Database[]) => {
-          deferred.resolve(databases);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while querying databases:\n ${JSON.stringify(error)}`
-          );
-          Logger.logError(JSON.stringify(error), "ReadDatabases", error.code);
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(id);
-      });
-
-    return deferred.promise;
-  }
-
-  public getOrCreateDatabaseAndCollection(
-    request: DataModels.CreateDatabaseAndCollectionRequest,
-    options: any = {}
-  ): Q.Promise<DataModels.Collection> {
-    const deferred: Q.Deferred<DataModels.Collection> = Q.defer<DataModels.Collection>();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Creating a new container ${request.collectionId} for database ${request.databaseId}`
-    );
-
-    DataAccessUtilityBase.getOrCreateDatabaseAndCollection(request, options)
-      .then(
-        (collection: DataModels.Collection) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully created container ${request.collectionId}`
-          );
-          deferred.resolve(collection);
-        },
-        (error: any) => {
-          const sanitizedError = ErrorParserUtility.replaceKnownError(JSON.stringify(error));
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while creating container ${request.collectionId}:\n ${sanitizedError}`
-          );
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => NotificationConsoleUtils.clearInProgressMessageWithId(id));
-
-    return deferred.promise;
-  }
-
-  public createDatabase(request: DataModels.CreateDatabaseRequest, options: any = {}): Q.Promise<DataModels.Database> {
-    const deferred: Q.Deferred<DataModels.Database> = Q.defer<DataModels.Database>();
-    const id = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Creating a new database ${request.databaseId}`
-    );
-
-    DataAccessUtilityBase.createDatabase(request, options)
-      .then(
-        (database: DataModels.Database) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully created database ${request.databaseId}`
-          );
-          deferred.resolve(database);
-        },
-        (error: any) => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Error,
-            `Error while creating database ${request.databaseId}:\n ${JSON.stringify(error)}`
-          );
-          this.sendNotificationForError(error);
-          deferred.reject(error);
-        }
-      )
-      .finally(() => NotificationConsoleUtils.clearInProgressMessageWithId(id));
-
-    return deferred.promise;
-  }
-
-  public sendNotificationForError(error: any) {
-    if (error && error.code === Constants.HttpStatusCodes.Forbidden) {
-      if (error.message && error.message.toLowerCase().indexOf("sharedoffer is disabled for your account") > 0) {
-        return;
+  return "item";
+}
+
+export function readStoredProcedures(
+  collection: ViewModels.Collection,
+  options: any = {}
+): Q.Promise<DataModels.StoredProcedure[]> {
+  var deferred = Q.defer<DataModels.StoredProcedure[]>();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Querying stored procedures for container ${collection.id()}`
+  );
+  DataAccessUtilityBase.readStoredProcedures(collection, options)
+    .then(
+      (storedProcedures: DataModels.StoredProcedure[]) => {
+        deferred.resolve(storedProcedures);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Failed to query stored procedures for container ${collection.id()}: ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "ReadStoredProcedures", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
       }
-      sendMessage({
-        type: MessageTypes.ForbiddenError,
-        reason: error && error.message ? error.message : error
-      });
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function readStoredProcedure(
+  collection: ViewModels.Collection,
+  requestedResource: DataModels.Resource,
+  options?: any
+): Q.Promise<DataModels.StoredProcedure> {
+  return DataAccessUtilityBase.readStoredProcedure(collection, requestedResource, options);
+}
+
+export function readUserDefinedFunctions(
+  collection: ViewModels.Collection,
+  options: any = {}
+): Q.Promise<DataModels.UserDefinedFunction[]> {
+  var deferred = Q.defer<DataModels.UserDefinedFunction[]>();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Querying user defined functions for collection ${collection.id()}`
+  );
+  DataAccessUtilityBase.readUserDefinedFunctions(collection, options)
+    .then(
+      (userDefinedFunctions: DataModels.UserDefinedFunction[]) => {
+        deferred.resolve(userDefinedFunctions);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Failed to query user defined functions for container ${collection.id()}: ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "ReadUDFs", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function readUserDefinedFunction(
+  collection: ViewModels.Collection,
+  requestedResource: DataModels.Resource,
+  options: any
+): Q.Promise<DataModels.UserDefinedFunction> {
+  return DataAccessUtilityBase.readUserDefinedFunction(collection, requestedResource, options);
+}
+
+export function readTriggers(collection: ViewModels.Collection, options: any): Q.Promise<DataModels.Trigger[]> {
+  var deferred = Q.defer<DataModels.Trigger[]>();
+
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Querying triggers for container ${collection.id()}`
+  );
+  DataAccessUtilityBase.readTriggers(collection, options)
+    .then(
+      (triggers: DataModels.Trigger[]) => {
+        deferred.resolve(triggers);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Failed to query triggers for container ${collection.id()}: ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "ReadTriggers", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function readTrigger(
+  collection: ViewModels.Collection,
+  requestedResource: DataModels.Resource,
+  options?: any
+): Q.Promise<DataModels.Trigger> {
+  return DataAccessUtilityBase.readTrigger(collection, requestedResource, options);
+}
+
+export function executeStoredProcedure(
+  collection: ViewModels.Collection,
+  storedProcedure: StoredProcedure,
+  partitionKeyValue: any,
+  params: any[]
+): Q.Promise<any> {
+  var deferred = Q.defer<any>();
+
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Executing stored procedure ${storedProcedure.id()}`
+  );
+  DataAccessUtilityBase.executeStoredProcedure(collection, storedProcedure, partitionKeyValue, params)
+    .then(
+      (response: any) => {
+        deferred.resolve(response);
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Finished executing stored procedure ${storedProcedure.id()} for container ${storedProcedure.collection.id()}`
+        );
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Failed to execute stored procedure ${storedProcedure.id()} for container ${storedProcedure.collection.id()}: ${JSON.stringify(
+            error
+          )}`
+        );
+        Logger.logError(JSON.stringify(error), "ExecuteStoredProcedure", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function queryDocumentsPage(
+  resourceName: string,
+  documentsIterator: MinimalQueryIterator,
+  firstItemIndex: number,
+  options: any
+): Q.Promise<ViewModels.QueryResults> {
+  var deferred = Q.defer<ViewModels.QueryResults>();
+  const entityName = getEntityName();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Querying ${entityName} for container ${resourceName}`
+  );
+  Q(nextPage(documentsIterator, firstItemIndex))
+    .then(
+      (result: ViewModels.QueryResults) => {
+        const itemCount = (result.documents && result.documents.length) || 0;
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully fetched ${itemCount} ${entityName} for container ${resourceName}`
+        );
+        deferred.resolve(result);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Failed to query ${entityName} for container ${resourceName}: ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "QueryDocumentsPage", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function readDocument(collection: ViewModels.CollectionBase, documentId: ViewModels.DocumentId): Q.Promise<any> {
+  var deferred = Q.defer<any>();
+  const entityName = getEntityName();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Reading ${entityName} ${documentId.id()}`
+  );
+  DataAccessUtilityBase.readDocument(collection, documentId)
+    .then(
+      (document: any) => {
+        deferred.resolve(document);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Failed to read ${entityName} ${documentId.id()}: ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "ReadDocument", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function updateCollection(
+  databaseId: string,
+  collection: ViewModels.Collection,
+  newCollection: DataModels.Collection
+): Q.Promise<DataModels.Collection> {
+  var deferred = Q.defer<any>();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Updating container ${collection.id()}`
+  );
+  DataAccessUtilityBase.updateCollection(databaseId, collection.id(), newCollection)
+    .then(
+      (replacedCollection: DataModels.Collection) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully updated container ${collection.id()}`
+        );
+        deferred.resolve(replacedCollection);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Failed to update container ${collection.id()}: ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "UpdateCollection", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function updateDocument(
+  collection: ViewModels.CollectionBase,
+  documentId: ViewModels.DocumentId,
+  newDocument: any
+): Q.Promise<any> {
+  var deferred = Q.defer<any>();
+  const entityName = getEntityName();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Updating ${entityName} ${documentId.id()}`
+  );
+  DataAccessUtilityBase.updateDocument(collection, documentId, newDocument)
+    .then(
+      (updatedDocument: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully updated ${entityName} ${documentId.id()}`
+        );
+        deferred.resolve(updatedDocument);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Failed to update ${entityName} ${documentId.id()}: ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "UpdateDocument", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function updateOffer(
+  offer: DataModels.Offer,
+  newOffer: DataModels.Offer,
+  options: RequestOptions
+): Q.Promise<DataModels.Offer> {
+  var deferred = Q.defer<any>();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Updating offer for resource ${offer.resource}`
+  );
+  DataAccessUtilityBase.updateOffer(offer, newOffer, options)
+    .then(
+      (replacedOffer: DataModels.Offer) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully updated offer for resource ${offer.resource}`
+        );
+        deferred.resolve(replacedOffer);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error updating offer for resource ${offer.resource}: ${JSON.stringify(error)}`
+        );
+        Logger.logError(
+          JSON.stringify({
+            oldOffer: offer,
+            newOffer: newOffer,
+            error: error
+          }),
+          "UpdateOffer",
+          error.code
+        );
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function updateOfferThroughputBeyondLimit(
+  requestPayload: DataModels.UpdateOfferThroughputRequest
+): Q.Promise<void> {
+  const deferred: Q.Deferred<void> = Q.defer<void>();
+  const resourceDescriptionInfo: string = requestPayload.collectionName
+    ? `database ${requestPayload.databaseName} and container ${requestPayload.collectionName}`
+    : `database ${requestPayload.databaseName}`;
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Requesting increase in throughput to ${requestPayload.throughput} for ${resourceDescriptionInfo}`
+  );
+  DataAccessUtilityBase.updateOfferThroughputBeyondLimit(requestPayload)
+    .then(
+      () => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully requested an increase in throughput to ${requestPayload.throughput} for ${resourceDescriptionInfo}`
+        );
+        deferred.resolve();
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Failed to request an increase in throughput for ${requestPayload.throughput}: ${JSON.stringify(error)}`
+        );
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => NotificationConsoleUtils.clearInProgressMessageWithId(id));
+
+  return deferred.promise.timeout(Constants.ClientDefaults.requestTimeoutMs);
+}
+
+export function updateStoredProcedure(
+  collection: ViewModels.Collection,
+  storedProcedure: DataModels.StoredProcedure,
+  options?: any
+): Q.Promise<DataModels.StoredProcedure> {
+  var deferred = Q.defer<any>();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Updating stored procedure ${storedProcedure.id}`
+  );
+  DataAccessUtilityBase.updateStoredProcedure(collection, storedProcedure, options)
+    .then(
+      (updatedStoredProcedure: DataModels.StoredProcedure) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully updated stored procedure ${storedProcedure.id}`
+        );
+        deferred.resolve(updatedStoredProcedure);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while updating stored procedure ${storedProcedure.id}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "UpdateStoredProcedure", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function updateUserDefinedFunction(
+  collection: ViewModels.Collection,
+  userDefinedFunction: DataModels.UserDefinedFunction,
+  options: any = {}
+): Q.Promise<DataModels.UserDefinedFunction> {
+  var deferred = Q.defer<any>();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Updating user defined function ${userDefinedFunction.id}`
+  );
+  DataAccessUtilityBase.updateUserDefinedFunction(collection, userDefinedFunction, options)
+    .then(
+      (updatedUserDefinedFunction: DataModels.UserDefinedFunction) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully updated user defined function ${userDefinedFunction.id}`
+        );
+        deferred.resolve(updatedUserDefinedFunction);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while updating user defined function ${userDefinedFunction.id}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "UpdateUDF", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function updateTrigger(
+  collection: ViewModels.Collection,
+  trigger: DataModels.Trigger
+): Q.Promise<DataModels.Trigger> {
+  var deferred = Q.defer<any>();
+  const id = NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.InProgress, `Updating trigger ${trigger.id}`);
+  DataAccessUtilityBase.updateTrigger(collection, trigger)
+    .then(
+      (updatedTrigger: DataModels.Trigger) => {
+        NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.Info, `Updated trigger ${trigger.id}`);
+        deferred.resolve(updatedTrigger);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while updating trigger ${trigger.id}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "UpdateTrigger", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function createDocument(collection: ViewModels.CollectionBase, newDocument: any): Q.Promise<any> {
+  var deferred = Q.defer<any>();
+  const entityName = getEntityName();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Creating new ${entityName} for container ${collection.id()}`
+  );
+  DataAccessUtilityBase.createDocument(collection, newDocument)
+    .then(
+      (savedDocument: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully created new ${entityName} for container ${collection.id()}`
+        );
+        deferred.resolve(savedDocument);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while creating new ${entityName} for container ${collection.id()}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "CreateDocument", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function createStoredProcedure(
+  collection: ViewModels.Collection,
+  newStoredProcedure: DataModels.StoredProcedure,
+  options?: any
+): Q.Promise<DataModels.StoredProcedure> {
+  var deferred = Q.defer<any>();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Creating stored procedure for container ${collection.id()}`
+  );
+  DataAccessUtilityBase.createStoredProcedure(collection, newStoredProcedure, options)
+    .then(
+      (createdStoredProcedure: DataModels.StoredProcedure) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully created stored procedure for container ${collection.id()}`
+        );
+        deferred.resolve(createdStoredProcedure);
+      },
+      error => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while creating stored procedure for container ${collection.id()}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "CreateStoredProcedure", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function createUserDefinedFunction(
+  collection: ViewModels.Collection,
+  newUserDefinedFunction: DataModels.UserDefinedFunction,
+  options?: any
+): Q.Promise<DataModels.UserDefinedFunction> {
+  var deferred = Q.defer<any>();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Creating user defined function for container ${collection.id()}`
+  );
+  DataAccessUtilityBase.createUserDefinedFunction(collection, newUserDefinedFunction, options)
+    .then(
+      (createdUserDefinedFunction: DataModels.UserDefinedFunction) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully created user defined function for container ${collection.id()}`
+        );
+        deferred.resolve(createdUserDefinedFunction);
+      },
+      error => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while creating user defined function for container ${collection.id()}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "CreateUDF", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function createTrigger(
+  collection: ViewModels.Collection,
+  newTrigger: DataModels.Trigger,
+  options: any = {}
+): Q.Promise<DataModels.Trigger> {
+  var deferred = Q.defer<any>();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Creating trigger for container ${collection.id()}`
+  );
+  DataAccessUtilityBase.createTrigger(collection, newTrigger, options)
+    .then(
+      (createdTrigger: DataModels.Trigger) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully created trigger for container ${collection.id()}`
+        );
+        deferred.resolve(createdTrigger);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while creating trigger for container ${collection.id()}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "CreateTrigger", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function deleteDocument(
+  collection: ViewModels.CollectionBase,
+  documentId: ViewModels.DocumentId
+): Q.Promise<any> {
+  var deferred = Q.defer<any>();
+  const entityName = getEntityName();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Deleting ${entityName} ${documentId.id()}`
+  );
+  DataAccessUtilityBase.deleteDocument(collection, documentId)
+    .then(
+      (response: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully deleted ${entityName} ${documentId.id()}`
+        );
+        deferred.resolve(response);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while deleting ${entityName} ${documentId.id()}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "DeleteDocument", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function deleteConflict(
+  collection: ViewModels.CollectionBase,
+  conflictId: ViewModels.ConflictId,
+  options?: any
+): Q.Promise<any> {
+  var deferred = Q.defer<any>();
+
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Deleting conflict ${conflictId.id()}`
+  );
+  DataAccessUtilityBase.deleteConflict(collection, conflictId, options)
+    .then(
+      (response: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully deleted conflict ${conflictId.id()}`
+        );
+        deferred.resolve(response);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while deleting conflict ${conflictId.id()}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "DeleteConflict", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function deleteCollection(collection: ViewModels.Collection, options: any = {}): Q.Promise<any> {
+  var deferred = Q.defer<any>();
+
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Deleting container ${collection.id()}`
+  );
+  DataAccessUtilityBase.deleteCollection(collection, options)
+    .then(
+      (response: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully deleted container ${collection.id()}`
+        );
+        deferred.resolve(response);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while deleting container ${collection.id()}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "DeleteCollection", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function deleteDatabase(database: ViewModels.Database, options: any = {}): Q.Promise<any> {
+  var deferred = Q.defer<any>();
+
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Deleting database ${database.id()}`
+  );
+  DataAccessUtilityBase.deleteDatabase(database, options)
+    .then(
+      (response: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully deleted database ${database.id()}`
+        );
+        deferred.resolve(response);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while deleting database ${database.id()}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "DeleteDatabase", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function deleteStoredProcedure(
+  collection: ViewModels.Collection,
+  storedProcedure: DataModels.StoredProcedure,
+  options: any = {}
+): Q.Promise<DataModels.StoredProcedure> {
+  var deferred = Q.defer<any>();
+
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Deleting stored procedure ${storedProcedure.id}`
+  );
+  DataAccessUtilityBase.deleteStoredProcedure(collection, storedProcedure, options)
+    .then(
+      (response: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully deleted stored procedure ${storedProcedure.id}`
+        );
+        deferred.resolve(response);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while deleting stored procedure ${storedProcedure.id}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "DeleteStoredProcedure", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function deleteUserDefinedFunction(
+  collection: ViewModels.Collection,
+  userDefinedFunction: DataModels.UserDefinedFunction,
+  options: any = {}
+): Q.Promise<DataModels.UserDefinedFunction> {
+  var deferred = Q.defer<any>();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Deleting user defined function ${userDefinedFunction.id}`
+  );
+  DataAccessUtilityBase.deleteUserDefinedFunction(collection, userDefinedFunction, options)
+    .then(
+      (response: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully deleted user defined function ${userDefinedFunction.id}`
+        );
+        deferred.resolve(response);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while deleting user defined function ${userDefinedFunction.id}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "DeleteUDF", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function deleteTrigger(
+  collection: ViewModels.Collection,
+  trigger: DataModels.Trigger,
+  options: any = {}
+): Q.Promise<DataModels.Trigger> {
+  var deferred = Q.defer<any>();
+  const id = NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.InProgress, `Deleting trigger ${trigger.id}`);
+  DataAccessUtilityBase.deleteTrigger(collection, trigger, options)
+    .then(
+      (response: any) => {
+        NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.Info, `Successfully deleted trigger ${trigger.id}`);
+        deferred.resolve(response);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while deleting trigger ${trigger.id}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "DeleteTrigger", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function refreshCachedResources(options: any = {}): Q.Promise<void> {
+  return DataAccessUtilityBase.refreshCachedResources(options);
+}
+
+export function refreshCachedOffers(): Q.Promise<void> {
+  return DataAccessUtilityBase.refreshCachedOffers();
+}
+
+export function readCollections(database: ViewModels.Database, options: any = {}): Q.Promise<DataModels.Collection[]> {
+  var deferred = Q.defer<DataModels.Collection[]>();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Querying containers for database ${database.id()}`
+  );
+  DataAccessUtilityBase.readCollections(database, options)
+    .then(
+      (collections: DataModels.Collection[]) => {
+        deferred.resolve(collections);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while querying containers for database ${database.id()}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "ReadCollections", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function readCollection(databaseId: string, collectionId: string): Q.Promise<DataModels.Collection> {
+  const deferred = Q.defer<DataModels.Collection>();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Querying container ${collectionId}`
+  );
+
+  DataAccessUtilityBase.readCollection(databaseId, collectionId)
+    .then(
+      (collection: DataModels.Collection) => {
+        deferred.resolve(collection);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while querying containers for database ${databaseId}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "ReadCollections", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function readCollectionQuotaInfo(
+  collection: ViewModels.Collection,
+  options?: any
+): Q.Promise<DataModels.CollectionQuotaInfo> {
+  var deferred = Q.defer<DataModels.CollectionQuotaInfo>();
+
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Querying quota info for container ${collection.id}`
+  );
+  DataAccessUtilityBase.readCollectionQuotaInfo(collection, options)
+    .then(
+      (quota: DataModels.CollectionQuotaInfo) => {
+        deferred.resolve(quota);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while querying quota info for container ${collection.id}:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "ReadCollectionQuotaInfo", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function readOffers(options: any = {}): Q.Promise<DataModels.Offer[]> {
+  var deferred = Q.defer<DataModels.Offer[]>();
+
+  const id = NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.InProgress, "Querying offers");
+  DataAccessUtilityBase.readOffers(options)
+    .then(
+      (offers: DataModels.Offer[]) => {
+        deferred.resolve(offers);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while querying offers:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "ReadOffers", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function readOffer(
+  requestedResource: DataModels.Offer,
+  options: any = {}
+): Q.Promise<DataModels.OfferWithHeaders> {
+  var deferred = Q.defer<DataModels.OfferWithHeaders>();
+
+  const id = NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.InProgress, "Querying offer");
+  DataAccessUtilityBase.readOffer(requestedResource, options)
+    .then(
+      (offer: DataModels.OfferWithHeaders) => {
+        deferred.resolve(offer);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while querying offer:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "ReadOffer", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function readDatabases(options: any): Q.Promise<DataModels.Database[]> {
+  var deferred = Q.defer<any>();
+  const id = NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.InProgress, "Querying databases");
+  DataAccessUtilityBase.readDatabases(options)
+    .then(
+      (databases: DataModels.Database[]) => {
+        deferred.resolve(databases);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while querying databases:\n ${JSON.stringify(error)}`
+        );
+        Logger.logError(JSON.stringify(error), "ReadDatabases", error.code);
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => {
+      NotificationConsoleUtils.clearInProgressMessageWithId(id);
+    });
+
+  return deferred.promise;
+}
+
+export function getOrCreateDatabaseAndCollection(
+  request: DataModels.CreateDatabaseAndCollectionRequest,
+  options: any = {}
+): Q.Promise<DataModels.Collection> {
+  const deferred: Q.Deferred<DataModels.Collection> = Q.defer<DataModels.Collection>();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Creating a new container ${request.collectionId} for database ${request.databaseId}`
+  );
+
+  DataAccessUtilityBase.getOrCreateDatabaseAndCollection(request, options)
+    .then(
+      (collection: DataModels.Collection) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully created container ${request.collectionId}`
+        );
+        deferred.resolve(collection);
+      },
+      (error: any) => {
+        const sanitizedError = ErrorParserUtility.replaceKnownError(JSON.stringify(error));
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while creating container ${request.collectionId}:\n ${sanitizedError}`
+        );
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => NotificationConsoleUtils.clearInProgressMessageWithId(id));
+
+  return deferred.promise;
+}
+
+export function createDatabase(
+  request: DataModels.CreateDatabaseRequest,
+  options: any = {}
+): Q.Promise<DataModels.Database> {
+  const deferred: Q.Deferred<DataModels.Database> = Q.defer<DataModels.Database>();
+  const id = NotificationConsoleUtils.logConsoleMessage(
+    ConsoleDataType.InProgress,
+    `Creating a new database ${request.databaseId}`
+  );
+
+  DataAccessUtilityBase.createDatabase(request, options)
+    .then(
+      (database: DataModels.Database) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Info,
+          `Successfully created database ${request.databaseId}`
+        );
+        deferred.resolve(database);
+      },
+      (error: any) => {
+        NotificationConsoleUtils.logConsoleMessage(
+          ConsoleDataType.Error,
+          `Error while creating database ${request.databaseId}:\n ${JSON.stringify(error)}`
+        );
+        sendNotificationForError(error);
+        deferred.reject(error);
+      }
+    )
+    .finally(() => NotificationConsoleUtils.clearInProgressMessageWithId(id));
+
+  return deferred.promise;
+}
+
+export function sendNotificationForError(error: any) {
+  if (error && error.code === Constants.HttpStatusCodes.Forbidden) {
+    if (error.message && error.message.toLowerCase().indexOf("sharedoffer is disabled for your account") > 0) {
+      return;
     }
+    sendMessage({
+      type: MessageTypes.ForbiddenError,
+      reason: error && error.message ? error.message : error
+    });
   }
 }

--- a/src/Contracts/ViewModels.ts
+++ b/src/Contracts/ViewModels.ts
@@ -1,6 +1,5 @@
 import * as DataModels from "./DataModels";
 import * as monaco from "monaco-editor";
-import DocumentClientUtilityBase from "../Common/DocumentClientUtilityBase";
 import Q from "q";
 import { AccessibleVerticalList } from "../Explorer/Tree/AccessibleVerticalList";
 import { CassandraTableKey, CassandraTableKeys } from "../Explorer/Tables/TableDataClient";
@@ -18,7 +17,6 @@ import ConflictsTab from "../Explorer/Tabs/ConflictsTab";
 import Trigger from "../Explorer/Tree/Trigger";
 
 export interface ExplorerOptions {
-  documentClientUtility: DocumentClientUtilityBase;
   notificationsClient: NotificationsClient;
   isEmulator: boolean;
 }
@@ -245,13 +243,11 @@ export interface ConflictId {
  */
 export interface PaneOptions {
   id: string;
-  documentClientUtility: DocumentClientUtilityBase;
   visible: ko.Observable<boolean>;
   container?: Explorer;
 }
 
 export interface ContextualPane {
-  documentClientUtility: DocumentClientUtilityBase;
   formErrors: ko.Observable<string>;
   formErrorsDetails: ko.Observable<string>;
   id: string;
@@ -406,7 +402,6 @@ export interface TabOptions {
   tabKind: CollectionTabKind;
   title: string;
   tabPath: string;
-  documentClientUtility: DocumentClientUtilityBase;
   selfLink: string;
   isActive: ko.Observable<boolean>;
   hashLocation: string;
@@ -493,11 +488,9 @@ export interface ScriptTabOption extends TabOptions {
 
 // Tabs
 export interface Tab {
-  documentClientUtility: DocumentClientUtilityBase;
   node: TreeNode; // Can be null
   collection: CollectionBase;
   rid: string;
-
   tabKind: CollectionTabKind;
   tabId: string;
   isActive: ko.Observable<boolean>;

--- a/src/Explorer/DataSamples/ContainerSampleGenerator.test.ts
+++ b/src/Explorer/DataSamples/ContainerSampleGenerator.test.ts
@@ -1,10 +1,11 @@
+jest.mock("../../Common/DocumentClientUtilityBase");
 import * as ko from "knockout";
 import * as sinon from "sinon";
 import * as ViewModels from "../../Contracts/ViewModels";
-import DocumentClientUtilityBase from "../../Common/DocumentClientUtilityBase";
 import Q from "q";
 import { ContainerSampleGenerator } from "./ContainerSampleGenerator";
 import { CosmosClient } from "../../Common/CosmosClient";
+import * as DocumentClientUtility from "../../Common/DocumentClientUtilityBase";
 import { GremlinClient } from "../Graph/GraphExplorerComponent/GremlinClient";
 import Explorer from "../Explorer";
 
@@ -62,19 +63,12 @@ describe("ContainerSampleGenerator", () => {
 
     const explorerStub = createExplorerStub(database);
     explorerStub.isPreferredApiDocumentDB = ko.computed<boolean>(() => true);
-
-    const fakeDocumentClientUtility = sinon.createStubInstance(DocumentClientUtilityBase);
-    fakeDocumentClientUtility.getOrCreateDatabaseAndCollection.returns(Q.resolve(collection));
-    fakeDocumentClientUtility.createDocument.returns(Q.resolve());
-
-    explorerStub.documentClientUtility = fakeDocumentClientUtility;
-
     const generator = await ContainerSampleGenerator.createSampleGeneratorAsync(explorerStub);
     generator.setData(sampleData);
 
     await generator.createSampleContainerAsync();
 
-    expect(fakeDocumentClientUtility.createDocument.called).toBe(true);
+    expect(DocumentClientUtility.createDocument).toHaveBeenCalled();
   });
 
   it("should send gremlin queries for Graph API account", async () => {
@@ -109,18 +103,12 @@ describe("ContainerSampleGenerator", () => {
     const explorerStub = createExplorerStub(database);
     explorerStub.isPreferredApiGraph = ko.computed<boolean>(() => true);
 
-    const fakeDocumentClientUtility = sinon.createStubInstance(DocumentClientUtilityBase);
-    fakeDocumentClientUtility.getOrCreateDatabaseAndCollection.returns(Q.resolve(collection));
-    fakeDocumentClientUtility.createDocument.returns(Q.resolve());
-
-    explorerStub.documentClientUtility = fakeDocumentClientUtility;
-
     const generator = await ContainerSampleGenerator.createSampleGeneratorAsync(explorerStub);
     generator.setData(sampleData);
 
     await generator.createSampleContainerAsync();
 
-    expect(fakeDocumentClientUtility.createDocument.called).toBe(false);
+    expect(DocumentClientUtility.createDocument).toHaveBeenCalled();
     expect(executeStub.called).toBe(true);
   });
 

--- a/src/Explorer/DataSamples/ContainerSampleGenerator.ts
+++ b/src/Explorer/DataSamples/ContainerSampleGenerator.ts
@@ -7,6 +7,7 @@ import { CosmosClient } from "../../Common/CosmosClient";
 import { GremlinClient } from "../Graph/GraphExplorerComponent/GremlinClient";
 import { NotificationConsoleUtils } from "../../Utils/NotificationConsoleUtils";
 import Explorer from "../Explorer";
+import { createDocument, getOrCreateDatabaseAndCollection } from "../../Common/DocumentClientUtilityBase";
 
 interface SampleDataFile extends DataModels.CreateDatabaseAndCollectionRequest {
   data: any[];
@@ -64,7 +65,7 @@ export class ContainerSampleGenerator {
       options.initialHeaders[Constants.HttpHeaders.usePolygonsSmallerThanAHemisphere] = true;
     }
 
-    await this.container.documentClientUtility.getOrCreateDatabaseAndCollection(createRequest, options);
+    await getOrCreateDatabaseAndCollection(createRequest, options);
     await this.container.refreshAllDatabases();
     const database = this.container.findDatabaseWithId(this.sampleDataFile.databaseId);
     if (!database) {
@@ -103,7 +104,7 @@ export class ContainerSampleGenerator {
     } else {
       // For SQL all queries are executed at the same time
       this.sampleDataFile.data.forEach(doc => {
-        const subPromise = this.container.documentClientUtility.createDocument(collection, doc);
+        const subPromise = createDocument(collection, doc);
         subPromise.catch(reason => NotificationConsoleUtils.logConsoleMessage(ConsoleDataType.Error, reason));
         promises.push(subPromise);
       });

--- a/src/Explorer/Explorer.ts
+++ b/src/Explorer/Explorer.ts
@@ -15,7 +15,7 @@ import CassandraAddCollectionPane from "./Panes/CassandraAddCollectionPane";
 import Database from "./Tree/Database";
 import DeleteCollectionConfirmationPane from "./Panes/DeleteCollectionConfirmationPane";
 import DeleteDatabaseConfirmationPane from "./Panes/DeleteDatabaseConfirmationPane";
-import DocumentClientUtilityBase from "../Common/DocumentClientUtilityBase";
+import { readDatabases, readCollection, readOffers, refreshCachedResources } from "../Common/DocumentClientUtilityBase";
 import EditTableEntityPane from "./Panes/Tables/EditTableEntityPane";
 import EnvironmentUtility from "../Common/EnvironmentUtility";
 import GraphStylingPane from "./Panes/GraphStylingPane";
@@ -127,7 +127,6 @@ export default class Explorer {
   public extensionEndpoint: ko.Observable<string>;
   public armEndpoint: ko.Observable<string>;
   public isTryCosmosDBSubscription: ko.Observable<boolean>;
-  public documentClientUtility: DocumentClientUtilityBase;
   public notificationsClient: ViewModels.NotificationsClient;
   public queriesClient: ViewModels.QueriesClient;
   public tableDataClient: TableDataClient;
@@ -358,7 +357,6 @@ export default class Explorer {
       }
     });
     this.memoryUsageInfo = ko.observable<DataModels.MemoryUsageInfo>();
-    this.documentClientUtility = options.documentClientUtility;
     this.notificationsClient = options.notificationsClient;
     this.isEmulator = options.isEmulator;
 
@@ -584,7 +582,6 @@ export default class Explorer {
     });
 
     this.addDatabasePane = new AddDatabasePane({
-      documentClientUtility: this.documentClientUtility,
       id: "adddatabasepane",
       visible: ko.observable<boolean>(false),
 
@@ -593,7 +590,6 @@ export default class Explorer {
 
     this.addCollectionPane = new AddCollectionPane({
       isPreferredApiTable: ko.computed(() => this.isPreferredApiTable()),
-      documentClientUtility: this.documentClientUtility,
       id: "addcollectionpane",
       visible: ko.observable<boolean>(false),
 
@@ -601,7 +597,6 @@ export default class Explorer {
     });
 
     this.deleteCollectionConfirmationPane = new DeleteCollectionConfirmationPane({
-      documentClientUtility: this.documentClientUtility,
       id: "deletecollectionconfirmationpane",
       visible: ko.observable<boolean>(false),
 
@@ -609,7 +604,6 @@ export default class Explorer {
     });
 
     this.deleteDatabaseConfirmationPane = new DeleteDatabaseConfirmationPane({
-      documentClientUtility: this.documentClientUtility,
       id: "deletedatabaseconfirmationpane",
       visible: ko.observable<boolean>(false),
 
@@ -617,7 +611,6 @@ export default class Explorer {
     });
 
     this.graphStylingPane = new GraphStylingPane({
-      documentClientUtility: this.documentClientUtility,
       id: "graphstylingpane",
       visible: ko.observable<boolean>(false),
 
@@ -625,7 +618,6 @@ export default class Explorer {
     });
 
     this.addTableEntityPane = new AddTableEntityPane({
-      documentClientUtility: this.documentClientUtility,
       id: "addtableentitypane",
       visible: ko.observable<boolean>(false),
 
@@ -633,7 +625,6 @@ export default class Explorer {
     });
 
     this.editTableEntityPane = new EditTableEntityPane({
-      documentClientUtility: this.documentClientUtility,
       id: "edittableentitypane",
       visible: ko.observable<boolean>(false),
 
@@ -641,7 +632,6 @@ export default class Explorer {
     });
 
     this.tableColumnOptionsPane = new TableColumnOptionsPane({
-      documentClientUtility: this.documentClientUtility,
       id: "tablecolumnoptionspane",
       visible: ko.observable<boolean>(false),
 
@@ -649,7 +639,6 @@ export default class Explorer {
     });
 
     this.querySelectPane = new QuerySelectPane({
-      documentClientUtility: this.documentClientUtility,
       id: "queryselectpane",
       visible: ko.observable<boolean>(false),
 
@@ -657,7 +646,6 @@ export default class Explorer {
     });
 
     this.newVertexPane = new NewVertexPane({
-      documentClientUtility: this.documentClientUtility,
       id: "newvertexpane",
       visible: ko.observable<boolean>(false),
 
@@ -665,7 +653,6 @@ export default class Explorer {
     });
 
     this.cassandraAddCollectionPane = new CassandraAddCollectionPane({
-      documentClientUtility: this.documentClientUtility,
       id: "cassandraaddcollectionpane",
       visible: ko.observable<boolean>(false),
 
@@ -673,7 +660,6 @@ export default class Explorer {
     });
 
     this.settingsPane = new SettingsPane({
-      documentClientUtility: this.documentClientUtility,
       id: "settingspane",
       visible: ko.observable<boolean>(false),
 
@@ -681,7 +667,6 @@ export default class Explorer {
     });
 
     this.executeSprocParamsPane = new ExecuteSprocParamsPane({
-      documentClientUtility: this.documentClientUtility,
       id: "executesprocparamspane",
       visible: ko.observable<boolean>(false),
 
@@ -689,7 +674,6 @@ export default class Explorer {
     });
 
     this.renewAdHocAccessPane = new RenewAdHocAccessPane({
-      documentClientUtility: this.documentClientUtility,
       id: "renewadhocaccesspane",
       visible: ko.observable<boolean>(false),
 
@@ -697,7 +681,6 @@ export default class Explorer {
     });
 
     this.uploadItemsPane = new UploadItemsPane({
-      documentClientUtility: this.documentClientUtility,
       id: "uploaditemspane",
       visible: ko.observable<boolean>(false),
 
@@ -707,7 +690,6 @@ export default class Explorer {
     this.uploadItemsPaneAdapter = new UploadItemsPaneAdapter(this);
 
     this.loadQueryPane = new LoadQueryPane({
-      documentClientUtility: this.documentClientUtility,
       id: "loadquerypane",
       visible: ko.observable<boolean>(false),
 
@@ -715,7 +697,6 @@ export default class Explorer {
     });
 
     this.saveQueryPane = new SaveQueryPane({
-      documentClientUtility: this.documentClientUtility,
       id: "savequerypane",
       visible: ko.observable<boolean>(false),
 
@@ -723,7 +704,6 @@ export default class Explorer {
     });
 
     this.browseQueriesPane = new BrowseQueriesPane({
-      documentClientUtility: this.documentClientUtility,
       id: "browsequeriespane",
       visible: ko.observable<boolean>(false),
 
@@ -731,7 +711,6 @@ export default class Explorer {
     });
 
     this.uploadFilePane = new UploadFilePane({
-      documentClientUtility: this.documentClientUtility,
       id: "uploadfilepane",
       visible: ko.observable<boolean>(false),
 
@@ -739,7 +718,6 @@ export default class Explorer {
     });
 
     this.stringInputPane = new StringInputPane({
-      documentClientUtility: this.documentClientUtility,
       id: "stringinputpane",
       visible: ko.observable<boolean>(false),
 
@@ -747,7 +725,6 @@ export default class Explorer {
     });
 
     this.setupNotebooksPane = new SetupNotebooksPane({
-      documentClientUtility: this.documentClientUtility,
       id: "setupnotebookspane",
       visible: ko.observable<boolean>(false),
 
@@ -780,7 +757,6 @@ export default class Explorer {
       this.setupNotebooksPane
     ];
     this.addDatabaseText.subscribe((addDatabaseText: string) => this.addDatabasePane.title(addDatabaseText));
-    this.rebindDocumentClientUtility.bind(this);
     this.isTabsContentExpanded = ko.observable(false);
 
     document.addEventListener(
@@ -862,7 +838,7 @@ export default class Explorer {
           this.editTableEntityPane.title("Edit Table Entity");
           this.deleteCollectionConfirmationPane.title("Delete Table");
           this.deleteCollectionConfirmationPane.collectionIdConfirmationText("Confirm by typing the table id");
-          this.tableDataClient = new TablesAPIDataClient(this.documentClientUtility);
+          this.tableDataClient = new TablesAPIDataClient();
           break;
         case Constants.DefaultAccountExperience.Cassandra.toLowerCase():
           this.addCollectionText("New Table");
@@ -881,7 +857,7 @@ export default class Explorer {
           this.deleteCollectionConfirmationPane.collectionIdConfirmationText("Confirm by typing the table id");
           this.deleteDatabaseConfirmationPane.title("Delete Keyspace");
           this.deleteDatabaseConfirmationPane.databaseIdConfirmationText("Confirm by typing the keyspace id");
-          this.tableDataClient = new CassandraAPIDataClient(this.documentClientUtility);
+          this.tableDataClient = new CassandraAPIDataClient();
           break;
       }
     });
@@ -1064,13 +1040,6 @@ export default class Explorer {
     TelemetryProcessor.traceStart(Action.EnableAzureSynapseLink);
 
     // TODO: return result
-  }
-
-  public rebindDocumentClientUtility(documentClientUtility: DocumentClientUtilityBase): void {
-    this.documentClientUtility = documentClientUtility;
-    this._panes.forEach((pane: ViewModels.ContextualPane) => {
-      pane.documentClientUtility = documentClientUtility;
-    });
   }
 
   public copyUrlLink(src: any, event: MouseEvent): void {
@@ -1391,7 +1360,7 @@ export default class Explorer {
     }
 
     const deferred: Q.Deferred<void> = Q.defer();
-    this.documentClientUtility.readCollection(databaseId, collectionId).then((collection: DataModels.Collection) => {
+    readCollection(databaseId, collectionId).then((collection: DataModels.Collection) => {
       this.resourceTokenCollection(new ResourceTokenCollection(this, databaseId, collection));
       this.selectedNode(this.resourceTokenCollection());
       deferred.resolve();
@@ -1421,7 +1390,7 @@ export default class Explorer {
 
     const refreshDatabases = (offers?: DataModels.Offer[]) => {
       this._setLoadingStatusText("Fetching databases...");
-      this.documentClientUtility.readDatabases(null /*options*/).then(
+      readDatabases(null /*options*/).then(
         (databases: DataModels.Database[]) => {
           this._setLoadingStatusText("Successfully fetched databases.");
           TelemetryProcessor.traceSuccess(
@@ -1478,7 +1447,7 @@ export default class Explorer {
       // Serverless accounts don't support offers call
       refreshDatabases();
     } else {
-      const offerPromise: Q.Promise<DataModels.Offer[]> = this.documentClientUtility.readOffers();
+      const offerPromise: Q.Promise<DataModels.Offer[]> = readOffers();
       this._setLoadingStatusText("Fetching offers...");
       offerPromise.then(
         (offers: DataModels.Offer[]) => {
@@ -1554,7 +1523,7 @@ export default class Explorer {
       dataExplorerArea: Constants.Areas.ResourceTree
     });
     this.isRefreshingExplorer(true);
-    this.documentClientUtility.refreshCachedResources().then(
+    refreshCachedResources().then(
       () => {
         TelemetryProcessor.traceSuccess(
           Action.LoadDatabases,
@@ -2480,8 +2449,6 @@ export default class Explorer {
         node: null,
         title: notebookContentItem.name,
         tabPath: notebookContentItem.path,
-        documentClientUtility: null,
-
         collection: null,
         selfLink: null,
         masterKey: CosmosClient.masterKey() || "",
@@ -2923,8 +2890,6 @@ export default class Explorer {
         node: null,
         title: title,
         tabPath: title,
-        documentClientUtility: null,
-
         collection: null,
         selfLink: null,
         hashLocation: hashLocation,

--- a/src/Explorer/Graph/GraphExplorerComponent/GraphExplorer.tsx
+++ b/src/Explorer/Graph/GraphExplorerComponent/GraphExplorer.tsx
@@ -696,7 +696,6 @@ export class GraphExplorer extends React.Component<GraphExplorerProps, GraphExpl
    * @param cmd
    */
   public submitToBackend(cmd: string): Q.Promise<GremlinClient.GremlinRequestResult> {
-    console.log("submit:", cmd);
     const id = GraphExplorer.reportToConsole(ConsoleDataType.InProgress, `Executing: ${cmd}`);
     this.setExecuteCounter(this.executeCounter + 1);
 

--- a/src/Explorer/Graph/GraphExplorerComponent/GraphExplorer.tsx
+++ b/src/Explorer/Graph/GraphExplorerComponent/GraphExplorer.tsx
@@ -28,7 +28,7 @@ import * as Constants from "../../../Common/Constants";
 import { InputProperty } from "../../../Contracts/ViewModels";
 import { QueryIterator, ItemDefinition, Resource } from "@azure/cosmos";
 import LoadingIndicatorIcon from "../../../../images/LoadingIndicator_3Squares.gif";
-import DocumentClientUtilityBase from "../../../Common/DocumentClientUtilityBase";
+import { queryDocuments, queryDocumentsPage } from "../../../Common/DocumentClientUtilityBase";
 
 export interface GraphAccessor {
   applyFilter: () => void;
@@ -47,7 +47,6 @@ export interface GraphExplorerProps {
   onIsValidQueryChange: (isValidQuery: boolean) => void;
 
   collectionPartitionKeyProperty: string;
-  documentClientUtility: DocumentClientUtilityBase;
   collectionRid: string;
   collectionSelfLink: string;
   graphBackendEndpoint: string;
@@ -730,26 +729,24 @@ export class GraphExplorer extends React.Component<GraphExplorerProps, GraphExpl
    */
   public executeNonPagedDocDbQuery(query: string): Q.Promise<DataModels.DocumentId[]> {
     // TODO maxItemCount: this reduces throttling, but won't cap the # of results
-    return this.props.documentClientUtility
-      .queryDocuments(this.props.databaseId, this.props.collectionId, query, {
-        maxItemCount: GraphExplorer.PAGE_ALL,
-        enableCrossPartitionQuery:
-          StorageUtility.LocalStorageUtility.getEntryString(StorageUtility.StorageKey.IsCrossPartitionQueryEnabled) ===
-          "true"
-      })
-      .then(
-        (iterator: QueryIterator<ItemDefinition & Resource>) => {
-          return iterator.fetchNext().then(response => response.resources);
-        },
-        (reason: any) => {
-          GraphExplorer.reportToConsole(
-            ConsoleDataType.Error,
-            `Failed to execute non-paged query ${query}. Reason:${reason}`,
-            reason
-          );
-          return null;
-        }
-      );
+    return queryDocuments(this.props.databaseId, this.props.collectionId, query, {
+      maxItemCount: GraphExplorer.PAGE_ALL,
+      enableCrossPartitionQuery:
+        StorageUtility.LocalStorageUtility.getEntryString(StorageUtility.StorageKey.IsCrossPartitionQueryEnabled) ===
+        "true"
+    }).then(
+      (iterator: QueryIterator<ItemDefinition & Resource>) => {
+        return iterator.fetchNext().then(response => response.resources);
+      },
+      (reason: any) => {
+        GraphExplorer.reportToConsole(
+          ConsoleDataType.Error,
+          `Failed to execute non-paged query ${query}. Reason:${reason}`,
+          reason
+        );
+        return null;
+      }
+    );
   }
 
   /**
@@ -1732,12 +1729,10 @@ export class GraphExplorer extends React.Component<GraphExplorerProps, GraphExpl
       query = `select root.id, root.${this.props.collectionPartitionKeyProperty} from root where IS_DEFINED(root._isEdge) = false order by root._ts asc`;
     }
 
-    return this.props.documentClientUtility
-      .queryDocuments(this.props.databaseId, this.props.collectionId, query, {
-        maxItemCount: GraphExplorer.ROOT_LIST_PAGE_SIZE,
-        enableCrossPartitionQuery:
-          LocalStorageUtility.getEntryString(StorageKey.IsCrossPartitionQueryEnabled) === "true"
-      })
+    return queryDocuments(this.props.databaseId, this.props.collectionId, query, {
+      maxItemCount: GraphExplorer.ROOT_LIST_PAGE_SIZE,
+      enableCrossPartitionQuery: LocalStorageUtility.getEntryString(StorageKey.IsCrossPartitionQueryEnabled) === "true"
+    })
       .then(
         (iterator: QueryIterator<ItemDefinition & Resource>) => {
           this.currentDocDBQueryInfo = {
@@ -1766,16 +1761,15 @@ export class GraphExplorer extends React.Component<GraphExplorerProps, GraphExpl
       .currentDocDBQueryInfo.index + GraphExplorer.ROOT_LIST_PAGE_SIZE})`;
     const id = GraphExplorer.reportToConsole(ConsoleDataType.InProgress, `Executing: ${queryInfoStr}`);
 
-    return this.props.documentClientUtility
-      .queryDocumentsPage(
-        this.props.collectionRid,
-        this.currentDocDBQueryInfo.iterator,
-        this.currentDocDBQueryInfo.index,
-        {
-          enableCrossPartitionQuery:
-            LocalStorageUtility.getEntryString(StorageKey.IsCrossPartitionQueryEnabled) === "true"
-        }
-      )
+    return queryDocumentsPage(
+      this.props.collectionRid,
+      this.currentDocDBQueryInfo.iterator,
+      this.currentDocDBQueryInfo.index,
+      {
+        enableCrossPartitionQuery:
+          LocalStorageUtility.getEntryString(StorageKey.IsCrossPartitionQueryEnabled) === "true"
+      }
+    )
       .then((results: ViewModels.QueryResults) => {
         GraphExplorer.clearConsoleProgress(id);
         this.currentDocDBQueryInfo.index = results.lastItemIndex + 1;

--- a/src/Explorer/Graph/GraphExplorerComponent/GraphExplorerAdapter.tsx
+++ b/src/Explorer/Graph/GraphExplorerComponent/GraphExplorerAdapter.tsx
@@ -3,7 +3,6 @@ import { ReactAdapter } from "../../../Bindings/ReactBindingHandler";
 import { GraphConfig } from "../../Tabs/GraphTab";
 import * as ViewModels from "../../../Contracts/ViewModels";
 import { GraphExplorer, GraphAccessor } from "./GraphExplorer";
-import DocumentClientUtilityBase from "../../../Common/DocumentClientUtilityBase";
 
 interface Parameter {
   onIsNewVertexDisabledChange: (isEnabled: boolean) => void;
@@ -18,7 +17,6 @@ interface Parameter {
   graphConfig?: GraphConfig;
 
   collectionPartitionKeyProperty: string;
-  documentClientUtility: DocumentClientUtilityBase;
   collectionRid: string;
   collectionSelfLink: string;
   graphBackendEndpoint: string;
@@ -51,7 +49,6 @@ export class GraphExplorerAdapter implements ReactAdapter {
         onIsGraphDisplayed={this.params.onIsGraphDisplayed}
         onResetDefaultGraphConfigValues={this.params.onResetDefaultGraphConfigValues}
         collectionPartitionKeyProperty={this.params.collectionPartitionKeyProperty}
-        documentClientUtility={this.params.documentClientUtility}
         collectionRid={this.params.collectionRid}
         collectionSelfLink={this.params.collectionSelfLink}
         graphBackendEndpoint={this.params.graphBackendEndpoint}

--- a/src/Explorer/Notebook/NotebookManager.ts
+++ b/src/Explorer/Notebook/NotebookManager.ts
@@ -57,7 +57,6 @@ export default class NotebookManager {
     this.gitHubOAuthService = new GitHubOAuthService(this.junoClient);
     this.gitHubClient = new GitHubClient(this.onGitHubClientError);
     this.gitHubReposPane = new GitHubReposPane({
-      documentClientUtility: this.params.container.documentClientUtility,
       id: "gitHubReposPane",
       visible: ko.observable<boolean>(false),
       container: this.params.container,

--- a/src/Explorer/Panes/AddCollectionPane.test.ts
+++ b/src/Explorer/Panes/AddCollectionPane.test.ts
@@ -41,7 +41,7 @@ describe("Add Collection Pane", () => {
     };
 
     beforeEach(() => {
-      explorer = new Explorer({ documentClientUtility: null, notificationsClient: null, isEmulator: false });
+      explorer = new Explorer({ notificationsClient: null, isEmulator: false });
       explorer.hasAutoPilotV2FeatureFlag = ko.computed<boolean>(() => true);
     });
 

--- a/src/Explorer/Panes/AddCollectionPane.ts
+++ b/src/Explorer/Panes/AddCollectionPane.ts
@@ -20,6 +20,7 @@ import { createMongoCollectionWithARM, createMongoCollectionWithProxy } from "..
 import { DynamicListItem } from "../Controls/DynamicList/DynamicListComponent";
 import { HashMap } from "../../Common/HashMap";
 import { PlatformType } from "../../PlatformType";
+import { refreshCachedResources, getOrCreateDatabaseAndCollection } from "../../Common/DocumentClientUtilityBase";
 
 export default class AddCollectionPane extends ContextualPaneBase {
   public defaultExperience: ko.Computed<string>;
@@ -941,8 +942,7 @@ export default class AddCollectionPane extends ContextualPaneBase {
           )
         );
     } else {
-      createCollectionFunc = () =>
-        this.container.documentClientUtility.getOrCreateDatabaseAndCollection(createRequest, options);
+      createCollectionFunc = () => getOrCreateDatabaseAndCollection(createRequest, options);
     }
 
     createCollectionFunc().then(
@@ -978,7 +978,7 @@ export default class AddCollectionPane extends ContextualPaneBase {
         };
         TelemetryProcessor.traceSuccess(Action.CreateCollection, addCollectionPaneSuccessMessage, startKey);
         this.resetData();
-        return this.container.documentClientUtility.refreshCachedResources().then(() => {
+        return refreshCachedResources().then(() => {
           this.container.refreshAllDatabases();
         });
       },

--- a/src/Explorer/Panes/AddDatabasePane.test.ts
+++ b/src/Explorer/Panes/AddDatabasePane.test.ts
@@ -40,7 +40,6 @@ describe("Add Database Pane", () => {
 
     beforeEach(() => {
       explorer = new Explorer({
-        documentClientUtility: null,
         notificationsClient: null,
         isEmulator: false
       });

--- a/src/Explorer/Panes/AddDatabasePane.ts
+++ b/src/Explorer/Panes/AddDatabasePane.ts
@@ -16,6 +16,7 @@ import { CassandraAPIDataClient } from "../Tables/TableDataClient";
 import { ContextualPaneBase } from "./ContextualPaneBase";
 import { CosmosClient } from "../../Common/CosmosClient";
 import { PlatformType } from "../../PlatformType";
+import { refreshCachedOffers, refreshCachedResources, createDatabase } from "../../Common/DocumentClientUtilityBase";
 
 export default class AddDatabasePane extends ContextualPaneBase {
   public defaultExperience: ko.Computed<string>;
@@ -334,10 +335,7 @@ export default class AddDatabasePane extends ContextualPaneBase {
   ) {
     AddDbUtilities.createSqlDatabase(this.container.armEndpoint(), createDatabaseParameters, autoPilotSettings).then(
       () => {
-        Promise.all([
-          this.container.documentClientUtility.refreshCachedOffers(),
-          this.container.documentClientUtility.refreshCachedResources()
-        ]).then(() => {
+        Promise.all([refreshCachedOffers(), refreshCachedResources()]).then(() => {
           this._onCreateDatabaseSuccess(createDatabaseParameters.offerThroughput, startKey);
         });
       }
@@ -354,10 +352,7 @@ export default class AddDatabasePane extends ContextualPaneBase {
       createDatabaseParameters,
       autoPilotSettings
     ).then(() => {
-      Promise.all([
-        this.container.documentClientUtility.refreshCachedOffers(),
-        this.container.documentClientUtility.refreshCachedResources()
-      ]).then(() => {
+      Promise.all([refreshCachedOffers(), refreshCachedResources()]).then(() => {
         this._onCreateDatabaseSuccess(createDatabaseParameters.offerThroughput, startKey);
       });
     });
@@ -373,10 +368,7 @@ export default class AddDatabasePane extends ContextualPaneBase {
       createDatabaseParameters,
       autoPilotSettings
     ).then(() => {
-      Promise.all([
-        this.container.documentClientUtility.refreshCachedOffers(),
-        this.container.documentClientUtility.refreshCachedResources()
-      ]).then(() => {
+      Promise.all([refreshCachedOffers(), refreshCachedResources()]).then(() => {
         this._onCreateDatabaseSuccess(createDatabaseParameters.offerThroughput, startKey);
       });
     });
@@ -413,7 +405,7 @@ export default class AddDatabasePane extends ContextualPaneBase {
       autoPilot,
       hasAutoPilotV2FeatureFlag: this.hasAutoPilotV2FeatureFlag()
     };
-    this.container.documentClientUtility.createDatabase(createRequest).then(
+    createDatabase(createRequest).then(
       (database: DataModels.Database) => {
         this._onCreateDatabaseSuccess(offerThroughput, telemetryStartKey);
       },
@@ -464,10 +456,7 @@ export default class AddDatabasePane extends ContextualPaneBase {
     startKey: number
   ): void {
     AddDbUtilities.createCassandraKeyspace(armEndpoint, createKeyspaceParameters, autoPilotSettings).then(() => {
-      Promise.all([
-        this.container.documentClientUtility.refreshCachedOffers(),
-        this.container.documentClientUtility.refreshCachedResources()
-      ]).then(() => {
+      Promise.all([refreshCachedOffers(), refreshCachedResources()]).then(() => {
         this._onCreateDatabaseSuccess(createKeyspaceParameters.offerThroughput, startKey);
       });
     });

--- a/src/Explorer/Panes/ContextualPaneBase.ts
+++ b/src/Explorer/Panes/ContextualPaneBase.ts
@@ -5,7 +5,6 @@ import { Action, ActionModifiers } from "../../Shared/Telemetry/TelemetryConstan
 import { KeyCodes } from "../../Common/Constants";
 import { WaitsForTemplateViewModel } from "../WaitsForTemplateViewModel";
 import TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
-import DocumentClientUtilityBase from "../../Common/DocumentClientUtilityBase";
 import Explorer from "../Explorer";
 
 // TODO: Use specific actions for logging telemetry data
@@ -17,14 +16,12 @@ export abstract class ContextualPaneBase extends WaitsForTemplateViewModel imple
   public formErrors: ko.Observable<string>;
   public title: ko.Observable<string>;
   public visible: ko.Observable<boolean>;
-  public documentClientUtility: DocumentClientUtilityBase;
   public isExecuting: ko.Observable<boolean>;
 
   constructor(options: ViewModels.PaneOptions) {
     super();
     this.id = options.id;
     this.container = options.container;
-    this.documentClientUtility = options.documentClientUtility;
     this.visible = options.visible || ko.observable(false);
     this.firstFieldHasFocus = ko.observable<boolean>(false);
     this.formErrors = ko.observable<string>();

--- a/src/Explorer/Panes/DeleteCollectionConfirmationPane.ts
+++ b/src/Explorer/Panes/DeleteCollectionConfirmationPane.ts
@@ -11,6 +11,7 @@ import { DefaultExperienceUtility } from "../../Shared/DefaultExperienceUtility"
 import DeleteFeedback from "../../Common/DeleteFeedback";
 import { NotificationConsoleUtils } from "../../Utils/NotificationConsoleUtils";
 import TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
+import { deleteCollection } from "../../Common/DocumentClientUtilityBase";
 
 export default class DeleteCollectionConfirmationPane extends ContextualPaneBase {
   public collectionIdConfirmationText: ko.Observable<string>;
@@ -58,7 +59,7 @@ export default class DeleteCollectionConfirmationPane extends ContextualPaneBase
         this.container
       );
     } else {
-      promise = this.container.documentClientUtility.deleteCollection(selectedCollection);
+      promise = deleteCollection(selectedCollection);
     }
     return promise.then(
       () => {

--- a/src/Explorer/Panes/DeleteDatabaseConfirmationPane.test.ts
+++ b/src/Explorer/Panes/DeleteDatabaseConfirmationPane.test.ts
@@ -1,23 +1,28 @@
+jest.mock("../../Common/DocumentClientUtilityBase");
+jest.mock("../../Shared/Telemetry/TelemetryProcessor");
 import * as ko from "knockout";
-import * as sinon from "sinon";
 import Q from "q";
 import { Action, ActionModifiers } from "../../Shared/Telemetry/TelemetryConstants";
 import * as DataModels from "../../Contracts/DataModels";
 import * as ViewModels from "../../Contracts/ViewModels";
 import DeleteDatabaseConfirmationPane from "./DeleteDatabaseConfirmationPane";
 import DeleteFeedback from "../../Common/DeleteFeedback";
-import DocumentClientUtilityBase from "../../Common/DocumentClientUtilityBase";
 import Explorer from "../Explorer";
 import TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
 import { TreeNode } from "../../Contracts/ViewModels";
 import { TabsManager } from "../Tabs/TabsManager";
+import { deleteDatabase } from "../../Common/DocumentClientUtilityBase";
 
 describe("Delete Database Confirmation Pane", () => {
   describe("Explorer.isLastDatabase() and Explorer.isLastNonEmptyDatabase()", () => {
     let explorer: Explorer;
 
+    beforeAll(() => {
+      (deleteDatabase as jest.Mock).mockResolvedValue(undefined);
+    });
+
     beforeEach(() => {
-      explorer = new Explorer({ documentClientUtility: null, notificationsClient: null, isEmulator: false });
+      explorer = new Explorer({ notificationsClient: null, isEmulator: false });
     });
 
     it("should be true if only 1 database", () => {
@@ -49,12 +54,10 @@ describe("Delete Database Confirmation Pane", () => {
 
   describe("shouldRecordFeedback()", () => {
     it("should return true if last non empty database or is last database that has shared throughput, else false", () => {
-      let fakeDocumentClientUtility = {} as DocumentClientUtilityBase;
       let fakeExplorer = {} as Explorer;
       fakeExplorer.isNotificationConsoleExpanded = ko.observable<boolean>(false);
 
       let pane = new DeleteDatabaseConfirmationPane({
-        documentClientUtility: fakeDocumentClientUtility as any,
         id: "deletedatabaseconfirmationpane",
         visible: ko.observable<boolean>(false),
         container: fakeExplorer as any
@@ -78,20 +81,8 @@ describe("Delete Database Confirmation Pane", () => {
   });
 
   describe("submit()", () => {
-    let telemetryProcessorSpy: sinon.SinonSpy;
-
-    beforeEach(() => {
-      telemetryProcessorSpy = sinon.spy(TelemetryProcessor, "trace");
-    });
-
-    afterEach(() => {
-      telemetryProcessorSpy.restore();
-    });
-
     it("on submit() it should log feedback if last non empty database or is last database that has shared throughput", () => {
       let selectedDatabaseId = "testDB";
-      let fakeDocumentClientUtility = {} as DocumentClientUtilityBase;
-      fakeDocumentClientUtility.deleteDatabase = () => Q.resolve(null);
       let fakeExplorer = {} as Explorer;
       fakeExplorer.findSelectedDatabase = () => {
         return {
@@ -114,13 +105,11 @@ describe("Delete Database Confirmation Pane", () => {
       fakeExplorer.isPreferredApiCassandra = ko.computed(() => {
         return false;
       });
-      fakeExplorer.documentClientUtility = fakeDocumentClientUtility;
       fakeExplorer.selectedNode = ko.observable<TreeNode>();
       fakeExplorer.tabsManager = new TabsManager();
       fakeExplorer.isLastNonEmptyDatabase = () => true;
 
       let pane = new DeleteDatabaseConfirmationPane({
-        documentClientUtility: fakeDocumentClientUtility as any,
         id: "deletedatabaseconfirmationpane",
         visible: ko.observable<boolean>(false),
         container: fakeExplorer as any
@@ -130,15 +119,12 @@ describe("Delete Database Confirmation Pane", () => {
       pane.databaseDeleteFeedback(Feedback);
 
       return pane.submit().then(() => {
-        expect(telemetryProcessorSpy.called).toBe(true);
         let deleteFeedback = new DeleteFeedback(SubscriptionId, AccountName, DataModels.ApiKind.SQL, Feedback);
-        expect(
-          telemetryProcessorSpy.calledWith(
-            Action.DeleteDatabase,
-            ActionModifiers.Mark,
-            JSON.stringify(deleteFeedback, Object.getOwnPropertyNames(deleteFeedback))
-          )
-        ).toBe(true);
+        expect(TelemetryProcessor.trace).toHaveBeenCalledWith(
+          Action.DeleteDatabase,
+          ActionModifiers.Mark,
+          JSON.stringify(deleteFeedback, Object.getOwnPropertyNames(deleteFeedback))
+        );
       });
     });
   });

--- a/src/Explorer/Panes/DeleteDatabaseConfirmationPane.ts
+++ b/src/Explorer/Panes/DeleteDatabaseConfirmationPane.ts
@@ -12,6 +12,7 @@ import DeleteFeedback from "../../Common/DeleteFeedback";
 
 import { NotificationConsoleUtils } from "../../Utils/NotificationConsoleUtils";
 import TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
+import { deleteDatabase } from "../../Common/DocumentClientUtilityBase";
 
 export default class DeleteDatabaseConfirmationPane extends ContextualPaneBase {
   public databaseIdConfirmationText: ko.Observable<string>;
@@ -59,7 +60,7 @@ export default class DeleteDatabaseConfirmationPane extends ContextualPaneBase {
         this.container
       );
     } else {
-      promise = this.container.documentClientUtility.deleteDatabase(selectedDatabase);
+      promise = deleteDatabase(selectedDatabase);
     }
     return promise.then(
       () => {

--- a/src/Explorer/Panes/SettingsPane.test.ts
+++ b/src/Explorer/Panes/SettingsPane.test.ts
@@ -7,7 +7,7 @@ describe("Settings Pane", () => {
     let explorer: Explorer;
 
     beforeEach(() => {
-      explorer = new Explorer({ documentClientUtility: null, notificationsClient: null, isEmulator: false });
+      explorer = new Explorer({ notificationsClient: null, isEmulator: false });
     });
 
     it("should be true for SQL API", () => {

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -15,8 +15,14 @@ import * as TableEntityProcessor from "./TableEntityProcessor";
 import * as ViewModels from "../../Contracts/ViewModels";
 import { MessageTypes } from "../../Contracts/ExplorerContracts";
 import { sendMessage } from "../../Common/MessageHandler";
-import DocumentClientUtilityBase from "../../Common/DocumentClientUtilityBase";
 import Explorer from "../Explorer";
+import {
+  queryDocuments,
+  refreshCachedResources,
+  deleteDocument,
+  updateDocument,
+  createDocument
+} from "../../Common/DocumentClientUtilityBase";
 
 export interface CassandraTableKeys {
   partitionKeys: CassandraTableKey[];
@@ -29,11 +35,7 @@ export interface CassandraTableKey {
 }
 
 export abstract class TableDataClient {
-  public documentClientUtility: DocumentClientUtilityBase;
-
-  constructor(documentClientUtility: DocumentClientUtilityBase) {
-    this.documentClientUtility = documentClientUtility;
-  }
+  constructor() {}
 
   public abstract createDocument(
     collection: ViewModels.Collection,
@@ -65,20 +67,18 @@ export class TablesAPIDataClient extends TableDataClient {
     entity: Entities.ITableEntity
   ): Q.Promise<Entities.ITableEntity> {
     const deferred = Q.defer<Entities.ITableEntity>();
-    this.documentClientUtility
-      .createDocument(
-        collection,
-        TableEntityProcessor.convertEntityToNewDocument(<Entities.ITableEntityForTablesAPI>entity)
-      )
-      .then(
-        (newDocument: any) => {
-          const newEntity = TableEntityProcessor.convertDocumentsToEntities([newDocument])[0];
-          deferred.resolve(newEntity);
-        },
-        reason => {
-          deferred.reject(reason);
-        }
-      );
+    createDocument(
+      collection,
+      TableEntityProcessor.convertEntityToNewDocument(<Entities.ITableEntityForTablesAPI>entity)
+    ).then(
+      (newDocument: any) => {
+        const newEntity = TableEntityProcessor.convertDocumentsToEntities([newDocument])[0];
+        deferred.resolve(newEntity);
+      },
+      reason => {
+        deferred.reject(reason);
+      }
+    );
     return deferred.promise;
   }
 
@@ -88,21 +88,20 @@ export class TablesAPIDataClient extends TableDataClient {
     entity: Entities.ITableEntity
   ): Q.Promise<Entities.ITableEntity> {
     const deferred = Q.defer<Entities.ITableEntity>();
-    this.documentClientUtility
-      .updateDocument(
-        collection,
-        originalDocument,
-        TableEntityProcessor.convertEntityToNewDocument(<Entities.ITableEntityForTablesAPI>entity)
-      )
-      .then(
-        (newDocument: any) => {
-          const newEntity = TableEntityProcessor.convertDocumentsToEntities([newDocument])[0];
-          deferred.resolve(newEntity);
-        },
-        reason => {
-          deferred.reject(reason);
-        }
-      );
+
+    updateDocument(
+      collection,
+      originalDocument,
+      TableEntityProcessor.convertEntityToNewDocument(<Entities.ITableEntityForTablesAPI>entity)
+    ).then(
+      (newDocument: any) => {
+        const newEntity = TableEntityProcessor.convertDocumentsToEntities([newDocument])[0];
+        deferred.resolve(newEntity);
+      },
+      reason => {
+        deferred.reject(reason);
+      }
+    );
     return deferred.promise;
   }
 
@@ -114,7 +113,7 @@ export class TablesAPIDataClient extends TableDataClient {
 
     let options: any = {};
     options.enableCrossPartitionQuery = HeadersUtility.shouldEnableCrossPartitionKey();
-    this.documentClientUtility.queryDocuments(collection.databaseId, collection.id(), query, options).then(
+    queryDocuments(collection.databaseId, collection.id(), query, options).then(
       iterator => {
         iterator
           .fetchNext()
@@ -150,7 +149,7 @@ export class TablesAPIDataClient extends TableDataClient {
     documentsToDelete &&
       documentsToDelete.forEach(document => {
         document.id = ko.observable<string>(document.id);
-        let promise: Q.Promise<any> = this.documentClientUtility.deleteDocument(collection, document);
+        let promise: Q.Promise<any> = deleteDocument(collection, document);
         promiseArray.push(promise);
       });
     return Q.all(promiseArray);
@@ -425,7 +424,7 @@ export class CassandraAPIDataClient extends TableDataClient {
             ConsoleDataType.Info,
             `Successfully created a keyspace with query ${createKeyspaceQuery}`
           );
-          explorer.documentClientUtility.refreshCachedResources().finally(() => deferred.resolve());
+          refreshCachedResources().finally(() => deferred.resolve());
         },
         reason => {
           NotificationConsoleUtils.logConsoleMessage(
@@ -472,7 +471,7 @@ export class CassandraAPIDataClient extends TableDataClient {
                 ConsoleDataType.Info,
                 `Successfully created a table with query ${createTableQuery}`
               );
-              this.documentClientUtility.refreshCachedResources(null).then(
+              refreshCachedResources(null).then(
                 () => {
                   deferred.resolve();
                 },
@@ -521,7 +520,7 @@ export class CassandraAPIDataClient extends TableDataClient {
             ConsoleDataType.Info,
             `Successfully deleted resource with query ${deleteQuery}`
           );
-          this.documentClientUtility.refreshCachedResources(null).then(
+          refreshCachedResources(null).then(
             () => {
               deferred.resolve();
             },

--- a/src/Explorer/Tabs/ConflictsTab.ts
+++ b/src/Explorer/Tabs/ConflictsTab.ts
@@ -21,6 +21,13 @@ import DeleteIcon from "../../../images/delete.svg";
 import { QueryIterator, ItemDefinition, Resource, ConflictDefinition } from "@azure/cosmos";
 import { MinimalQueryIterator } from "../../Common/IteratorUtilities";
 import Explorer from "../Explorer";
+import {
+  queryConflicts,
+  deleteConflict,
+  deleteDocument,
+  createDocument,
+  updateDocument
+} from "../../Common/DocumentClientUtilityBase";
 
 export default class ConflictsTab extends TabsBase {
   public selectedConflictId: ko.Observable<ViewModels.ConflictId>;
@@ -286,7 +293,7 @@ export default class ConflictsTab extends TabsBase {
     if (selectedConflict.operationType === Constants.ConflictOperationType.Replace) {
       const documentContent = JSON.parse(this.selectedConflictContent());
 
-      operationPromise = this._container.documentClientUtility.updateDocument(
+      operationPromise = updateDocument(
         this.collection,
         selectedConflict.buildDocumentIdFromConflict(documentContent[selectedConflict.partitionKeyProperty]),
         documentContent
@@ -296,13 +303,13 @@ export default class ConflictsTab extends TabsBase {
     if (selectedConflict.operationType === Constants.ConflictOperationType.Create) {
       const documentContent = JSON.parse(this.selectedConflictContent());
 
-      operationPromise = this._container.documentClientUtility.createDocument(this.collection, documentContent);
+      operationPromise = createDocument(this.collection, documentContent);
     }
 
     if (selectedConflict.operationType === Constants.ConflictOperationType.Delete && !!this.selectedConflictContent()) {
       const documentContent = JSON.parse(this.selectedConflictContent());
 
-      operationPromise = this._container.documentClientUtility.deleteDocument(
+      operationPromise = deleteDocument(
         this.collection,
         selectedConflict.buildDocumentIdFromConflict(documentContent[selectedConflict.partitionKeyProperty])
       );
@@ -311,7 +318,7 @@ export default class ConflictsTab extends TabsBase {
     return operationPromise
       .then(
         () => {
-          return this._container.documentClientUtility.deleteConflict(this.collection, selectedConflict).then(() => {
+          return deleteConflict(this.collection, selectedConflict).then(() => {
             this.conflictIds.remove((conflictId: ViewModels.ConflictId) => conflictId.rid === selectedConflict.rid);
             this.selectedConflictContent("");
             this.selectedConflictCurrent("");
@@ -370,8 +377,7 @@ export default class ConflictsTab extends TabsBase {
       conflictResourceId: selectedConflict.resourceId
     });
 
-    return this._container.documentClientUtility
-      .deleteConflict(this.collection, selectedConflict)
+    return deleteConflict(this.collection, selectedConflict)
       .then(
         () => {
           this.conflictIds.remove((conflictId: ViewModels.ConflictId) => conflictId.rid === selectedConflict.rid);
@@ -491,7 +497,7 @@ export default class ConflictsTab extends TabsBase {
     const query: string = undefined;
     let options: any = {};
     options.enableCrossPartitionQuery = HeadersUtility.shouldEnableCrossPartitionKey();
-    return this.documentClientUtility.queryConflicts(this.collection.databaseId, this.collection.id(), query, options);
+    return queryConflicts(this.collection.databaseId, this.collection.id(), query, options);
   }
 
   public loadNextPage(): Q.Promise<any> {

--- a/src/Explorer/Tabs/DocumentsTab.test.ts
+++ b/src/Explorer/Tabs/DocumentsTab.test.ts
@@ -3,7 +3,6 @@ import * as ViewModels from "../../Contracts/ViewModels";
 import * as Constants from "../../Common/Constants";
 import DocumentsTab from "./DocumentsTab";
 import Explorer from "../Explorer";
-import DocumentClientUtilityBase from "../../Common/DocumentClientUtilityBase";
 
 describe("Documents tab", () => {
   describe("buildQuery", () => {
@@ -14,7 +13,6 @@ describe("Documents tab", () => {
         tabKind: ViewModels.CollectionTabKind.Documents,
         title: "",
         tabPath: "",
-        documentClientUtility: new DocumentClientUtilityBase(),
         selfLink: "",
         hashLocation: "",
         isActive: ko.observable<boolean>(false),
@@ -28,13 +26,11 @@ describe("Documents tab", () => {
 
   describe("showPartitionKey", () => {
     const explorer = new Explorer({
-      documentClientUtility: null,
       notificationsClient: null,
       isEmulator: false
     });
 
     const mongoExplorer = new Explorer({
-      documentClientUtility: null,
       notificationsClient: null,
       isEmulator: false
     });
@@ -97,7 +93,6 @@ describe("Documents tab", () => {
         tabKind: ViewModels.CollectionTabKind.Documents,
         title: "",
         tabPath: "",
-        documentClientUtility: new DocumentClientUtilityBase(),
         selfLink: "",
         hashLocation: "",
         isActive: ko.observable<boolean>(false),
@@ -116,7 +111,6 @@ describe("Documents tab", () => {
         tabKind: ViewModels.CollectionTabKind.Documents,
         title: "",
         tabPath: "",
-        documentClientUtility: new DocumentClientUtilityBase(),
         selfLink: "",
         hashLocation: "",
         isActive: ko.observable<boolean>(false),
@@ -135,7 +129,6 @@ describe("Documents tab", () => {
         tabKind: ViewModels.CollectionTabKind.Documents,
         title: "",
         tabPath: "",
-        documentClientUtility: new DocumentClientUtilityBase(),
         selfLink: "",
         hashLocation: "",
         isActive: ko.observable<boolean>(false),
@@ -154,7 +147,6 @@ describe("Documents tab", () => {
         tabKind: ViewModels.CollectionTabKind.Documents,
         title: "",
         tabPath: "",
-        documentClientUtility: new DocumentClientUtilityBase(),
         selfLink: "",
         hashLocation: "",
         isActive: ko.observable<boolean>(false),
@@ -173,7 +165,6 @@ describe("Documents tab", () => {
         tabKind: ViewModels.CollectionTabKind.Documents,
         title: "",
         tabPath: "",
-        documentClientUtility: new DocumentClientUtilityBase(),
         selfLink: "",
         hashLocation: "",
         isActive: ko.observable<boolean>(false),

--- a/src/Explorer/Tabs/DocumentsTab.ts
+++ b/src/Explorer/Tabs/DocumentsTab.ts
@@ -26,6 +26,13 @@ import { extractPartitionKey, PartitionKeyDefinition, QueryIterator, ItemDefinit
 import { ConsoleDataType } from "../Menus/NotificationConsole/NotificationConsoleComponent";
 import { NotificationConsoleUtils } from "../../Utils/NotificationConsoleUtils";
 import Explorer from "../Explorer";
+import {
+  readDocument,
+  queryDocuments,
+  deleteDocument,
+  updateDocument,
+  createDocument
+} from "../../Common/DocumentClientUtilityBase";
 
 export default class DocumentsTab extends TabsBase implements ViewModels.DocumentsTab {
   public selectedDocumentId: ko.Observable<ViewModels.DocumentId>;
@@ -442,8 +449,7 @@ export default class DocumentsTab extends TabsBase implements ViewModels.Documen
     });
     const document = JSON.parse(this.selectedDocumentContent());
     this.isExecuting(true);
-    return this.documentClientUtility
-      .createDocument(this.collection, document)
+    return createDocument(this.collection, document)
       .then(
         (savedDocument: any) => {
           const value: string = this.renderObjectForEditor(savedDocument || {}, null, 4);
@@ -516,8 +522,7 @@ export default class DocumentsTab extends TabsBase implements ViewModels.Documen
       tabTitle: this.tabTitle()
     });
     this.isExecuting(true);
-    return this.documentClientUtility
-      .updateDocument(this.collection, selectedDocumentId, documentContent)
+    return updateDocument(this.collection, selectedDocumentId, documentContent)
       .then(
         (updatedDocument: any) => {
           const value: string = this.renderObjectForEditor(updatedDocument || {}, null, 4);
@@ -665,7 +670,7 @@ export default class DocumentsTab extends TabsBase implements ViewModels.Documen
   };
 
   protected __deleteDocument(documentId: ViewModels.DocumentId): Q.Promise<any> {
-    return this.documentClientUtility.deleteDocument(this.collection, documentId);
+    return deleteDocument(this.collection, documentId);
   }
 
   private _deleteDocument(selectedDocumentId: ViewModels.DocumentId): Q.Promise<any> {
@@ -724,12 +729,12 @@ export default class DocumentsTab extends TabsBase implements ViewModels.Documen
       options.partitionKey = this._resourceTokenPartitionKey;
     }
 
-    return this.documentClientUtility.queryDocuments(this.collection.databaseId, this.collection.id(), query, options);
+    return queryDocuments(this.collection.databaseId, this.collection.id(), query, options);
   }
 
   public selectDocument(documentId: ViewModels.DocumentId): Q.Promise<any> {
     this.selectedDocumentId(documentId);
-    return this.documentClientUtility.readDocument(this.collection, documentId).then((content: any) => {
+    return readDocument(this.collection, documentId).then((content: any) => {
       this.initDocumentEditor(documentId, content);
     });
   }

--- a/src/Explorer/Tabs/GraphTab.ts
+++ b/src/Explorer/Tabs/GraphTab.ts
@@ -83,7 +83,6 @@ export default class GraphTab extends TabsBase implements ViewModels.Tab {
       onIsFilterQueryLoading: (isFilterQueryLoading: boolean): void => this.isFilterQueryLoading(isFilterQueryLoading),
       onIsValidQuery: (isValidQuery: boolean): void => this.isValidQuery(isValidQuery),
       collectionPartitionKeyProperty: options.collectionPartitionKeyProperty,
-      documentClientUtility: this.documentClientUtility,
       collectionRid: this.rid,
       collectionSelfLink: options.selfLink,
       graphBackendEndpoint: GraphTab.getGremlinEndpoint(options.account),
@@ -101,7 +100,6 @@ export default class GraphTab extends TabsBase implements ViewModels.Tab {
 
     this.isFilterQueryLoading = ko.observable(false);
     this.isValidQuery = ko.observable(true);
-    this.documentClientUtility = options.documentClientUtility;
     this.toolbarViewModel = ko.observable<Toolbar>();
   }
 

--- a/src/Explorer/Tabs/QueryTab.test.ts
+++ b/src/Explorer/Tabs/QueryTab.test.ts
@@ -25,7 +25,6 @@ describe("Query Tab", () => {
       database: database,
       title: "",
       tabPath: "",
-      documentClientUtility: container.documentClientUtility,
       selfLink: "",
       isActive: ko.observable<boolean>(false),
       hashLocation: "",
@@ -51,7 +50,7 @@ describe("Query Tab", () => {
     let explorer: Explorer;
 
     beforeEach(() => {
-      explorer = new Explorer({ documentClientUtility: null, notificationsClient: null, isEmulator: false });
+      explorer = new Explorer({ notificationsClient: null, isEmulator: false });
     });
 
     it("should be true for accounts using SQL API", () => {
@@ -71,7 +70,7 @@ describe("Query Tab", () => {
     let explorer: Explorer;
 
     beforeEach(() => {
-      explorer = new Explorer({ documentClientUtility: null, notificationsClient: null, isEmulator: false });
+      explorer = new Explorer({ notificationsClient: null, isEmulator: false });
     });
 
     it("should be visible when using a supported API", () => {

--- a/src/Explorer/Tabs/QueryTab.ts
+++ b/src/Explorer/Tabs/QueryTab.ts
@@ -16,6 +16,7 @@ import { QueryUtils } from "../../Utils/QueryUtils";
 import SaveQueryIcon from "../../../images/save-cosmos.svg";
 
 import { MinimalQueryIterator } from "../../Common/IteratorUtilities";
+import { queryDocuments, queryDocumentsPage } from "../../Common/DocumentClientUtilityBase";
 
 enum ToggleState {
   Result,
@@ -290,12 +291,7 @@ export default class QueryTab extends TabsBase implements ViewModels.QueryTab, V
     options.enableCrossPartitionQuery = HeadersUtility.shouldEnableCrossPartitionKey();
 
     const queryDocuments = (firstItemIndex: number) =>
-      this.documentClientUtility.queryDocumentsPage(
-        this.collection && this.collection.id(),
-        this._iterator,
-        firstItemIndex,
-        options
-      );
+      queryDocumentsPage(this.collection && this.collection.id(), this._iterator, firstItemIndex, options);
     this.isExecuting(true);
     return QueryUtils.queryPagesUntilContentPresent(firstItemIndex, queryDocuments)
       .then(
@@ -497,9 +493,9 @@ export default class QueryTab extends TabsBase implements ViewModels.QueryTab, V
     }
 
     return Q(
-      this.documentClientUtility
-        .queryDocuments(this.collection.databaseId, this.collection.id(), this.sqlStatementToExecute(), options)
-        .then(iterator => (this._iterator = iterator))
+      queryDocuments(this.collection.databaseId, this.collection.id(), this.sqlStatementToExecute(), options).then(
+        iterator => (this._iterator = iterator)
+      )
     );
   }
 

--- a/src/Explorer/Tabs/SettingsTab.test.ts
+++ b/src/Explorer/Tabs/SettingsTab.test.ts
@@ -4,7 +4,6 @@ import * as ko from "knockout";
 import * as ViewModels from "../../Contracts/ViewModels";
 import Collection from "../Tree/Collection";
 import Database from "../Tree/Database";
-import DocumentClientUtilityBase from "../../Common/DocumentClientUtilityBase";
 import Explorer from "../Explorer";
 import SettingsTab from "../Tabs/SettingsTab";
 
@@ -63,8 +62,6 @@ describe("Settings tab", () => {
           tabKind: ViewModels.CollectionTabKind.Settings,
           title: "Scale & Settings",
           tabPath: "",
-          documentClientUtility: undefined,
-
           selfLink: "",
           hashLocation: "",
           isActive: ko.observable(false),
@@ -80,7 +77,7 @@ describe("Settings tab", () => {
       };
 
       beforeEach(() => {
-        explorer = new Explorer({ documentClientUtility: null, notificationsClient: null, isEmulator: false });
+        explorer = new Explorer({ notificationsClient: null, isEmulator: false });
         explorer.hasAutoPilotV2FeatureFlag = ko.computed<boolean>(() => true);
       });
 
@@ -179,7 +176,7 @@ describe("Settings tab", () => {
     let explorer: Explorer;
 
     beforeEach(() => {
-      explorer = new Explorer({ documentClientUtility: null, notificationsClient: null, isEmulator: false });
+      explorer = new Explorer({ notificationsClient: null, isEmulator: false });
       explorer.hasAutoPilotV2FeatureFlag = ko.computed<boolean>(() => true);
     });
 
@@ -188,8 +185,6 @@ describe("Settings tab", () => {
         tabKind: ViewModels.CollectionTabKind.Settings,
         title: "Scale & Settings",
         tabPath: "",
-        documentClientUtility: new DocumentClientUtilityBase(),
-
         selfLink: "",
         hashLocation: "",
         isActive: ko.observable(false),
@@ -212,7 +207,6 @@ describe("Settings tab", () => {
         tabKind: ViewModels.CollectionTabKind.Settings,
         title: "Scale & Settings",
         tabPath: "",
-        documentClientUtility: new DocumentClientUtilityBase(),
 
         selfLink: "",
         hashLocation: "",
@@ -231,7 +225,6 @@ describe("Settings tab", () => {
         tabKind: ViewModels.CollectionTabKind.Settings,
         title: "Scale & Settings",
         tabPath: "",
-        documentClientUtility: new DocumentClientUtilityBase(),
 
         selfLink: "",
         hashLocation: "",
@@ -261,7 +254,7 @@ describe("Settings tab", () => {
     let explorer: Explorer;
 
     beforeEach(() => {
-      explorer = new Explorer({ documentClientUtility: null, notificationsClient: null, isEmulator: false });
+      explorer = new Explorer({ notificationsClient: null, isEmulator: false });
       explorer.hasAutoPilotV2FeatureFlag = ko.computed<boolean>(() => true);
     });
 
@@ -270,7 +263,6 @@ describe("Settings tab", () => {
         tabKind: ViewModels.CollectionTabKind.Settings,
         title: "Scale & Settings",
         tabPath: "",
-        documentClientUtility: new DocumentClientUtilityBase(),
 
         selfLink: "",
         hashLocation: "",
@@ -287,7 +279,6 @@ describe("Settings tab", () => {
         tabKind: ViewModels.CollectionTabKind.Settings,
         title: "Scale & Settings",
         tabPath: "",
-        documentClientUtility: new DocumentClientUtilityBase(),
 
         selfLink: "",
         hashLocation: "",
@@ -313,7 +304,6 @@ describe("Settings tab", () => {
         tabKind: ViewModels.CollectionTabKind.Settings,
         title: "Scale & Settings",
         tabPath: "",
-        documentClientUtility: new DocumentClientUtilityBase(),
 
         selfLink: "",
         hashLocation: "",
@@ -346,7 +336,6 @@ describe("Settings tab", () => {
 
     function getCollection(defaultApi: string, partitionKeyOption: PartitionKeyOption) {
       const explorer = new Explorer({
-        documentClientUtility: null,
         notificationsClient: null,
         isEmulator: false
       });
@@ -394,7 +383,6 @@ describe("Settings tab", () => {
         tabKind: ViewModels.CollectionTabKind.Settings,
         title: "Scale & Settings",
         tabPath: "",
-        documentClientUtility: new DocumentClientUtilityBase(),
 
         selfLink: "",
         hashLocation: "",
@@ -483,7 +471,6 @@ describe("Settings tab", () => {
   describe("AutoPilot", () => {
     function getCollection(autoPilotTier: DataModels.AutopilotTier) {
       const explorer = new Explorer({
-        documentClientUtility: null,
         notificationsClient: null,
         isEmulator: false
       });
@@ -540,7 +527,6 @@ describe("Settings tab", () => {
         tabKind: ViewModels.CollectionTabKind.Settings,
         title: "Scale & Settings",
         tabPath: "",
-        documentClientUtility: new DocumentClientUtilityBase(),
 
         selfLink: "",
         hashLocation: "",

--- a/src/Explorer/Tabs/SettingsTab.ts
+++ b/src/Explorer/Tabs/SettingsTab.ts
@@ -18,6 +18,11 @@ import { CosmosClient } from "../../Common/CosmosClient";
 import { PlatformType } from "../../PlatformType";
 import { RequestOptions } from "@azure/cosmos/dist-esm";
 import Explorer from "../Explorer";
+import {
+  updateOfferThroughputBeyondLimit,
+  updateOffer,
+  updateCollection
+} from "../../Common/DocumentClientUtilityBase";
 
 const ttlWarning: string = `
 The system will automatically delete items based on the TTL value (in seconds) you provide, without needing a delete operation explicitly issued by a client application. 
@@ -1062,9 +1067,8 @@ export default class SettingsTab extends TabsBase implements ViewModels.WaitsFor
       }
 
       const newCollection: DataModels.Collection = _.extend({}, this.collection.rawDataModel, newCollectionAttributes);
-      const updateCollectionPromise = this.container.documentClientUtility
-        .updateCollection(this.collection.databaseId, this.collection, newCollection)
-        .then((updatedCollection: DataModels.Collection) => {
+      const updateCollectionPromise = updateCollection(this.collection.databaseId, this.collection, newCollection).then(
+        (updatedCollection: DataModels.Collection) => {
           this.collection.rawDataModel = updatedCollection;
           this.collection.defaultTtl(updatedCollection.defaultTtl);
           this.collection.analyticalStorageTtl(updatedCollection.analyticalStorageTtl);
@@ -1073,7 +1077,8 @@ export default class SettingsTab extends TabsBase implements ViewModels.WaitsFor
           this.collection.conflictResolutionPolicy(updatedCollection.conflictResolutionPolicy);
           this.collection.changeFeedPolicy(updatedCollection.changeFeedPolicy);
           this.collection.geospatialConfig(updatedCollection.geospatialConfig);
-        });
+        }
+      );
 
       promises.push(updateCollectionPromise);
     }
@@ -1147,48 +1152,46 @@ export default class SettingsTab extends TabsBase implements ViewModels.WaitsFor
           throughput: newThroughput,
           offerIsRUPerMinuteThroughputEnabled: isRUPerMinuteThroughputEnabled
         };
-        const updateOfferBeyondLimitPromise: Q.Promise<void> = this.documentClientUtility
-          .updateOfferThroughputBeyondLimit(requestPayload)
-          .then(
-            () => {
-              this.collection.offer().content.offerThroughput = originalThroughputValue;
-              this.throughput(originalThroughputValue);
-              this.notificationStatusInfo(
-                throughputApplyDelayedMessage(
-                  this.isAutoPilotSelected(),
-                  originalThroughputValue,
-                  this._getThroughputUnit(),
-                  this.collection.databaseId,
-                  this.collection.id(),
-                  newThroughput
-                )
-              );
-              this.throughput.valueHasMutated(); // force component re-render
-            },
-            (error: any) => {
-              TelemetryProcessor.traceFailure(
-                Action.UpdateSettings,
-                {
-                  databaseAccountName: this.container.databaseAccount().name,
-                  databaseName: this.collection && this.collection.databaseId,
-                  collectionName: this.collection && this.collection.id(),
-                  defaultExperience: this.container.defaultExperience(),
-                  dataExplorerArea: Constants.Areas.Tab,
-                  tabTitle: this.tabTitle(),
-                  error: error
-                },
-                startKey
-              );
-            }
-          );
+        const updateOfferBeyondLimitPromise: Q.Promise<void> = updateOfferThroughputBeyondLimit(requestPayload).then(
+          () => {
+            this.collection.offer().content.offerThroughput = originalThroughputValue;
+            this.throughput(originalThroughputValue);
+            this.notificationStatusInfo(
+              throughputApplyDelayedMessage(
+                this.isAutoPilotSelected(),
+                originalThroughputValue,
+                this._getThroughputUnit(),
+                this.collection.databaseId,
+                this.collection.id(),
+                newThroughput
+              )
+            );
+            this.throughput.valueHasMutated(); // force component re-render
+          },
+          (error: any) => {
+            TelemetryProcessor.traceFailure(
+              Action.UpdateSettings,
+              {
+                databaseAccountName: this.container.databaseAccount().name,
+                databaseName: this.collection && this.collection.databaseId,
+                collectionName: this.collection && this.collection.id(),
+                defaultExperience: this.container.defaultExperience(),
+                dataExplorerArea: Constants.Areas.Tab,
+                tabTitle: this.tabTitle(),
+                error: error
+              },
+              startKey
+            );
+          }
+        );
         promises.push(updateOfferBeyondLimitPromise);
       } else {
-        const updateOfferPromise = this.documentClientUtility
-          .updateOffer(this.collection.offer(), newOffer, headerOptions)
-          .then((updatedOffer: DataModels.Offer) => {
+        const updateOfferPromise = updateOffer(this.collection.offer(), newOffer, headerOptions).then(
+          (updatedOffer: DataModels.Offer) => {
             this.collection.offer(updatedOffer);
             this.collection.offer.valueHasMutated();
-          });
+          }
+        );
 
         promises.push(updateOfferPromise);
       }

--- a/src/Explorer/Tabs/StoredProcedureTab.ts
+++ b/src/Explorer/Tabs/StoredProcedureTab.ts
@@ -10,6 +10,7 @@ import ScriptTabBase from "./ScriptTabBase";
 import TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
 import ExecuteQueryIcon from "../../../images/ExecuteQuery.svg";
 import StoredProcedure from "../Tree/StoredProcedure";
+import { createStoredProcedure, updateStoredProcedure } from "../../Common/DocumentClientUtilityBase";
 
 enum ToggleState {
   Result = "result",
@@ -81,8 +82,7 @@ export default class StoredProcedureTab extends ScriptTabBase implements ViewMod
       dataExplorerArea: Constants.Areas.Tab,
       tabTitle: this.tabTitle()
     });
-    return this.documentClientUtility
-      .updateStoredProcedure(this.collection, data)
+    return updateStoredProcedure(this.collection, data)
       .then(
         (updatedResource: DataModels.StoredProcedure) => {
           this.resource(updatedResource);
@@ -240,8 +240,7 @@ export default class StoredProcedureTab extends ScriptTabBase implements ViewMod
       tabTitle: this.tabTitle()
     });
 
-    return this.documentClientUtility
-      .createStoredProcedure(this.collection, resource)
+    return createStoredProcedure(this.collection, resource)
       .then(
         createdResource => {
           this.tabTitle(createdResource.id);

--- a/src/Explorer/Tabs/TabsBase.ts
+++ b/src/Explorer/Tabs/TabsBase.ts
@@ -7,13 +7,11 @@ import { RouteHandler } from "../../RouteHandlers/RouteHandler";
 import { WaitsForTemplateViewModel } from "../WaitsForTemplateViewModel";
 import TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
 import ThemeUtility from "../../Common/ThemeUtility";
-import DocumentClientUtilityBase from "../../Common/DocumentClientUtilityBase";
 import Explorer from "../Explorer";
 
 // TODO: Use specific actions for logging telemetry data
 export default class TabsBase extends WaitsForTemplateViewModel implements ViewModels.Tab {
   public closeTabButton: ViewModels.Button;
-  public documentClientUtility: DocumentClientUtilityBase;
   public node: ViewModels.TreeNode;
   public collection: ViewModels.CollectionBase;
   public database: ViewModels.Database;
@@ -39,7 +37,6 @@ export default class TabsBase extends WaitsForTemplateViewModel implements ViewM
     const id = new Date().getTime().toString();
 
     this._theme = ThemeUtility.getMonacoTheme(options.theme);
-    this.documentClientUtility = options.documentClientUtility;
     this.node = options.node;
     this.collection = options.collection;
     this.database = options.database;

--- a/src/Explorer/Tabs/TabsManager.test.ts
+++ b/src/Explorer/Tabs/TabsManager.test.ts
@@ -1,7 +1,6 @@
 import * as ko from "knockout";
 import * as ViewModels from "../../Contracts/ViewModels";
 import { TabsManager } from "./TabsManager";
-import DocumentClientUtilityBase from "../../Common/DocumentClientUtilityBase";
 import DocumentsTab from "./DocumentsTab";
 import Explorer from "../Explorer";
 import QueryTab from "./QueryTab";
@@ -15,7 +14,7 @@ describe("Tabs manager tests", () => {
   let documentsTab: DocumentsTab;
 
   beforeAll(() => {
-    explorer = new Explorer({ documentClientUtility: undefined, notificationsClient: undefined, isEmulator: false });
+    explorer = new Explorer({ notificationsClient: undefined, isEmulator: false });
     explorer.databaseAccount = ko.observable<ViewModels.DatabaseAccount>({
       id: "test",
       name: "test",
@@ -49,7 +48,6 @@ describe("Tabs manager tests", () => {
       database,
       title: "",
       tabPath: "",
-      documentClientUtility: explorer.documentClientUtility,
       selfLink: "",
       isActive: ko.observable<boolean>(false),
       hashLocation: "",
@@ -63,7 +61,6 @@ describe("Tabs manager tests", () => {
       collection,
       title: "",
       tabPath: "",
-      documentClientUtility: new DocumentClientUtilityBase(),
       selfLink: "",
       hashLocation: "",
       isActive: ko.observable<boolean>(false),

--- a/src/Explorer/Tabs/TriggerTab.ts
+++ b/src/Explorer/Tabs/TriggerTab.ts
@@ -7,6 +7,7 @@ import ScriptTabBase from "./ScriptTabBase";
 import editable from "../../Common/EditableUtility";
 import TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
 import Trigger from "../Tree/Trigger";
+import { createTrigger, updateTrigger } from "../../Common/DocumentClientUtilityBase";
 
 export default class TriggerTab extends ScriptTabBase implements ViewModels.TriggerTab {
   public collection: ViewModels.Collection;
@@ -41,8 +42,7 @@ export default class TriggerTab extends ScriptTabBase implements ViewModels.Trig
       tabTitle: this.tabTitle()
     });
 
-    return this.documentClientUtility
-      .updateTrigger(this.collection, data)
+    return updateTrigger(this.collection, data)
       .then(
         (createdResource: DataModels.Trigger) => {
           this.resource(createdResource);
@@ -119,8 +119,7 @@ export default class TriggerTab extends ScriptTabBase implements ViewModels.Trig
       tabTitle: this.tabTitle()
     });
 
-    return this.documentClientUtility
-      .createTrigger(this.collection, resource)
+    return createTrigger(this.collection, resource)
       .then(
         (createdResource: DataModels.Trigger) => {
           this.tabTitle(createdResource.id);

--- a/src/Explorer/Tabs/UserDefinedFunctionTab.ts
+++ b/src/Explorer/Tabs/UserDefinedFunctionTab.ts
@@ -6,6 +6,7 @@ import { Action } from "../../Shared/Telemetry/TelemetryConstants";
 import ScriptTabBase from "./ScriptTabBase";
 import TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
 import UserDefinedFunction from "../Tree/UserDefinedFunction";
+import { createUserDefinedFunction, updateUserDefinedFunction } from "../../Common/DocumentClientUtilityBase";
 
 export default class UserDefinedFunctionTab extends ScriptTabBase implements ViewModels.UserDefinedFunctionTab {
   public collection: ViewModels.Collection;
@@ -34,8 +35,7 @@ export default class UserDefinedFunctionTab extends ScriptTabBase implements Vie
       tabTitle: this.tabTitle()
     });
 
-    return this.documentClientUtility
-      .updateUserDefinedFunction(this.collection, data)
+    return updateUserDefinedFunction(this.collection, data)
       .then(
         (createdResource: DataModels.UserDefinedFunction) => {
           this.resource(createdResource);
@@ -104,8 +104,7 @@ export default class UserDefinedFunctionTab extends ScriptTabBase implements Vie
       tabTitle: this.tabTitle()
     });
 
-    return this.documentClientUtility
-      .createUserDefinedFunction(this.collection, resource)
+    return createUserDefinedFunction(this.collection, resource)
       .then(
         (createdResource: DataModels.UserDefinedFunction) => {
           this.tabTitle(createdResource.id);

--- a/src/Explorer/Tree/ResourceTokenCollection.ts
+++ b/src/Explorer/Tree/ResourceTokenCollection.ts
@@ -91,7 +91,6 @@ export default class ResourceTokenCollection implements ViewModels.CollectionBas
       tabKind: ViewModels.CollectionTabKind.Query,
       title: title,
       tabPath: "",
-      documentClientUtility: this.container.documentClientUtility,
       collection: this,
       node: this,
       selfLink: this.self,
@@ -143,8 +142,6 @@ export default class ResourceTokenCollection implements ViewModels.CollectionBas
         documentIds: ko.observableArray<DocumentId>([]),
         tabKind: ViewModels.CollectionTabKind.Documents,
         title: "Items",
-        documentClientUtility: this.container.documentClientUtility,
-
         selfLink: this.self,
         isActive: ko.observable<boolean>(false),
         collection: this,

--- a/src/Explorer/Tree/StoredProcedure.ts
+++ b/src/Explorer/Tree/StoredProcedure.ts
@@ -7,6 +7,7 @@ import { Action, ActionModifiers } from "../../Shared/Telemetry/TelemetryConstan
 import StoredProcedureTab from "../Tabs/StoredProcedureTab";
 import TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
 import Explorer from "../Explorer";
+import { deleteStoredProcedure, executeStoredProcedure } from "../../Common/DocumentClientUtilityBase";
 
 const sampleStoredProcedureBody: string = `// SAMPLE STORED PROCEDURE
 function sample(prefix) {
@@ -69,7 +70,6 @@ export default class StoredProcedure {
       tabKind: ViewModels.CollectionTabKind.StoredProcedures,
       title: `New Stored Procedure ${id}`,
       tabPath: `${source.databaseId}>${source.id()}>New Stored Procedure ${id}`,
-      documentClientUtility: source.container.documentClientUtility,
       collection: source,
       node: source,
       hashLocation: `${Constants.HashRoutePrefixes.collectionsWithIds(source.databaseId, source.id())}/sproc`,
@@ -116,7 +116,6 @@ export default class StoredProcedure {
         tabKind: ViewModels.CollectionTabKind.StoredProcedures,
         title: storedProcedureData.id,
         tabPath: `${this.collection.databaseId}>${this.collection.id()}>${storedProcedureData.id}`,
-        documentClientUtility: this.container.documentClientUtility,
         collection: this.collection,
         node: this,
         hashLocation: `${Constants.HashRoutePrefixes.collectionsWithIds(
@@ -144,7 +143,7 @@ export default class StoredProcedure {
       body: this.body()
     };
 
-    this.container.documentClientUtility.deleteStoredProcedure(this.collection, storedProcedureData).then(
+    deleteStoredProcedure(this.collection, storedProcedureData).then(
       () => {
         this.container.tabsManager.removeTabByComparator(
           (tab: ViewModels.Tab) => tab.node && tab.node.rid === this.rid
@@ -163,8 +162,7 @@ export default class StoredProcedure {
     const sprocTab: ViewModels.StoredProcedureTab = sprocTabs && sprocTabs.length > 0 && sprocTabs[0];
     sprocTab.isExecuting(true);
     this.container &&
-      this.container.documentClientUtility
-        .executeStoredProcedure(this.collection, this, partitionKeyValue, params)
+      executeStoredProcedure(this.collection, this, partitionKeyValue, params)
         .then(
           (result: any) => {
             sprocTab.onExecuteSprocsResult(result, result.scriptLogs);

--- a/src/Explorer/Tree/Trigger.ts
+++ b/src/Explorer/Tree/Trigger.ts
@@ -6,6 +6,7 @@ import { Action, ActionModifiers } from "../../Shared/Telemetry/TelemetryConstan
 import TriggerTab from "../Tabs/TriggerTab";
 import TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
 import Explorer from "../Explorer";
+import { deleteTrigger } from "../../Common/DocumentClientUtilityBase";
 
 export default class Trigger {
   public nodeKind: string;
@@ -55,7 +56,6 @@ export default class Trigger {
       tabKind: ViewModels.CollectionTabKind.Triggers,
       title: `New Trigger ${id}`,
       tabPath: "",
-      documentClientUtility: source.container.documentClientUtility,
       collection: source,
       node: source,
       hashLocation: `${Constants.HashRoutePrefixes.collectionsWithIds(source.databaseId, source.id())}/trigger`,
@@ -94,7 +94,6 @@ export default class Trigger {
         tabKind: ViewModels.CollectionTabKind.Triggers,
         title: triggerData.id,
         tabPath: "",
-        documentClientUtility: this.container.documentClientUtility,
         collection: this.collection,
         node: this,
         hashLocation: `${Constants.HashRoutePrefixes.collectionsWithIds(
@@ -124,7 +123,7 @@ export default class Trigger {
       triggerType: this.triggerType()
     };
 
-    this.container.documentClientUtility.deleteTrigger(this.collection, triggerData).then(
+    deleteTrigger(this.collection, triggerData).then(
       () => {
         this.container.tabsManager.removeTabByComparator(
           (tab: ViewModels.Tab) => tab.node && tab.node.rid === this.rid

--- a/src/Explorer/Tree/UserDefinedFunction.ts
+++ b/src/Explorer/Tree/UserDefinedFunction.ts
@@ -6,6 +6,7 @@ import { Action, ActionModifiers } from "../../Shared/Telemetry/TelemetryConstan
 import UserDefinedFunctionTab from "../Tabs/UserDefinedFunctionTab";
 import TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
 import Explorer from "../Explorer";
+import { deleteUserDefinedFunction } from "../../Common/DocumentClientUtilityBase";
 
 export default class UserDefinedFunction {
   public nodeKind: string;
@@ -40,7 +41,6 @@ export default class UserDefinedFunction {
       tabKind: ViewModels.CollectionTabKind.UserDefinedFunctions,
       title: `New UDF ${id}`,
       tabPath: "",
-      documentClientUtility: source.container.documentClientUtility,
       collection: source,
       node: source,
       hashLocation: `${Constants.HashRoutePrefixes.collectionsWithIds(source.databaseId, source.id())}/udf`,
@@ -77,7 +77,6 @@ export default class UserDefinedFunction {
         tabKind: ViewModels.CollectionTabKind.UserDefinedFunctions,
         title: userDefinedFunctionData.id,
         tabPath: "",
-        documentClientUtility: this.container.documentClientUtility,
         collection: this.collection,
         node: this,
         hashLocation: `${Constants.HashRoutePrefixes.collectionsWithIds(
@@ -114,7 +113,7 @@ export default class UserDefinedFunction {
       id: this.id(),
       body: this.body()
     };
-    this.container.documentClientUtility.deleteUserDefinedFunction(this.collection, userDefinedFunctionData).then(
+    deleteUserDefinedFunction(this.collection, userDefinedFunctionData).then(
       () => {
         this.container.tabsManager.removeTabByComparator(
           (tab: ViewModels.Tab) => tab.node && tab.node.rid === this.rid

--- a/src/Platform/Emulator/ExplorerFactory.ts
+++ b/src/Platform/Emulator/ExplorerFactory.ts
@@ -3,15 +3,10 @@ import { AccountKind, TagNames, DefaultAccountExperience } from "../../Common/Co
 import Explorer from "../../Explorer/Explorer";
 
 import { NotificationsClient } from "./NotificationsClient";
-import DocumentClientUtilityBase from "../../Common/DocumentClientUtilityBase";
 
 export default class EmulatorExplorerFactory {
   public static createExplorer(): Explorer {
-    DocumentClientUtilityBase;
-    const documentClientUtility: DocumentClientUtilityBase = new DocumentClientUtilityBase();
-
     const explorer: Explorer = new Explorer({
-      documentClientUtility: documentClientUtility,
       notificationsClient: new NotificationsClient(),
       isEmulator: true
     });

--- a/src/Platform/Hosted/ExplorerFactory.ts
+++ b/src/Platform/Hosted/ExplorerFactory.ts
@@ -1,13 +1,9 @@
 import Explorer from "../../Explorer/Explorer";
 import { NotificationsClient } from "./NotificationsClient";
-import DocumentClientUtilityBase from "../../Common/DocumentClientUtilityBase";
 
 export default class HostedExplorerFactory {
   public createExplorer(): Explorer {
-    var documentClientUtility = new DocumentClientUtilityBase();
-
     const explorer = new Explorer({
-      documentClientUtility: documentClientUtility,
       notificationsClient: new NotificationsClient(),
       isEmulator: false
     });
@@ -17,8 +13,6 @@ export default class HostedExplorerFactory {
 
   public static reInitializeDocumentClientUtilityForExplorer(explorer: Explorer): void {
     if (!!explorer) {
-      const documentClientUtility = new DocumentClientUtilityBase();
-      explorer.rebindDocumentClientUtility(documentClientUtility);
       explorer.notificationConsoleData([]);
     }
   }

--- a/src/Platform/Portal/ExplorerFactory.ts
+++ b/src/Platform/Portal/ExplorerFactory.ts
@@ -1,14 +1,9 @@
 import Explorer from "../../Explorer/Explorer";
-
 import { NotificationsClient } from "./NotificationsClient";
-import DocumentClientUtilityBase from "../../Common/DocumentClientUtilityBase";
 
 export default class PortalExplorerFactory {
   public createExplorer(): Explorer {
-    var documentClientUtility = new DocumentClientUtilityBase();
-
     var explorer = new Explorer({
-      documentClientUtility: documentClientUtility,
       notificationsClient: new NotificationsClient(),
       isEmulator: false
     });

--- a/src/RouteHandlers/TabRouteHandler.test.ts
+++ b/src/RouteHandlers/TabRouteHandler.test.ts
@@ -10,7 +10,6 @@ describe("TabRouteHandler", () => {
 
   beforeAll(() => {
     (<any>window).dataExplorer = new Explorer({
-      documentClientUtility: null,
       notificationsClient: null,
       isEmulator: false
     }); // create a mock to avoid null refs


### PR DESCRIPTION
This is the logical extension of #112. There is no longer a need for DocumentClientUtilityBase to be a class. This refactors it to bare functions. Later I plan to move each function into individual files to try and make progress on #95 