### PR TITLE
Updating error message on mongo collection create

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -302,7 +302,6 @@ src/Utils/NotificationConsoleUtils.ts
 src/Utils/OfferUtils.test.ts
 src/Utils/OfferUtils.ts
 src/Utils/PricingUtils.test.ts
-src/Utils/PricingUtils.ts
 src/Utils/QueryUtils.test.ts
 src/Utils/QueryUtils.ts
 src/Utils/StringUtils.test.ts

--- a/src/Common/ErrorParserUtility.ts
+++ b/src/Common/ErrorParserUtility.ts
@@ -7,6 +7,10 @@ export function replaceKnownError(err: string): string {
     err.indexOf("SharedOffer is Disabled for your account") >= 0
   ) {
     return "Database throughput is not supported for internal subscriptions.";
+  } else if (
+    err.indexOf("Partition key paths must contain only valid") >= 0
+  ) {
+    return "Partition key paths must contain only valid characters and not contain a trailing slash or wildcard character.";
   }
 
   return err;

--- a/src/Common/ErrorParserUtility.ts
+++ b/src/Common/ErrorParserUtility.ts
@@ -7,9 +7,7 @@ export function replaceKnownError(err: string): string {
     err.indexOf("SharedOffer is Disabled for your account") >= 0
   ) {
     return "Database throughput is not supported for internal subscriptions.";
-  } else if (
-    err.indexOf("Partition key paths must contain only valid") >= 0
-  ) {
+  } else if (err.indexOf("Partition key paths must contain only valid") >= 0) {
     return "Partition key paths must contain only valid characters and not contain a trailing slash or wildcard character.";
   }
 

--- a/src/Utils/PricingUtils.test.ts
+++ b/src/Utils/PricingUtils.test.ts
@@ -373,12 +373,12 @@ describe("PricingUtils Tests", () => {
       expect(value).toBe(1);
     });
 
-    it("should return 1 for -1", () => {
+    it("should return -1 for -1", () => {
       const value = PricingUtils.normalizeNumber(-1);
       expect(value).toBe(-1);
     });
 
-    it("should return 1 for 0.1", () => {
+    it("should return 0 for 0.1", () => {
       const value = PricingUtils.normalizeNumber(0.1);
       expect(value).toBe(0);
     });

--- a/src/Utils/PricingUtils.ts
+++ b/src/Utils/PricingUtils.ts
@@ -7,10 +7,11 @@ import { AutopilotTier } from "../Contracts/DataModels";
  * Otherwise, return numberOfRegions
  * @param number
  */
-export function normalizeNumber(number: any): number {
-  const normalizedNumber: number = number === null ? 0 : isNaN(number) ? 0 : parseInt(number);
-
-  return normalizedNumber;
+export function normalizeNumber(number: null|undefined|string|number): number {
+  if (!number){
+    return 0;
+  }
+  return Number(number);
 }
 
 export function getRuToolTipText(isV2AutoPilot: boolean): string {
@@ -79,16 +80,16 @@ export function getPriceCurrency(serverId: string): string {
 
 export function computeStorageUsagePrice(serverId: string, storageUsedRoundUpToGB: number): string {
   if (serverId === "mooncake") {
-    let storageCharge = storageUsedRoundUpToGB * Constants.OfferPricing.HourlyPricing.mooncake.Standard.PricePerGB;
+    const storageCharge = storageUsedRoundUpToGB * Constants.OfferPricing.HourlyPricing.mooncake.Standard.PricePerGB;
     return calculateEstimateNumber(storageCharge) + " " + Constants.OfferPricing.HourlyPricing.mooncake.Currency;
   }
 
-  let storageCharge = storageUsedRoundUpToGB * Constants.OfferPricing.HourlyPricing.default.Standard.PricePerGB;
+  const storageCharge = storageUsedRoundUpToGB * Constants.OfferPricing.HourlyPricing.default.Standard.PricePerGB;
   return calculateEstimateNumber(storageCharge) + " " + Constants.OfferPricing.HourlyPricing.default.Currency;
 }
 
 export function computeDisplayUsageString(usageInKB: number): string {
-  let usageInMB = usageInKB / 1024,
+  const usageInMB = usageInKB / 1024,
     usageInGB = usageInMB / 1024,
     displayUsageString =
       usageInGB > 0.1
@@ -100,7 +101,7 @@ export function computeDisplayUsageString(usageInKB: number): string {
 }
 
 export function usageInGB(usageInKB: number): number {
-  let usageInMB = usageInKB / 1024,
+  const usageInMB = usageInKB / 1024,
     usageInGB = usageInMB / 1024;
   return Math.ceil(usageInGB);
 }
@@ -109,7 +110,7 @@ export function calculateEstimateNumber(n: number): string {
   return n >= 1 ? n.toFixed(2) : n.toPrecision(2);
 }
 
-export function numberWithCommasFormatter(n: number) {
+export function numberWithCommasFormatter(n: number): string {
   return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
 
@@ -279,7 +280,7 @@ export function getEstimatedSpendAcknowledgeString(
       )} - ${currencySign}${calculateEstimateNumber(monthlyPrice)} monthly cost for the throughput above.`;
 }
 
-export function getUpsellMessage(serverId: string = "default", isFreeTier: boolean = false): string {
+export function getUpsellMessage(serverId = "default", isFreeTier = false): string {
   if (isFreeTier) {
     return "With free tier discount, you'll get the first 400 RU/s and 5 GB of storage in this account for free. Charges will apply if your resource throughput exceeds 400 RU/s.";
   } else {

--- a/src/Utils/PricingUtils.ts
+++ b/src/Utils/PricingUtils.ts
@@ -281,7 +281,7 @@ export function getEstimatedSpendAcknowledgeString(
 
 export function getUpsellMessage(serverId: string = "default", isFreeTier: boolean = false): string {
   if (isFreeTier) {
-    return `With free tier discount, you'll get the first 400 RU/s and 5 GB of storage in this account for free. Charges will apply if your resource throughput exceeds 400 RU/s.`;
+    return "With free tier discount, you'll get the first 400 RU/s and 5 GB of storage in this account for free. Charges will apply if your resource throughput exceeds 400 RU/s.";
   } else {
     let price: number = Constants.OfferPricing.MonthlyPricing.default.Standard.StartingPrice;
 

--- a/src/Utils/PricingUtils.ts
+++ b/src/Utils/PricingUtils.ts
@@ -7,11 +7,11 @@ import { AutopilotTier } from "../Contracts/DataModels";
  * Otherwise, return numberOfRegions
  * @param number
  */
-export function normalizeNumber(number: null|undefined|string|number): number {
-  if (!number){
+export function normalizeNumber(number: null | undefined | string | number): number {
+  if (!number) {
     return 0;
   }
-  return Number(number);
+  return Math.floor(Number(number));
 }
 
 export function getRuToolTipText(isV2AutoPilot: boolean): string {


### PR DESCRIPTION
1) Updated mongo collection create pane to display a better error when a shard key is ill formed.

2) Updated an error message to use double quotes since no string interpolation is used. I thought it was included in a previous PR but I guess the change didn't get staged.