### PR TITLE
Fix refresh resources button and remove portal specific notebooks call

### DIFF
--- a/src/Common/MessageHandler.ts
+++ b/src/Common/MessageHandler.ts
@@ -2,6 +2,7 @@ import { MessageTypes } from "../Contracts/ExplorerContracts";
 import Q from "q";
 import * as _ from "underscore";
 import * as Constants from "./Constants";
+import { config, Platform } from "../Config";
 
 export interface CachedDataPromise<T> {
   deferred: Q.Deferred<T>;
@@ -59,7 +60,7 @@ export function sendMessage(data: any): void {
 }
 
 export function canSendMessage(): boolean {
-  return window.parent !== window;
+  return config.platform === Platform.Portal && window.parent !== window;
 }
 
 // TODO: This is exported just for testing. It should not be.

--- a/src/Explorer/Explorer.ts
+++ b/src/Explorer/Explorer.ts
@@ -1529,7 +1529,6 @@ export default class Explorer {
   };
 
   public onRefreshResourcesClick = (source: any, event: MouseEvent): void => {
-    console.log("HEREREER");
     const startKey: number = TelemetryProcessor.traceStart(Action.LoadDatabases, {
       description: "Refresh button clicked",
       databaseAccountName: this.databaseAccount() && this.databaseAccount().name,

--- a/src/Explorer/Explorer.ts
+++ b/src/Explorer/Explorer.ts
@@ -1529,6 +1529,7 @@ export default class Explorer {
   };
 
   public onRefreshResourcesClick = (source: any, event: MouseEvent): void => {
+    console.log("HEREREER");
     const startKey: number = TelemetryProcessor.traceStart(Action.LoadDatabases, {
       description: "Refresh button clicked",
       databaseAccountName: this.databaseAccount() && this.databaseAccount().name,
@@ -2606,7 +2607,11 @@ export default class Explorer {
 
   private async _refreshNotebooksEnabledStateForAccount(): Promise<void> {
     const authType = window.authType as AuthType;
-    if (authType === AuthType.EncryptedToken || authType === AuthType.ResourceToken) {
+    if (
+      authType === AuthType.EncryptedToken ||
+      authType === AuthType.ResourceToken ||
+      authType === AuthType.MasterKey
+    ) {
       this.isNotebooksEnabledForAccount(false);
       return;
     }


### PR DESCRIPTION
- Fixes #122. Changes `sendMessage` to only work in portal context
- Disables notebooks API call for master key authenticated accounts 