### PR TITLE
Fix tabs manager test

### DIFF
--- a/src/Explorer/Tabs/TabsManager.test.ts
+++ b/src/Explorer/Tabs/TabsManager.test.ts
@@ -68,6 +68,10 @@ describe("Tabs manager tests", () => {
       isActive: ko.observable<boolean>(false),
       onUpdateTabsButtons: undefined
     });
+
+    // make sure tabs have different tabId
+    queryTab.tabId = "1";
+    documentsTab.tabId = "2";
   });
 
   beforeEach(() => {


### PR DESCRIPTION
Currently the "closes tab" test case is sometimes flaky. The test case closes one of the two opened tabs and checks if there's still one opened tab left. However, sometimes there's no opened tab left.

This is could be caused by the two tabs having the same tabId so that when it tries to close one tab by passing its tabId, both tabs are closed. This is possible since we assign tabId based on the time that the tab is created.

The fix is to hardcode the tabId of each tab to make sure they are different.