### PR TITLE
Fix connection string renew token pane

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -14,7 +14,10 @@ export class BackendEndpoints {
 }
 
 export class EndpointsRegex {
-  public static readonly cassandra = ["AccountEndpoint=(.*).cassandra.cosmosdb.azure.com", "HostName=(.*).cassandra.cosmos.azure.com"];
+  public static readonly cassandra = [
+    "AccountEndpoint=(.*).cassandra.cosmosdb.azure.com",
+    "HostName=(.*).cassandra.cosmos.azure.com"
+  ];
   public static readonly mongo = "mongodb://.*:(.*)@(.*).documents.azure.com";
   public static readonly mongoCompute = "mongodb://.*:(.*)@(.*).mongo.cosmos.azure.com";
   public static readonly sql = "AccountEndpoint=https://(.*).documents.azure.com";

--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -14,7 +14,7 @@ export class BackendEndpoints {
 }
 
 export class EndpointsRegex {
-  public static readonly cassandra = "AccountEndpoint=(.*).cassandra.cosmosdb.azure.com";
+  public static readonly cassandra = ["AccountEndpoint=(.*).cassandra.cosmosdb.azure.com", "HostName=(.*).cassandra.cosmos.azure.com"];
   public static readonly mongo = "mongodb://.*:(.*)@(.*).documents.azure.com";
   public static readonly mongoCompute = "mongodb://.*:(.*)@(.*).mongo.cosmos.azure.com";
   public static readonly sql = "AccountEndpoint=https://(.*).documents.azure.com";

--- a/src/Common/DataAccessUtilityBase.ts
+++ b/src/Common/DataAccessUtilityBase.ts
@@ -655,7 +655,7 @@ export async function updateOfferThroughputBeyondLimit(
     method: "POST",
     body: JSON.stringify(request),
     headers: {
-      [Constants.HttpHeaders.contentType]: "application/json", 
+      [Constants.HttpHeaders.contentType]: "application/json",
       [authorizationHeader.header]: authorizationHeader.token
     }
   });

--- a/src/Common/DataAccessUtilityBase.ts
+++ b/src/Common/DataAccessUtilityBase.ts
@@ -654,10 +654,7 @@ export async function updateOfferThroughputBeyondLimit(
   const response = await fetch(url, {
     method: "POST",
     body: JSON.stringify(request),
-    headers: {
-      [Constants.HttpHeaders.contentType]: "application/json",
-      [authorizationHeader.header]: authorizationHeader.token
-    }
+    headers: { [authorizationHeader.header]: authorizationHeader.token }
   });
 
   if (response.ok) {

--- a/src/Common/DataAccessUtilityBase.ts
+++ b/src/Common/DataAccessUtilityBase.ts
@@ -654,7 +654,10 @@ export async function updateOfferThroughputBeyondLimit(
   const response = await fetch(url, {
     method: "POST",
     body: JSON.stringify(request),
-    headers: { [authorizationHeader.header]: authorizationHeader.token }
+    headers: {
+      [Constants.HttpHeaders.contentType]: "application/json", 
+      [authorizationHeader.header]: authorizationHeader.token
+    }
   });
 
   if (response.ok) {

--- a/src/Platform/Hosted/Helpers/ConnectionStringParser.ts
+++ b/src/Platform/Hosted/Helpers/ConnectionStringParser.ts
@@ -20,9 +20,13 @@ export class ConnectionStringParser {
             const matches: string[] = connectionStringPart.match(Constants.EndpointsRegex.mongoCompute);
             accessInput.accountName = matches && matches.length > 1 && matches[2];
             accessInput.apiKind = DataModels.ApiKind.MongoDBCompute;
-          } else if (RegExp(Constants.EndpointsRegex.cassandra).test(connectionStringPart)) {
-            accessInput.accountName = connectionStringPart.match(Constants.EndpointsRegex.cassandra)[1];
-            accessInput.apiKind = DataModels.ApiKind.Cassandra;
+          } else if (Constants.EndpointsRegex.cassandra.some(regex => RegExp(regex).test(connectionStringPart))) {
+            Constants.EndpointsRegex.cassandra.forEach(regex => {
+              if (RegExp(regex).test(connectionStringPart)) {
+                accessInput.accountName = connectionStringPart.match(regex)[1];
+                accessInput.apiKind = DataModels.ApiKind.Cassandra;
+              }
+            });
           } else if (RegExp(Constants.EndpointsRegex.table).test(connectionStringPart)) {
             accessInput.accountName = connectionStringPart.match(Constants.EndpointsRegex.table)[1];
             accessInput.apiKind = DataModels.ApiKind.Table;


### PR DESCRIPTION
This fixes the renew token/session pane in data explorer so it accommodates the new cassandra connection string format.