### PR TITLE
Add null check when reading offerAutopilotSettings

### DIFF
--- a/src/Explorer/Tabs/SettingsTab.ts
+++ b/src/Explorer/Tabs/SettingsTab.ts
@@ -344,7 +344,7 @@ export default class SettingsTab extends TabsBase implements ViewModels.WaitsFor
       if (!this.isAutoPilotSelected()) {
         return false;
       }
-      const originalAutoPilotSettings = this.collection.offer().content.offerAutopilotSettings;
+      const originalAutoPilotSettings = this.collection?.offer()?.content?.offerAutopilotSettings;
       if (!originalAutoPilotSettings) {
         return false;
       }


### PR DESCRIPTION
`content` is an optional property of `offer`, so `offer.content.offerAutopilotSettings` could throw an error if the offer doesn't have a `content` property.

The fix is to add null check when reading `offerAutopiloSettings`.