### PR TITLE
Create Cassandra Keyspace via ARM

### DIFF
--- a/src/Explorer/Panes/AddDatabasePane.ts
+++ b/src/Explorer/Panes/AddDatabasePane.ts
@@ -421,7 +421,7 @@ export default class AddDatabasePane extends ContextualPaneBase {
     startKey: number
   ): void {
     if (EnvironmentUtility.isAadUser()) {
-      this._createKeyspaceUsingRP(this.container.armEndpoint(), createDatabaseParameters, autoPilotSettings, startKey);
+      this._createKeyspaceUsingRP(createDatabaseParameters, autoPilotSettings, startKey);
     } else {
       this._createKeyspaceUsingProxy(createDatabaseParameters.offerThroughput, startKey);
     }
@@ -450,12 +450,11 @@ export default class AddDatabasePane extends ContextualPaneBase {
   }
 
   private _createKeyspaceUsingRP(
-    armEndpoint: string,
     createKeyspaceParameters: DataModels.RpParameters,
     autoPilotSettings: DataModels.RpOptions,
     startKey: number
   ): void {
-    AddDbUtilities.createCassandraKeyspace(armEndpoint, createKeyspaceParameters, autoPilotSettings).then(() => {
+    AddDbUtilities.createCassandraKeyspace(createKeyspaceParameters, autoPilotSettings).then(() => {
       Promise.all([refreshCachedOffers(), refreshCachedResources()]).then(() => {
         this._onCreateDatabaseSuccess(createKeyspaceParameters.offerThroughput, startKey);
       });

--- a/src/Utils/arm/generatedClients/2020-04-01/cassandraResources.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/cassandraResources.ts
@@ -39,7 +39,7 @@ export async function createUpdateCassandraKeyspace(
   body: Types.CassandraKeyspaceCreateUpdateParameters
 ): Promise<Types.CassandraKeyspaceGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/cassandraKeyspaces/${keyspaceName}`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Deletes an existing Azure Cosmos DB Cassandra keyspace. */
@@ -73,7 +73,7 @@ export async function updateCassandraKeyspaceThroughput(
   body: Types.ThroughputSettingsUpdateParameters
 ): Promise<Types.ThroughputSettingsGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/cassandraKeyspaces/${keyspaceName}/throughputSettings/default`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Migrate an Azure Cosmos DB Cassandra Keyspace from manual throughput to autoscale */
@@ -131,7 +131,7 @@ export async function createUpdateCassandraTable(
   body: Types.CassandraTableCreateUpdateParameters
 ): Promise<Types.CassandraTableGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/cassandraKeyspaces/${keyspaceName}/tables/${tableName}`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Deletes an existing Azure Cosmos DB Cassandra table. */
@@ -168,7 +168,7 @@ export async function updateCassandraTableThroughput(
   body: Types.ThroughputSettingsUpdateParameters
 ): Promise<Types.ThroughputSettingsGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/cassandraKeyspaces/${keyspaceName}/tables/${tableName}/throughputSettings/default`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Migrate an Azure Cosmos DB Cassandra table from manual throughput to autoscale */

--- a/src/Utils/arm/generatedClients/2020-04-01/databaseAccounts.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/databaseAccounts.ts
@@ -27,13 +27,7 @@ export async function update(
   body: Types.DatabaseAccountUpdateParameters
 ): Promise<Types.DatabaseAccountGetResults> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}`;
-  return armRequest({
-    host: configContext.ARM_ENDPOINT,
-    path,
-    method: "PATCH",
-    apiVersion,
-    body: JSON.stringify(body)
-  });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PATCH", apiVersion, body });
 }
 
 /* Creates or updates an Azure Cosmos DB database account. The "Update" method is preferred when performing updates on an account. */
@@ -44,7 +38,7 @@ export async function createOrUpdate(
   body: Types.DatabaseAccountCreateUpdateParameters
 ): Promise<Types.DatabaseAccountGetResults> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Deletes an existing Azure Cosmos DB database account. */
@@ -61,7 +55,7 @@ export async function failoverPriorityChange(
   body: Types.FailoverPolicies
 ): Promise<void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/failoverPriorityChange`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "POST", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "POST", apiVersion, body });
 }
 
 /* Lists all the Azure Cosmos DB database accounts available under the subscription. */
@@ -107,7 +101,7 @@ export async function offlineRegion(
   body: Types.RegionForOnlineOffline
 ): Promise<void | Types.ErrorResponse> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/offlineRegion`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "POST", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "POST", apiVersion, body });
 }
 
 /* Online the specified region for the specified Azure Cosmos DB database account. */
@@ -118,7 +112,7 @@ export async function onlineRegion(
   body: Types.RegionForOnlineOffline
 ): Promise<void | Types.ErrorResponse> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/onlineRegion`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "POST", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "POST", apiVersion, body });
 }
 
 /* Lists the read-only access keys for the specified Azure Cosmos DB database account. */
@@ -149,7 +143,7 @@ export async function regenerateKey(
   body: Types.DatabaseAccountRegenerateKeyParameters
 ): Promise<void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/regenerateKey`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "POST", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "POST", apiVersion, body });
 }
 
 /* Checks that the Azure Cosmos DB account name already exists. A valid account name may contain only lowercase letters, numbers, and the '-' character, and must be between 3 and 50 characters. */

--- a/src/Utils/arm/generatedClients/2020-04-01/gremlinResources.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/gremlinResources.ts
@@ -39,7 +39,7 @@ export async function createUpdateGremlinDatabase(
   body: Types.GremlinDatabaseCreateUpdateParameters
 ): Promise<Types.GremlinDatabaseGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/gremlinDatabases/${databaseName}`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Deletes an existing Azure Cosmos DB Gremlin database. */
@@ -73,7 +73,7 @@ export async function updateGremlinDatabaseThroughput(
   body: Types.ThroughputSettingsUpdateParameters
 ): Promise<Types.ThroughputSettingsGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/gremlinDatabases/${databaseName}/throughputSettings/default`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Migrate an Azure Cosmos DB Gremlin database from manual throughput to autoscale */
@@ -131,7 +131,7 @@ export async function createUpdateGremlinGraph(
   body: Types.GremlinGraphCreateUpdateParameters
 ): Promise<Types.GremlinGraphGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/gremlinDatabases/${databaseName}/graphs/${graphName}`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Deletes an existing Azure Cosmos DB Gremlin graph. */
@@ -168,7 +168,7 @@ export async function updateGremlinGraphThroughput(
   body: Types.ThroughputSettingsUpdateParameters
 ): Promise<Types.ThroughputSettingsGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/gremlinDatabases/${databaseName}/graphs/${graphName}/throughputSettings/default`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Migrate an Azure Cosmos DB Gremlin graph from manual throughput to autoscale */

--- a/src/Utils/arm/generatedClients/2020-04-01/mongoDBResources.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/mongoDBResources.ts
@@ -39,7 +39,7 @@ export async function createUpdateMongoDBDatabase(
   body: Types.MongoDBDatabaseCreateUpdateParameters
 ): Promise<Types.MongoDBDatabaseGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/mongodbDatabases/${databaseName}`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Deletes an existing Azure Cosmos DB MongoDB database. */
@@ -73,7 +73,7 @@ export async function updateMongoDBDatabaseThroughput(
   body: Types.ThroughputSettingsUpdateParameters
 ): Promise<Types.ThroughputSettingsGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/mongodbDatabases/${databaseName}/throughputSettings/default`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Migrate an Azure Cosmos DB MongoDB database from manual throughput to autoscale */
@@ -131,7 +131,7 @@ export async function createUpdateMongoDBCollection(
   body: Types.MongoDBCollectionCreateUpdateParameters
 ): Promise<Types.MongoDBCollectionGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/mongodbDatabases/${databaseName}/collections/${collectionName}`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Deletes an existing Azure Cosmos DB MongoDB Collection. */
@@ -168,7 +168,7 @@ export async function updateMongoDBCollectionThroughput(
   body: Types.ThroughputSettingsUpdateParameters
 ): Promise<Types.ThroughputSettingsGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/mongodbDatabases/${databaseName}/collections/${collectionName}/throughputSettings/default`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Migrate an Azure Cosmos DB MongoDB collection from manual throughput to autoscale */

--- a/src/Utils/arm/generatedClients/2020-04-01/sqlResources.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/sqlResources.ts
@@ -39,7 +39,7 @@ export async function createUpdateSqlDatabase(
   body: Types.SqlDatabaseCreateUpdateParameters
 ): Promise<Types.SqlDatabaseGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/sqlDatabases/${databaseName}`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Deletes an existing Azure Cosmos DB SQL database. */
@@ -73,7 +73,7 @@ export async function updateSqlDatabaseThroughput(
   body: Types.ThroughputSettingsUpdateParameters
 ): Promise<Types.ThroughputSettingsGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/sqlDatabases/${databaseName}/throughputSettings/default`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Migrate an Azure Cosmos DB SQL database from manual throughput to autoscale */
@@ -131,7 +131,7 @@ export async function createUpdateSqlContainer(
   body: Types.SqlContainerCreateUpdateParameters
 ): Promise<Types.SqlContainerGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/sqlDatabases/${databaseName}/containers/${containerName}`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Deletes an existing Azure Cosmos DB SQL container. */
@@ -168,7 +168,7 @@ export async function updateSqlContainerThroughput(
   body: Types.ThroughputSettingsUpdateParameters
 ): Promise<Types.ThroughputSettingsGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/sqlDatabases/${databaseName}/containers/${containerName}/throughputSettings/default`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Migrate an Azure Cosmos DB SQL container from manual throughput to autoscale */
@@ -231,7 +231,7 @@ export async function createUpdateSqlStoredProcedure(
   body: Types.SqlStoredProcedureCreateUpdateParameters
 ): Promise<Types.SqlStoredProcedureGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/sqlDatabases/${databaseName}/containers/${containerName}/storedProcedures/${storedProcedureName}`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Deletes an existing Azure Cosmos DB SQL storedProcedure. */
@@ -283,7 +283,7 @@ export async function createUpdateSqlUserDefinedFunction(
   body: Types.SqlUserDefinedFunctionCreateUpdateParameters
 ): Promise<Types.SqlUserDefinedFunctionGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/sqlDatabases/${databaseName}/containers/${containerName}/userDefinedFunctions/${userDefinedFunctionName}`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Deletes an existing Azure Cosmos DB SQL userDefinedFunction. */
@@ -335,7 +335,7 @@ export async function createUpdateSqlTrigger(
   body: Types.SqlTriggerCreateUpdateParameters
 ): Promise<Types.SqlTriggerGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/sqlDatabases/${databaseName}/containers/${containerName}/triggers/${triggerName}`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Deletes an existing Azure Cosmos DB SQL trigger. */

--- a/src/Utils/arm/generatedClients/2020-04-01/tableResources.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/tableResources.ts
@@ -39,7 +39,7 @@ export async function createUpdateTable(
   body: Types.TableCreateUpdateParameters
 ): Promise<Types.TableGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/tables/${tableName}`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Deletes an existing Azure Cosmos DB Table. */
@@ -73,7 +73,7 @@ export async function updateTableThroughput(
   body: Types.ThroughputSettingsUpdateParameters
 ): Promise<Types.ThroughputSettingsGetResults | void> {
   const path = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${accountName}/tables/${tableName}/throughputSettings/default`;
-  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body: JSON.stringify(body) });
+  return armRequest({ host: configContext.ARM_ENDPOINT, path, method: "PUT", apiVersion, body });
 }
 
 /* Migrate an Azure Cosmos DB Table from manual throughput to autoscale */

--- a/src/Utils/arm/generatedClients/2020-04-01/types.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/types.ts
@@ -7,87 +7,87 @@
 /* The List operation response, that contains the database accounts and their properties. */
 export interface DatabaseAccountsListResult {
   /* List of database account and their properties. */
-  readonly value: DatabaseAccountGetResults[];
+  readonly value?: DatabaseAccountGetResults[];
 }
 
 /* The List operation response, that contains the SQL databases and their properties. */
 export interface SqlDatabaseListResult {
   /* List of SQL databases and their properties. */
-  readonly value: SqlDatabaseGetResults[];
+  readonly value?: SqlDatabaseGetResults[];
 }
 
 /* The List operation response, that contains the containers and their properties. */
 export interface SqlContainerListResult {
   /* List of containers and their properties. */
-  readonly value: SqlContainerGetResults[];
+  readonly value?: SqlContainerGetResults[];
 }
 
 /* The List operation response, that contains the storedProcedures and their properties. */
 export interface SqlStoredProcedureListResult {
   /* List of storedProcedures and their properties. */
-  readonly value: SqlStoredProcedureGetResults[];
+  readonly value?: SqlStoredProcedureGetResults[];
 }
 
 /* The List operation response, that contains the userDefinedFunctions and their properties. */
 export interface SqlUserDefinedFunctionListResult {
   /* List of userDefinedFunctions and their properties. */
-  readonly value: SqlUserDefinedFunctionGetResults[];
+  readonly value?: SqlUserDefinedFunctionGetResults[];
 }
 
 /* The List operation response, that contains the triggers and their properties. */
 export interface SqlTriggerListResult {
   /* List of triggers and their properties. */
-  readonly value: SqlTriggerGetResults[];
+  readonly value?: SqlTriggerGetResults[];
 }
 
 /* The List operation response, that contains the MongoDB databases and their properties. */
 export interface MongoDBDatabaseListResult {
   /* List of MongoDB databases and their properties. */
-  readonly value: MongoDBDatabaseGetResults[];
+  readonly value?: MongoDBDatabaseGetResults[];
 }
 
 /* The List operation response, that contains the MongoDB collections and their properties. */
 export interface MongoDBCollectionListResult {
   /* List of MongoDB collections and their properties. */
-  readonly value: MongoDBCollectionGetResults[];
+  readonly value?: MongoDBCollectionGetResults[];
 }
 
 /* The List operation response, that contains the Table and their properties. */
 export interface TableListResult {
   /* List of Table and their properties. */
-  readonly value: TableGetResults[];
+  readonly value?: TableGetResults[];
 }
 
 /* The List operation response, that contains the Cassandra keyspaces and their properties. */
 export interface CassandraKeyspaceListResult {
   /* List of Cassandra keyspaces and their properties. */
-  readonly value: CassandraKeyspaceGetResults[];
+  readonly value?: CassandraKeyspaceGetResults[];
 }
 
 /* The List operation response, that contains the Cassandra tables and their properties. */
 export interface CassandraTableListResult {
   /* List of Cassandra tables and their properties. */
-  readonly value: CassandraTableGetResults[];
+  readonly value?: CassandraTableGetResults[];
 }
 
 /* The List operation response, that contains the Gremlin databases and their properties. */
 export interface GremlinDatabaseListResult {
   /* List of Gremlin databases and their properties. */
-  readonly value: GremlinDatabaseGetResults[];
+  readonly value?: GremlinDatabaseGetResults[];
 }
 
 /* The List operation response, that contains the graphs and their properties. */
 export interface GremlinGraphListResult {
   /* List of graphs and their properties. */
-  readonly value: GremlinGraphGetResults[];
+  readonly value?: GremlinGraphGetResults[];
 }
 
 /* Error Response. */
 export interface ErrorResponse {
   /* Error code. */
-  code: string;
+  code?: string;
   /* Error message indicating why the operation failed. */
-  message: string;
+  message?: string;
 }
 
 /* The list of new failover policies for the failover priority change. */
@@ -99,11 +99,11 @@ export interface FailoverPolicies {
 /* The failover policy for a given region of a database account. */
 export interface FailoverPolicy {
   /* The unique identifier of the region in which the database account replicates to. Example: &lt;accountName&gt;-&lt;locationName&gt;. */
-  readonly id: string;
+  readonly id?: string;
   /* The name of the region in which the database account exists. */
-  locationName: string;
+  locationName?: string;
   /* The failover priority of the region. A failover priority of 0 indicates a write region. The maximum value for a failover priority = (total number of regions - 1). Failover priority values must be unique for each of the regions in which the database account exists. */
-  failoverPriority: number;
+  failoverPriority?: number;
 }
 
 /* Cosmos DB region to online or offline. */
@@ -115,234 +115,234 @@ export interface RegionForOnlineOffline {
 /* A region in which the Azure Cosmos DB database account is deployed. */
 export interface Location {
   /* The unique identifier of the region within the database account. Example: &lt;accountName&gt;-&lt;locationName&gt;. */
-  readonly id: string;
+  readonly id?: string;
   /* The name of the region. */
-  locationName: string;
+  locationName?: string;
   /* The connection endpoint for the specific region. Example: https://&lt;accountName&gt;-&lt;locationName&gt;.documents.azure.com:443/ */
-  readonly documentEndpoint: string;
+  readonly documentEndpoint?: string;
   /* undocumented */
-  provisioningState: ProvisioningState;
+  provisioningState?: ProvisioningState;
 
   /* The failover priority of the region. A failover priority of 0 indicates a write region. The maximum value for a failover priority = (total number of regions - 1). Failover priority values must be unique for each of the regions in which the database account exists. */
-  failoverPriority: number;
+  failoverPriority?: number;
   /* Flag to indicate whether or not this region is an AvailabilityZone region */
-  isZoneRedundant: boolean;
+  isZoneRedundant?: boolean;
 }
 
 /* The core properties of ARM resources. */
 export interface ARMResourceProperties {
   /* The unique resource identifier of the ARM resource. */
-  readonly id: string;
+  readonly id?: string;
   /* The name of the ARM resource. */
-  readonly name: string;
+  readonly name?: string;
   /* The type of Azure resource. */
-  readonly type: string;
+  readonly type?: string;
   /* The location of the resource group to which the resource belongs. */
-  location: string;
+  location?: string;
   /* undocumented */
-  tags: Tags;
+  tags?: Tags;
 }
 
 /* The resource model definition for a ARM proxy resource. It will have everything other than required location and tags */
 export interface ARMProxyResource {
   /* The unique resource identifier of the database account. */
-  readonly id: string;
+  readonly id?: string;
   /* The name of the database account. */
-  readonly name: string;
+  readonly name?: string;
   /* The type of Azure resource. */
-  readonly type: string;
+  readonly type?: string;
 }
 
 /* An Azure Cosmos DB database account. */
 export type DatabaseAccountGetResults = ARMResourceProperties & {
   /* Indicates the type of database account. This can only be set at database account creation. */
-  kind: string;
+  kind?: string;
   /* undocumented */
-  properties: DatabaseAccountGetProperties;
+  properties?: DatabaseAccountGetProperties;
 };
 
 /* The system generated resource properties associated with SQL databases, SQL containers, Gremlin databases and Gremlin graphs. */
 export interface ExtendedResourceProperties {
   /* A system generated property. A unique identifier. */
-  readonly _rid: string;
+  readonly _rid?: string;
   /* A system generated property that denotes the last updated timestamp of the resource. */
-  readonly _ts: unknown;
+  readonly _ts?: unknown;
   /* A system generated property representing the resource etag required for optimistic concurrency control. */
-  readonly _etag: string;
+  readonly _etag?: string;
 }
 
 /* An Azure Cosmos DB resource throughput. */
 export type ThroughputSettingsGetResults = ARMResourceProperties & {
   /* The properties of an Azure Cosmos DB resource throughput */
-  properties: ThroughputSettingsGetProperties;
+  properties?: ThroughputSettingsGetProperties;
 };
 
 /* The properties of an Azure Cosmos DB resource throughput */
 export interface ThroughputSettingsGetProperties {
   /* undocumented */
-  resource: ThroughputSettingsResource & ExtendedResourceProperties;
+  resource?: ThroughputSettingsResource & ExtendedResourceProperties;
 }
 
 /* An Azure Cosmos DB SQL database. */
 export type SqlDatabaseGetResults = ARMResourceProperties & {
   /* The properties of an Azure Cosmos DB SQL database */
-  properties: SqlDatabaseGetProperties;
+  properties?: SqlDatabaseGetProperties;
 };
 
 /* The properties of an Azure Cosmos DB SQL database */
 export interface SqlDatabaseGetProperties {
   /* undocumented */
-  resource: SqlDatabaseResource & ExtendedResourceProperties;
+  resource?: SqlDatabaseResource & ExtendedResourceProperties;
   /* undocumented */
-  options: OptionsResource;
+  options?: OptionsResource;
 }
 
 /* An Azure Cosmos DB container. */
 export type SqlContainerGetResults = ARMResourceProperties & {
   /* The properties of an Azure Cosmos DB container */
-  properties: SqlContainerGetProperties;
+  properties?: SqlContainerGetProperties;
 };
 
 /* The properties of an Azure Cosmos DB container */
 export interface SqlContainerGetProperties {
   /* undocumented */
-  resource: SqlContainerResource & ExtendedResourceProperties;
+  resource?: SqlContainerResource & ExtendedResourceProperties;
   /* undocumented */
-  options: OptionsResource;
+  options?: OptionsResource;
 }
 
 /* An Azure Cosmos DB storedProcedure. */
 export type SqlStoredProcedureGetResults = ARMResourceProperties & {
   /* The properties of an Azure Cosmos DB storedProcedure */
-  properties: SqlStoredProcedureGetProperties;
+  properties?: SqlStoredProcedureGetProperties;
 };
 
 /* The properties of an Azure Cosmos DB StoredProcedure */
 export interface SqlStoredProcedureGetProperties {
   /* undocumented */
-  resource: SqlStoredProcedureResource & ExtendedResourceProperties;
+  resource?: SqlStoredProcedureResource & ExtendedResourceProperties;
 }
 
 /* An Azure Cosmos DB userDefinedFunction. */
 export type SqlUserDefinedFunctionGetResults = ARMResourceProperties & {
   /* The properties of an Azure Cosmos DB userDefinedFunction */
-  properties: SqlUserDefinedFunctionGetProperties;
+  properties?: SqlUserDefinedFunctionGetProperties;
 };
 
 /* The properties of an Azure Cosmos DB userDefinedFunction */
 export interface SqlUserDefinedFunctionGetProperties {
   /* undocumented */
-  resource: SqlUserDefinedFunctionResource & ExtendedResourceProperties;
+  resource?: SqlUserDefinedFunctionResource & ExtendedResourceProperties;
 }
 
 /* An Azure Cosmos DB trigger. */
 export type SqlTriggerGetResults = ARMResourceProperties & {
   /* The properties of an Azure Cosmos DB trigger */
-  properties: SqlTriggerGetProperties;
+  properties?: SqlTriggerGetProperties;
 };
 
 /* The properties of an Azure Cosmos DB trigger */
 export interface SqlTriggerGetProperties {
   /* undocumented */
-  resource: SqlTriggerResource & ExtendedResourceProperties;
+  resource?: SqlTriggerResource & ExtendedResourceProperties;
 }
 
 /* An Azure Cosmos DB MongoDB database. */
 export type MongoDBDatabaseGetResults = ARMResourceProperties & {
   /* The properties of an Azure Cosmos DB MongoDB database */
-  properties: MongoDBDatabaseGetProperties;
+  properties?: MongoDBDatabaseGetProperties;
 };
 
 /* The properties of an Azure Cosmos DB MongoDB database */
 export interface MongoDBDatabaseGetProperties {
   /* undocumented */
-  resource: MongoDBDatabaseResource & ExtendedResourceProperties;
+  resource?: MongoDBDatabaseResource & ExtendedResourceProperties;
   /* undocumented */
-  options: OptionsResource;
+  options?: OptionsResource;
 }
 
 /* An Azure Cosmos DB MongoDB collection. */
 export type MongoDBCollectionGetResults = ARMResourceProperties & {
   /* The properties of an Azure Cosmos DB MongoDB collection */
-  properties: MongoDBCollectionGetProperties;
+  properties?: MongoDBCollectionGetProperties;
 };
 
 /* The properties of an Azure Cosmos DB MongoDB collection */
 export interface MongoDBCollectionGetProperties {
   /* undocumented */
-  resource: MongoDBCollectionResource & ExtendedResourceProperties;
+  resource?: MongoDBCollectionResource & ExtendedResourceProperties;
   /* undocumented */
-  options: OptionsResource;
+  options?: OptionsResource;
 }
 
 /* An Azure Cosmos DB Table. */
 export type TableGetResults = ARMResourceProperties & {
   /* The properties of an Azure Cosmos DB Table */
-  properties: TableGetProperties;
+  properties?: TableGetProperties;
 };
 
 /* The properties of an Azure Cosmos Table */
 export interface TableGetProperties {
   /* undocumented */
-  resource: TableResource & ExtendedResourceProperties;
+  resource?: TableResource & ExtendedResourceProperties;
   /* undocumented */
-  options: OptionsResource;
+  options?: OptionsResource;
 }
 
 /* An Azure Cosmos DB Cassandra keyspace. */
 export type CassandraKeyspaceGetResults = ARMResourceProperties & {
   /* The properties of an Azure Cosmos DB Cassandra keyspace */
-  properties: CassandraKeyspaceGetProperties;
+  properties?: CassandraKeyspaceGetProperties;
 };
 
 /* The properties of an Azure Cosmos DB Cassandra keyspace */
 export interface CassandraKeyspaceGetProperties {
   /* undocumented */
-  resource: CassandraKeyspaceResource & ExtendedResourceProperties;
+  resource?: CassandraKeyspaceResource & ExtendedResourceProperties;
   /* undocumented */
-  options: OptionsResource;
+  options?: OptionsResource;
 }
 
 /* An Azure Cosmos DB Cassandra table. */
 export type CassandraTableGetResults = ARMResourceProperties & {
   /* The properties of an Azure Cosmos DB Cassandra table */
-  properties: CassandraTableGetProperties;
+  properties?: CassandraTableGetProperties;
 };
 
 /* The properties of an Azure Cosmos DB Cassandra table */
 export interface CassandraTableGetProperties {
   /* undocumented */
-  resource: CassandraTableResource & ExtendedResourceProperties;
+  resource?: CassandraTableResource & ExtendedResourceProperties;
   /* undocumented */
-  options: OptionsResource;
+  options?: OptionsResource;
 }
 
 /* An Azure Cosmos DB Gremlin database. */
 export type GremlinDatabaseGetResults = ARMResourceProperties & {
   /* The properties of an Azure Cosmos DB SQL database */
-  properties: GremlinDatabaseGetProperties;
+  properties?: GremlinDatabaseGetProperties;
 };
 
 /* The properties of an Azure Cosmos DB SQL database */
 export interface GremlinDatabaseGetProperties {
   /* undocumented */
-  resource: GremlinDatabaseResource & ExtendedResourceProperties;
+  resource?: GremlinDatabaseResource & ExtendedResourceProperties;
   /* undocumented */
-  options: OptionsResource;
+  options?: OptionsResource;
 }
 
 /* An Azure Cosmos DB Gremlin graph. */
 export type GremlinGraphGetResults = ARMResourceProperties & {
   /* The properties of an Azure Cosmos DB Gremlin graph */
-  properties: GremlinGraphGetProperties;
+  properties?: GremlinGraphGetProperties;
 };
 
 /* The properties of an Azure Cosmos DB Gremlin graph */
 export interface GremlinGraphGetProperties {
   /* undocumented */
-  resource: GremlinGraphResource & ExtendedResourceProperties;
+  resource?: GremlinGraphResource & ExtendedResourceProperties;
   /* undocumented */
-  options: OptionsResource;
+  options?: OptionsResource;
 }
 
 /* The consistency policy for the Cosmos DB database account. */
@@ -350,79 +350,95 @@ export interface ConsistencyPolicy {
   /* The default consistency level and configuration settings of the Cosmos DB account. */
   defaultConsistencyLevel: string;
   /* When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. */
-  maxStalenessPrefix: number;
+  maxStalenessPrefix?: number;
   /* When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. */
-  maxIntervalInSeconds: number;
+  maxIntervalInSeconds?: number;
+}
+
+/* The CORS policy for the Cosmos DB database account. */
+export interface CorsPolicy {
+  /* The origin domains that are permitted to make a request against the service via CORS. */
+  allowedOrigins: string;
+  /* The methods (HTTP request verbs) that the origin domain may use for a CORS request. */
+  allowedMethods?: string;
+  /* The request headers that the origin domain may specify on the CORS request. */
+  allowedHeaders?: string;
+  /* The response headers that may be sent in the response to the CORS request and exposed by the browser to the request issuer. */
+  exposedHeaders?: string;
+  /* The maximum amount time that a browser should cache the preflight OPTIONS request. */
+  maxAgeInSeconds?: number;
 }
 
 /* Properties for the database account. */
 export interface DatabaseAccountGetProperties {
   /* undocumented */
-  provisioningState: ProvisioningState;
+  provisioningState?: ProvisioningState;
 
   /* The connection endpoint for the Cosmos DB database account. */
-  readonly documentEndpoint: string;
+  readonly documentEndpoint?: string;
   /* The offer type for the Cosmos DB database account. Default value: Standard. */
-  readonly databaseAccountOfferType: DatabaseAccountOfferType;
+  readonly databaseAccountOfferType?: DatabaseAccountOfferType;
 
   /* List of IpRules. */
-  ipRules: IPRules;
+  ipRules?: IPRules;
 
   /* Flag to indicate whether to enable/disable Virtual Network ACL rules. */
-  isVirtualNetworkFilterEnabled: boolean;
+  isVirtualNetworkFilterEnabled?: boolean;
   /* Enables automatic failover of the write region in the rare event that the region is unavailable due to an outage. Automatic failover will result in a new write region for the account and is chosen based on the failover priorities configured for the account. */
-  enableAutomaticFailover: boolean;
+  enableAutomaticFailover?: boolean;
   /* The consistency policy for the Cosmos DB database account. */
-  consistencyPolicy: ConsistencyPolicy;
+  consistencyPolicy?: ConsistencyPolicy;
 
   /* List of Cosmos DB capabilities for the account */
-  capabilities: Capability[];
+  capabilities?: Capability[];
 
   /* An array that contains the write location for the Cosmos DB account. */
-  readonly writeLocations: Location[];
+  readonly writeLocations?: Location[];
 
   /* An array that contains of the read locations enabled for the Cosmos DB account. */
-  readonly readLocations: Location[];
+  readonly readLocations?: Location[];
 
   /* An array that contains all of the locations enabled for the Cosmos DB account. */
-  readonly locations: Location[];
+  readonly locations?: Location[];
 
   /* An array that contains the regions ordered by their failover priorities. */
-  readonly failoverPolicies: FailoverPolicy[];
+  readonly failoverPolicies?: FailoverPolicy[];
 
   /* List of Virtual Network ACL rules configured for the Cosmos DB account. */
-  virtualNetworkRules: VirtualNetworkRule[];
+  virtualNetworkRules?: VirtualNetworkRule[];
 
   /* List of Private Endpoint Connections configured for the Cosmos DB account. */
-  readonly privateEndpointConnections: PrivateEndpointConnection[];
+  readonly privateEndpointConnections?: PrivateEndpointConnection[];
 
   /* Enables the account to write in multiple locations */
-  enableMultipleWriteLocations: boolean;
+  enableMultipleWriteLocations?: boolean;
   /* Enables the cassandra connector on the Cosmos DB C* account */
-  enableCassandraConnector: boolean;
+  enableCassandraConnector?: boolean;
   /* The cassandra connector offer type for the Cosmos DB database C* account. */
-  connectorOffer: ConnectorOffer;
+  connectorOffer?: ConnectorOffer;
 
   /* Disable write operations on metadata resources (databases, containers, throughput) via account keys */
-  disableKeyBasedMetadataWriteAccess: boolean;
+  disableKeyBasedMetadataWriteAccess?: boolean;
   /* The URI of the key vault */
-  keyVaultKeyUri: string;
+  keyVaultKeyUri?: string;
   /* Whether requests from Public Network are allowed */
-  publicNetworkAccess: PublicNetworkAccess;
+  publicNetworkAccess?: PublicNetworkAccess;
 
   /* Flag to indicate whether Free Tier is enabled. */
-  enableFreeTier: boolean;
+  enableFreeTier?: boolean;
   /* API specific properties. */
-  apiProperties: ApiProperties;
+  apiProperties?: ApiProperties;
 
   /* Flag to indicate whether to enable storage analytics. */
-  enableAnalyticalStorage: boolean;
+  enableAnalyticalStorage?: boolean;
+  /* The CORS policy for the Cosmos DB database account. */
+  cors?: CorsPolicy[];
 }
 
 /* Properties to create and update Azure Cosmos DB database accounts. */
 export interface DatabaseAccountCreateUpdateProperties {
   /* The consistency policy for the Cosmos DB account. */
-  consistencyPolicy: ConsistencyPolicy;
+  consistencyPolicy?: ConsistencyPolicy;
 
   /* An array that contains the georeplication locations enabled for the Cosmos DB account. */
   locations: Location[];
@@ -431,45 +447,47 @@ export interface DatabaseAccountCreateUpdateProperties {
   databaseAccountOfferType: DatabaseAccountOfferType;
 
   /* List of IpRules. */
-  ipRules: IPRules;
+  ipRules?: IPRules;
 
   /* Flag to indicate whether to enable/disable Virtual Network ACL rules. */
-  isVirtualNetworkFilterEnabled: boolean;
+  isVirtualNetworkFilterEnabled?: boolean;
   /* Enables automatic failover of the write region in the rare event that the region is unavailable due to an outage. Automatic failover will result in a new write region for the account and is chosen based on the failover priorities configured for the account. */
-  enableAutomaticFailover: boolean;
+  enableAutomaticFailover?: boolean;
   /* List of Cosmos DB capabilities for the account */
-  capabilities: Capability[];
+  capabilities?: Capability[];
 
   /* List of Virtual Network ACL rules configured for the Cosmos DB account. */
-  virtualNetworkRules: VirtualNetworkRule[];
+  virtualNetworkRules?: VirtualNetworkRule[];
 
   /* Enables the account to write in multiple locations */
-  enableMultipleWriteLocations: boolean;
+  enableMultipleWriteLocations?: boolean;
   /* Enables the cassandra connector on the Cosmos DB C* account */
-  enableCassandraConnector: boolean;
+  enableCassandraConnector?: boolean;
   /* The cassandra connector offer type for the Cosmos DB database C* account. */
-  connectorOffer: ConnectorOffer;
+  connectorOffer?: ConnectorOffer;
 
   /* Disable write operations on metadata resources (databases, containers, throughput) via account keys */
-  disableKeyBasedMetadataWriteAccess: boolean;
+  disableKeyBasedMetadataWriteAccess?: boolean;
   /* The URI of the key vault */
-  keyVaultKeyUri: string;
+  keyVaultKeyUri?: string;
   /* Whether requests from Public Network are allowed */
-  publicNetworkAccess: PublicNetworkAccess;
+  publicNetworkAccess?: PublicNetworkAccess;
 
   /* Flag to indicate whether Free Tier is enabled. */
-  enableFreeTier: boolean;
+  enableFreeTier?: boolean;
   /* API specific properties. Currently, supported only for MongoDB API. */
-  apiProperties: ApiProperties;
+  apiProperties?: ApiProperties;
 
   /* Flag to indicate whether to enable storage analytics. */
-  enableAnalyticalStorage: boolean;
+  enableAnalyticalStorage?: boolean;
+  /* The CORS policy for the Cosmos DB database account. */
+  cors?: CorsPolicy[];
 }
 
 /* Parameters to create and update Cosmos DB database accounts. */
 export type DatabaseAccountCreateUpdateParameters = ARMResourceProperties & {
   /* Indicates the type of database account. This can only be set at database account creation. */
-  kind: string;
+  kind?: string;
   /* undocumented */
   properties: DatabaseAccountCreateUpdateProperties;
 };
@@ -477,86 +495,88 @@ export type DatabaseAccountCreateUpdateParameters = ARMResourceProperties & {
 /* Properties to update Azure Cosmos DB database accounts. */
 export interface DatabaseAccountUpdateProperties {
   /* The consistency policy for the Cosmos DB account. */
-  consistencyPolicy: ConsistencyPolicy;
+  consistencyPolicy?: ConsistencyPolicy;
 
   /* An array that contains the georeplication locations enabled for the Cosmos DB account. */
-  locations: Location[];
+  locations?: Location[];
 
   /* List of IpRules. */
-  ipRules: IPRules;
+  ipRules?: IPRules;
 
   /* Flag to indicate whether to enable/disable Virtual Network ACL rules. */
-  isVirtualNetworkFilterEnabled: boolean;
+  isVirtualNetworkFilterEnabled?: boolean;
   /* Enables automatic failover of the write region in the rare event that the region is unavailable due to an outage. Automatic failover will result in a new write region for the account and is chosen based on the failover priorities configured for the account. */
-  enableAutomaticFailover: boolean;
+  enableAutomaticFailover?: boolean;
   /* List of Cosmos DB capabilities for the account */
-  capabilities: Capability[];
+  capabilities?: Capability[];
 
   /* List of Virtual Network ACL rules configured for the Cosmos DB account. */
-  virtualNetworkRules: VirtualNetworkRule[];
+  virtualNetworkRules?: VirtualNetworkRule[];
 
   /* Enables the account to write in multiple locations */
-  enableMultipleWriteLocations: boolean;
+  enableMultipleWriteLocations?: boolean;
   /* Enables the cassandra connector on the Cosmos DB C* account */
-  enableCassandraConnector: boolean;
+  enableCassandraConnector?: boolean;
   /* The cassandra connector offer type for the Cosmos DB database C* account. */
-  connectorOffer: ConnectorOffer;
+  connectorOffer?: ConnectorOffer;
 
   /* Disable write operations on metadata resources (databases, containers, throughput) via account keys */
-  disableKeyBasedMetadataWriteAccess: boolean;
+  disableKeyBasedMetadataWriteAccess?: boolean;
   /* The URI of the key vault */
-  keyVaultKeyUri: string;
+  keyVaultKeyUri?: string;
   /* Whether requests from Public Network are allowed */
-  publicNetworkAccess: PublicNetworkAccess;
+  publicNetworkAccess?: PublicNetworkAccess;
 
   /* Flag to indicate whether Free Tier is enabled. */
-  enableFreeTier: boolean;
+  enableFreeTier?: boolean;
   /* API specific properties. Currently, supported only for MongoDB API. */
-  apiProperties: ApiProperties;
+  apiProperties?: ApiProperties;
 
   /* Flag to indicate whether to enable storage analytics. */
-  enableAnalyticalStorage: boolean;
+  enableAnalyticalStorage?: boolean;
+  /* The CORS policy for the Cosmos DB database account. */
+  cors?: CorsPolicy[];
 }
 
 /* Parameters for patching Azure Cosmos DB database account properties. */
 export interface DatabaseAccountUpdateParameters {
   /* undocumented */
-  tags: Tags;
+  tags?: Tags;
 
   /* The location of the resource group to which the resource belongs. */
-  location: string;
+  location?: string;
   /* undocumented */
-  properties: DatabaseAccountUpdateProperties;
+  properties?: DatabaseAccountUpdateProperties;
 }
 
 /* The read-only access keys for the given database account. */
 export interface DatabaseAccountListReadOnlyKeysResult {
   /* Base 64 encoded value of the primary read-only key. */
-  readonly primaryReadonlyMasterKey: string;
+  readonly primaryReadonlyMasterKey?: string;
   /* Base 64 encoded value of the secondary read-only key. */
-  readonly secondaryReadonlyMasterKey: string;
+  readonly secondaryReadonlyMasterKey?: string;
 }
 
 /* The access keys for the given database account. */
 export type DatabaseAccountListKeysResult = DatabaseAccountListReadOnlyKeysResult & {
   /* Base 64 encoded value of the primary read-write key. */
-  readonly primaryMasterKey: string;
+  readonly primaryMasterKey?: string;
   /* Base 64 encoded value of the secondary read-write key. */
-  readonly secondaryMasterKey: string;
+  readonly secondaryMasterKey?: string;
 };
 
 /* Connection string for the Cosmos DB account */
 export interface DatabaseAccountConnectionString {
   /* Value of the connection string */
-  readonly connectionString: string;
+  readonly connectionString?: string;
   /* Description of the connection string */
-  readonly description: string;
+  readonly description?: string;
 }
 
 /* The connection strings for the given database account. */
 export interface DatabaseAccountListConnectionStringsResult {
   /* An array that contains the connection strings for the Cosmos DB account. */
-  connectionStrings: DatabaseAccountConnectionString[];
+  connectionStrings?: DatabaseAccountConnectionString[];
 }
 
 /* Parameters to regenerate the keys within the database account. */
@@ -763,14 +783,14 @@ export interface GremlinGraphCreateUpdateProperties {
 /* Cosmos DB resource throughput object. Either throughput is required or autoscaleSettings is required, but not both. */
 export interface ThroughputSettingsResource {
   /* Value of the Cosmos DB resource throughput. Either throughput is required or autoscaleSettings is required, but not both. */
-  throughput: number;
+  throughput?: number;
   /* Cosmos DB resource for autoscale settings. Either throughput is required or autoscaleSettings is required, but not both. */
-  autoscaleSettings: AutoscaleSettingsResource;
+  autoscaleSettings?: AutoscaleSettingsResource;
 
   /* The minimum throughput of the resource */
-  readonly minimumThroughput: string;
+  readonly minimumThroughput?: string;
   /* The throughput replace is pending */
-  readonly offerReplacePending: string;
+  readonly offerReplacePending?: string;
 }
 
 /* Cosmos DB provisioned throughput settings object */
@@ -778,32 +798,32 @@ export interface AutoscaleSettingsResource {
   /* Represents maximum throughput container can scale up to. */
   maxThroughput: number;
   /* Cosmos DB resource auto-upgrade policy */
-  autoUpgradePolicy: AutoUpgradePolicyResource;
+  autoUpgradePolicy?: AutoUpgradePolicyResource;
 
   /* Represents target maximum throughput container can scale up to once offer is no longer in pending state. */
-  readonly targetMaxThroughput: number;
+  readonly targetMaxThroughput?: number;
 }
 
 /* Cosmos DB resource auto-upgrade policy */
 export interface AutoUpgradePolicyResource {
   /* Represents throughput policy which service must adhere to for auto-upgrade */
-  throughputPolicy: ThroughputPolicyResource;
+  throughputPolicy?: ThroughputPolicyResource;
 }
 
 /* Cosmos DB resource throughput policy */
 export interface ThroughputPolicyResource {
   /* Determines whether the ThroughputPolicy is active or not */
-  isEnabled: boolean;
+  isEnabled?: boolean;
   /* Represents the percentage by which throughput can increase every time throughput policy kicks in. */
-  incrementPercent: number;
+  incrementPercent?: number;
 }
 
 /* Cosmos DB options resource object */
 export interface OptionsResource {
   /* Value of the Cosmos DB resource throughput or autoscaleSettings. Use the ThroughputSetting resource when retrieving offer details. */
-  throughput: number;
+  throughput?: number;
   /* Specifies the Autoscale settings. */
-  autoscaleSettings: AutoscaleSettings;
+  autoscaleSettings?: AutoscaleSettings;
 }
 
 /* Cosmos DB SQL database resource object */
@@ -817,61 +837,61 @@ export interface SqlContainerResource {
   /* Name of the Cosmos DB SQL container */
   id: string;
   /* The configuration of the indexing policy. By default, the indexing is automatic for all document paths within the container */
-  indexingPolicy: IndexingPolicy;
+  indexingPolicy?: IndexingPolicy;
 
   /* The configuration of the partition key to be used for partitioning data into multiple partitions */
-  partitionKey: ContainerPartitionKey;
+  partitionKey?: ContainerPartitionKey;
 
   /* Default time to live */
-  defaultTtl: number;
+  defaultTtl?: number;
   /* The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service. */
-  uniqueKeyPolicy: UniqueKeyPolicy;
+  uniqueKeyPolicy?: UniqueKeyPolicy;
 
   /* The conflict resolution policy for the container. */
-  conflictResolutionPolicy: ConflictResolutionPolicy;
+  conflictResolutionPolicy?: ConflictResolutionPolicy;
 }
 
 /* Cosmos DB indexing policy */
 export interface IndexingPolicy {
   /* Indicates if the indexing policy is automatic */
-  automatic: boolean;
+  automatic?: boolean;
   /* Indicates the indexing mode. */
-  indexingMode: string;
+  indexingMode?: string;
   /* List of paths to include in the indexing */
-  includedPaths: IncludedPath[];
+  includedPaths?: IncludedPath[];
 
   /* List of paths to exclude from indexing */
-  excludedPaths: ExcludedPath[];
+  excludedPaths?: ExcludedPath[];
 
   /* List of composite path list */
-  compositeIndexes: CompositePathList[];
+  compositeIndexes?: CompositePathList[];
 
   /* List of spatial specifics */
-  spatialIndexes: SpatialSpec[];
+  spatialIndexes?: SpatialSpec[];
 }
 
 /* undocumented */
 export interface ExcludedPath {
   /* The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) */
-  path: string;
+  path?: string;
 }
 
 /* The paths that are included in indexing */
 export interface IncludedPath {
   /* The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) */
-  path: string;
+  path?: string;
   /* List of indexes for this path */
-  indexes: Indexes[];
+  indexes?: Indexes[];
 }
 
 /* The indexes for the path. */
 export interface Indexes {
   /* The datatype for which the indexing behavior is applied to. */
-  dataType: string;
+  dataType?: string;
   /* The precision of the index. -1 is maximum precision. */
-  precision: number;
+  precision?: number;
   /* Indicates the type of index. */
-  kind: string;
+  kind?: string;
 }
 
 /* List of composite path */
@@ -880,17 +900,17 @@ export type CompositePathList = CompositePath[];
 /* undocumented */
 export interface CompositePath {
   /* The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) */
-  path: string;
+  path?: string;
   /* Sort order for composite paths. */
-  order: string;
+  order?: string;
 }
 
 /* undocumented */
 export interface SpatialSpec {
   /* The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) */
-  path: string;
+  path?: string;
   /* List of path's spatial type */
-  types: SpatialType[];
+  types?: SpatialType[];
 }
 
 /* Indicates the spatial type of index. */
@@ -899,12 +919,12 @@ export type SpatialType = "Point" | "LineString" | "Polygon" | "MultiPolygon";
 /* The configuration of the partition key to be used for partitioning data into multiple partitions */
 export interface ContainerPartitionKey {
   /* List of paths using which data within the container can be partitioned */
-  paths: Path[];
+  paths?: Path[];
 
   /* Indicates the kind of algorithm used for partitioning */
-  kind: string;
+  kind?: string;
   /* Indicates the version of the partition key definition */
-  version: number;
+  version?: number;
 }
 
 /* A path. These typically start with root (/path) */
@@ -913,23 +933,23 @@ export type Path = string;
 /* The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service. */
 export interface UniqueKeyPolicy {
   /* List of unique keys on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service. */
-  uniqueKeys: UniqueKey[];
+  uniqueKeys?: UniqueKey[];
 }
 
 /* The unique key on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service. */
 export interface UniqueKey {
   /* List of paths must be unique for each document in the Azure Cosmos DB service */
-  paths: Path[];
+  paths?: Path[];
 }
 
 /* The conflict resolution policy for the container. */
 export interface ConflictResolutionPolicy {
   /* Indicates the conflict resolution mode. */
-  mode: string;
+  mode?: string;
   /* The conflict resolution path in the case of LastWriterWins mode. */
-  conflictResolutionPath: string;
+  conflictResolutionPath?: string;
   /* The procedure to resolve conflicts in the case of custom mode. */
-  conflictResolutionProcedure: string;
+  conflictResolutionProcedure?: string;
 }
 
 /* Cosmos DB SQL storedProcedure resource object */
@@ -937,7 +957,7 @@ export interface SqlStoredProcedureResource {
   /* Name of the Cosmos DB SQL storedProcedure */
   id: string;
   /* Body of the Stored Procedure */
-  body: string;
+  body?: string;
 }
 
 /* Cosmos DB SQL userDefinedFunction resource object */
@@ -945,7 +965,7 @@ export interface SqlUserDefinedFunctionResource {
   /* Name of the Cosmos DB SQL userDefinedFunction */
   id: string;
   /* Body of the User Defined Function */
-  body: string;
+  body?: string;
 }
 
 /* Cosmos DB SQL trigger resource object */
@@ -953,11 +973,11 @@ export interface SqlTriggerResource {
   /* Name of the Cosmos DB SQL trigger */
   id: string;
   /* Body of the Trigger */
-  body: string;
+  body?: string;
   /* Type of the Trigger */
-  triggerType: string;
+  triggerType?: string;
   /* The operation the trigger is associated with */
-  triggerOperation: string;
+  triggerOperation?: string;
 }
 
 /* Cosmos DB MongoDB database resource object */
@@ -971,13 +991,13 @@ export interface MongoDBCollectionResource {
   /* Name of the Cosmos DB MongoDB collection */
   id: string;
   /* A key-value pair of shard keys to be applied for the request. */
-  shardKey: ShardKeys;
+  shardKey?: ShardKeys;
 
   /* List of index keys */
-  indexes: MongoIndex[];
+  indexes?: MongoIndex[];
 
   /* Analytical TTL. */
-  analyticalStorageTtl: number;
+  analyticalStorageTtl?: number;
 }
 
 /* The shard key and partition kind pair, only support "Hash" partition kind */
@@ -986,16 +1006,16 @@ export type ShardKeys = { [key: string]: string };
 /* Cosmos DB MongoDB collection index key */
 export interface MongoIndex {
   /* Cosmos DB MongoDB collection index keys */
-  key: MongoIndexKeys;
+  key?: MongoIndexKeys;
 
   /* Cosmos DB MongoDB collection index key options */
-  options: MongoIndexOptions;
+  options?: MongoIndexOptions;
 }
 
 /* Cosmos DB MongoDB collection resource object */
 export interface MongoIndexKeys {
   /* List of keys for each MongoDB collection in the Azure Cosmos DB service */
-  keys: Key[];
+  keys?: Key[];
 }
 
 /* A Key. */
@@ -1004,9 +1024,9 @@ export type Key = string;
 /* Cosmos DB MongoDB collection index options */
 export interface MongoIndexOptions {
   /* Expire after seconds */
-  expireAfterSeconds: number;
+  expireAfterSeconds?: number;
   /* Is unique or not */
-  unique: boolean;
+  unique?: boolean;
 }
 
 /* Cosmos DB table resource object */
@@ -1026,46 +1046,46 @@ export interface CassandraTableResource {
   /* Name of the Cosmos DB Cassandra table */
   id: string;
   /* Time to live of the Cosmos DB Cassandra table */
-  defaultTtl: number;
+  defaultTtl?: number;
   /* Schema of the Cosmos DB Cassandra table */
-  schema: CassandraSchema;
+  schema?: CassandraSchema;
 
   /* Analytical TTL. */
-  analyticalStorageTtl: number;
+  analyticalStorageTtl?: number;
 }
 
 /* Cosmos DB Cassandra table schema */
 export interface CassandraSchema {
   /* List of Cassandra table columns. */
-  columns: Column[];
+  columns?: Column[];
 
   /* List of partition key. */
-  partitionKeys: CassandraPartitionKey[];
+  partitionKeys?: CassandraPartitionKey[];
 
   /* List of cluster key. */
-  clusterKeys: ClusterKey[];
+  clusterKeys?: ClusterKey[];
 }
 
 /* Cosmos DB Cassandra table column */
 export interface Column {
   /* Name of the Cosmos DB Cassandra table column */
-  name: string;
+  name?: string;
   /* Type of the Cosmos DB Cassandra table column */
-  type: string;
+  type?: string;
 }
 
 /* Cosmos DB Cassandra table partition key */
 export interface CassandraPartitionKey {
   /* Name of the Cosmos DB Cassandra table partition key */
-  name: string;
+  name?: string;
 }
 
 /* Cosmos DB Cassandra table cluster key */
 export interface ClusterKey {
   /* Name of the Cosmos DB Cassandra table cluster key */
-  name: string;
+  name?: string;
   /* Order of the Cosmos DB Cassandra table cluster key, only support "Asc" and "Desc" */
-  orderBy: string;
+  orderBy?: string;
 }
 
 /* Cosmos DB Gremlin database resource object */
@@ -1079,38 +1099,38 @@ export interface GremlinGraphResource {
   /* Name of the Cosmos DB Gremlin graph */
   id: string;
   /* The configuration of the indexing policy. By default, the indexing is automatic for all document paths within the graph */
-  indexingPolicy: IndexingPolicy;
+  indexingPolicy?: IndexingPolicy;
 
   /* The configuration of the partition key to be used for partitioning data into multiple partitions */
-  partitionKey: ContainerPartitionKey;
+  partitionKey?: ContainerPartitionKey;
 
   /* Default time to live */
-  defaultTtl: number;
+  defaultTtl?: number;
   /* The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service. */
-  uniqueKeyPolicy: UniqueKeyPolicy;
+  uniqueKeyPolicy?: UniqueKeyPolicy;
 
   /* The conflict resolution policy for the graph. */
-  conflictResolutionPolicy: ConflictResolutionPolicy;
+  conflictResolutionPolicy?: ConflictResolutionPolicy;
 }
 
 /* CreateUpdateOptions are a list of key-value pairs that describe the resource. Supported keys are "If-Match", "If-None-Match", "Session-Token" and "Throughput" */
 export interface CreateUpdateOptions {
   /* Request Units per second. For example, "throughput": 10000. */
-  throughput: number;
+  throughput?: number;
   /* Specifies the Autoscale settings. */
-  autoscaleSettings: AutoscaleSettings;
+  autoscaleSettings?: AutoscaleSettings;
 }
 
 /* undocumented */
 export interface AutoscaleSettings {
   /* Represents maximum throughput, the resource can scale up to. */
-  maxThroughput: number;
+  maxThroughput?: number;
 }
 
 /* Cosmos DB capability object */
 export interface Capability {
   /* Name of the Cosmos DB capability. For example, "name": "EnableCassandra". Current values also include "EnableTable" and "EnableGremlin". */
-  name: string;
+  name?: string;
 }
 
 /* Tags are a list of key-value pairs that describe the resource. These tags can be used in viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key no greater than 128 characters and value no greater than 256 characters. For example, the default experience for a template type is set with "defaultExperience": "Cassandra". Current "defaultExperience" values also include "Table", "Graph", "DocumentDB", and "MongoDB". */
@@ -1125,231 +1145,231 @@ export type IPRules = IpAddressOrRange[];
 /* IpAddressOrRange object */
 export interface IpAddressOrRange {
   /* A single IPv4 address or a single IPv4 address range in CIDR format. Provided IPs must be well-formatted and cannot be contained in one of the following ranges: 10.0.0.0/8, 100.64.0.0/10, 172.16.0.0/12, 192.168.0.0/16, since these are not enforceable by the IP address filter. Example of valid inputs: “23.40.210.245” or “23.40.210.0/8”. */
-  ipAddressOrRange: string;
+  ipAddressOrRange?: string;
 }
 
 /* Virtual Network ACL Rule object */
 export interface VirtualNetworkRule {
   /* Resource ID of a subnet, for example: /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. */
-  id: string;
+  id?: string;
   /* Create firewall rule before the virtual network has vnet service endpoint enabled. */
-  ignoreMissingVNetServiceEndpoint: boolean;
+  ignoreMissingVNetServiceEndpoint?: boolean;
 }
 
 /* A private endpoint connection */
 export type PrivateEndpointConnection = unknown & {
   /* Resource properties. */
-  properties: PrivateEndpointConnectionProperties;
+  properties?: PrivateEndpointConnectionProperties;
 };
 
 /* Properties of a private endpoint connection. */
 export interface PrivateEndpointConnectionProperties {
   /* Private endpoint which the connection belongs to. */
-  privateEndpoint: PrivateEndpointProperty;
+  privateEndpoint?: PrivateEndpointProperty;
 
   /* Connection State of the Private Endpoint Connection. */
-  privateLinkServiceConnectionState: PrivateLinkServiceConnectionStateProperty;
+  privateLinkServiceConnectionState?: PrivateLinkServiceConnectionStateProperty;
 }
 
 /* Private endpoint which the connection belongs to. */
 export interface PrivateEndpointProperty {
   /* Resource id of the private endpoint. */
-  id: string;
+  id?: string;
 }
 
 /* Connection State of the Private Endpoint Connection. */
 export interface PrivateLinkServiceConnectionStateProperty {
   /* The private link service connection status. */
-  status: string;
+  status?: string;
   /* Any action that is required beyond basic workflow (approve/ reject/ disconnect) */
-  readonly actionsRequired: string;
+  readonly actionsRequired?: string;
 }
 
 /* REST API operation */
 export interface Operation {
   /* Operation name: {provider}/{resource}/{operation} */
-  name: string;
+  name?: string;
   /* The object that represents the operation. */
-  display: unknown;
+  display?: unknown;
 }
 
 /* Result of the request to list Resource Provider operations. It contains a list of operations and a URL link to get the next set of results. */
 export interface OperationListResult {
   /* List of operations supported by the Resource Provider. */
-  value: Operation[];
+  value?: Operation[];
 
   /* URL to get the next set of operation list results if there are any. */
-  nextLink: string;
+  nextLink?: string;
 }
 
 /* The response to a list usage request. */
 export interface UsagesResult {
   /* The list of usages for the database. A usage is a point in time metric */
-  readonly value: Usage[];
+  readonly value?: Usage[];
 }
 
 /* The usage data for a usage request. */
 export interface Usage {
   /* The unit of the metric. */
-  unit: UnitType;
+  unit?: UnitType;
 
   /* The name information for the metric. */
-  readonly name: MetricName;
+  readonly name?: MetricName;
 
   /* The quota period used to summarize the usage values. */
-  readonly quotaPeriod: string;
+  readonly quotaPeriod?: string;
   /* Maximum value for this metric */
-  readonly limit: number;
+  readonly limit?: number;
   /* Current value for this metric */
-  readonly currentValue: number;
+  readonly currentValue?: number;
 }
 
 /* The response to a list partition level usage request. */
 export interface PartitionUsagesResult {
   /* The list of partition-level usages for the database. A usage is a point in time metric */
-  readonly value: PartitionUsage[];
+  readonly value?: PartitionUsage[];
 }
 
 /* The partition level usage data for a usage request. */
 export type PartitionUsage = Usage & {
   /* The partition id (GUID identifier) of the usages. */
-  readonly partitionId: string;
+  readonly partitionId?: string;
   /* The partition key range id (integer identifier) of the usages. */
-  readonly partitionKeyRangeId: string;
+  readonly partitionKeyRangeId?: string;
 };
 
 /* The response to a list metric definitions request. */
 export interface MetricDefinitionsListResult {
   /* The list of metric definitions for the account. */
-  readonly value: MetricDefinition[];
+  readonly value?: MetricDefinition[];
 }
 
 /* The definition of a metric. */
 export interface MetricDefinition {
   /* The list of metric availabilities for the account. */
-  readonly metricAvailabilities: MetricAvailability[];
+  readonly metricAvailabilities?: MetricAvailability[];
 
   /* The primary aggregation type of the metric. */
-  readonly primaryAggregationType: string;
+  readonly primaryAggregationType?: string;
   /* The unit of the metric. */
-  unit: UnitType;
+  unit?: UnitType;
 
   /* The resource uri of the database. */
-  readonly resourceUri: string;
+  readonly resourceUri?: string;
   /* The name information for the metric. */
-  readonly name: MetricName;
+  readonly name?: MetricName;
 }
 
 /* The availability of the metric. */
 export interface MetricAvailability {
   /* The time grain to be used to summarize the metric values. */
-  readonly timeGrain: string;
+  readonly timeGrain?: string;
   /* The retention for the metric values. */
-  readonly retention: string;
+  readonly retention?: string;
 }
 
 /* The response to a list metrics request. */
 export interface MetricListResult {
   /* The list of metrics for the account. */
-  readonly value: Metric[];
+  readonly value?: Metric[];
 }
 
 /* Metric data */
 export interface Metric {
   /* The start time for the metric (ISO-8601 format). */
-  readonly startTime: string;
+  readonly startTime?: string;
   /* The end time for the metric (ISO-8601 format). */
-  readonly endTime: string;
+  readonly endTime?: string;
   /* The time grain to be used to summarize the metric values. */
-  readonly timeGrain: string;
+  readonly timeGrain?: string;
   /* The unit of the metric. */
-  unit: UnitType;
+  unit?: UnitType;
 
   /* The name information for the metric. */
-  readonly name: MetricName;
+  readonly name?: MetricName;
 
   /* The metric values for the specified time window and timestep. */
-  readonly metricValues: MetricValue[];
+  readonly metricValues?: MetricValue[];
 }
 
 /* A metric name. */
 export interface MetricName {
   /* The name of the metric. */
-  readonly value: string;
+  readonly value?: string;
   /* The friendly name of the metric. */
-  readonly localizedValue: string;
+  readonly localizedValue?: string;
 }
 
 /* Represents metrics values. */
 export interface MetricValue {
   /* The number of values for the metric. */
-  readonly _count: number;
+  readonly _count?: number;
   /* The average value of the metric. */
-  readonly average: number;
+  readonly average?: number;
   /* The max value of the metric. */
-  readonly maximum: number;
+  readonly maximum?: number;
   /* The min value of the metric. */
-  readonly minimum: number;
+  readonly minimum?: number;
   /* The metric timestamp (ISO-8601 format). */
-  readonly timestamp: string;
+  readonly timestamp?: string;
   /* The total value of the metric. */
-  readonly total: number;
+  readonly total?: number;
 }
 
 /* The response to a list percentile metrics request. */
 export interface PercentileMetricListResult {
   /* The list of percentile metrics for the account. */
-  readonly value: PercentileMetric[];
+  readonly value?: PercentileMetric[];
 }
 
 /* Percentile Metric data */
 export interface PercentileMetric {
   /* The start time for the metric (ISO-8601 format). */
-  readonly startTime: string;
+  readonly startTime?: string;
   /* The end time for the metric (ISO-8601 format). */
-  readonly endTime: string;
+  readonly endTime?: string;
   /* The time grain to be used to summarize the metric values. */
-  readonly timeGrain: string;
+  readonly timeGrain?: string;
   /* The unit of the metric. */
-  unit: UnitType;
+  unit?: UnitType;
 
   /* The name information for the metric. */
-  readonly name: MetricName;
+  readonly name?: MetricName;
 
   /* The percentile metric values for the specified time window and timestep. */
-  readonly metricValues: PercentileMetricValue[];
+  readonly metricValues?: PercentileMetricValue[];
 }
 
 /* Represents percentile metrics values. */
 export type PercentileMetricValue = MetricValue & {
   /* The 10th percentile value for the metric. */
-  readonly P10: number;
+  readonly P10?: number;
   /* The 25th percentile value for the metric. */
-  readonly P25: number;
+  readonly P25?: number;
   /* The 50th percentile value for the metric. */
-  readonly P50: number;
+  readonly P50?: number;
   /* The 75th percentile value for the metric. */
-  readonly P75: number;
+  readonly P75?: number;
   /* The 90th percentile value for the metric. */
-  readonly P90: number;
+  readonly P90?: number;
   /* The 95th percentile value for the metric. */
-  readonly P95: number;
+  readonly P95?: number;
   /* The 99th percentile value for the metric. */
-  readonly P99: number;
+  readonly P99?: number;
 };
 
 /* The response to a list partition metrics request. */
 export interface PartitionMetricListResult {
   /* The list of partition-level metrics for the account. */
-  readonly value: PartitionMetric[];
+  readonly value?: PartitionMetric[];
 }
 
 /* The metric values for a single partition. */
 export type PartitionMetric = Metric & {
   /* The partition id (GUID identifier) of the metric values. */
-  readonly partitionId: string;
+  readonly partitionId?: string;
   /* The partition key range id (integer identifier) of the metric values. */
-  readonly partitionKeyRangeId: string;
+  readonly partitionKeyRangeId?: string;
 };
 
 /* The unit of the metric. */
@@ -1364,5 +1384,5 @@ export type PublicNetworkAccess = "Enabled" | "Disabled";
 /* undocumented */
 export interface ApiProperties {
   /* Describes the ServerVersion of an a MongoDB account. */
-  serverVersion: string;
+  serverVersion?: string;
 }


### PR DESCRIPTION
Cassandra create is a pretty low risk first move to create. It was already done via ARM, but this moves it to the new auto generated ARM functions.
- Fixes a double stringify bug in the ARM request body code
- Adds handling of required and optional body parameters to generator clients.