### PR TITLE
Fix deleteDatabase and deleteCollection with ARM

### DIFF
--- a/src/Common/dataAccess/deleteCollection.test.ts
+++ b/src/Common/dataAccess/deleteCollection.test.ts
@@ -6,6 +6,7 @@ import { AuthType } from "../../AuthType";
 import { updateUserContext } from "../../UserContext";
 import { DatabaseAccount } from "../../Contracts/DataModels";
 import { sendCachedDataMessage } from "../MessageHandler";
+import { DefaultAccountExperienceType } from "../../DefaultAccountExperienceType";
 
 describe("deleteCollection", () => {
   it("should call ARM if logged in with AAD", async () => {
@@ -13,7 +14,8 @@ describe("deleteCollection", () => {
     updateUserContext({
       databaseAccount: {
         name: "test"
-      } as DatabaseAccount
+      } as DatabaseAccount,
+      defaultExperience: DefaultAccountExperienceType.DocumentDB
     });
     (sendCachedDataMessage as jest.Mock).mockResolvedValue(undefined);
     await deleteCollection("database", "collection");

--- a/src/Common/dataAccess/deleteCollection.ts
+++ b/src/Common/dataAccess/deleteCollection.ts
@@ -1,5 +1,10 @@
 import { AuthType } from "../../AuthType";
+import { DefaultAccountExperienceType } from "../../DefaultAccountExperienceType";
 import { deleteSqlContainer } from "../../Utils/arm/generatedClients/2020-04-01/sqlResources";
+import { deleteCassandraTable } from "../../Utils/arm/generatedClients/2020-04-01/cassandraResources";
+import { deleteMongoDBCollection } from "../../Utils/arm/generatedClients/2020-04-01/mongoDBResources";
+import { deleteGremlinGraph } from "../../Utils/arm/generatedClients/2020-04-01/gremlinResources";
+import { deleteTable } from "../../Utils/arm/generatedClients/2020-04-01/tableResources";
 import { logConsoleError, logConsoleInfo, logConsoleProgress } from "../../Utils/NotificationConsoleUtils";
 import { userContext } from "../../UserContext";
 import { client } from "../CosmosClient";
@@ -9,13 +14,7 @@ export async function deleteCollection(databaseId: string, collectionId: string)
   const clearMessage = logConsoleProgress(`Deleting container ${collectionId}`);
   try {
     if (window.authType === AuthType.AAD) {
-      await deleteSqlContainer(
-        userContext.subscriptionId,
-        userContext.resourceGroup,
-        userContext.databaseAccount.name,
-        databaseId,
-        collectionId
-      );
+      await deleteCollectionWithARM(databaseId, collectionId);
     } else {
       await client()
         .database(databaseId)
@@ -29,4 +28,26 @@ export async function deleteCollection(databaseId: string, collectionId: string)
   logConsoleInfo(`Successfully deleted container ${collectionId}`);
   clearMessage();
   await refreshCachedResources();
+}
+
+function deleteCollectionWithARM(databaseId: string, collectionId: string): Promise<void> {
+  const subscriptionId: string = userContext.subscriptionId;
+  const resourceGroup: string = userContext.resourceGroup;
+  const accountName: string = userContext.databaseAccount.name;
+  const defaultExperience: DefaultAccountExperienceType = userContext.defaultExperience;
+
+  switch (defaultExperience) {
+    case DefaultAccountExperienceType.DocumentDB:
+      return deleteSqlContainer(subscriptionId, resourceGroup, accountName, databaseId, collectionId);
+    case DefaultAccountExperienceType.MongoDB:
+      return deleteMongoDBCollection(subscriptionId, resourceGroup, accountName, databaseId, collectionId);
+    case DefaultAccountExperienceType.Cassandra:
+      return deleteCassandraTable(subscriptionId, resourceGroup, accountName, databaseId, collectionId);
+    case DefaultAccountExperienceType.Graph:
+      return deleteGremlinGraph(subscriptionId, resourceGroup, accountName, databaseId, collectionId);
+    case DefaultAccountExperienceType.Table:
+      return deleteTable(subscriptionId, resourceGroup, accountName, collectionId);
+    default:
+      throw new Error(`Unsupported default experience type: ${defaultExperience}`);
+  }
 }

--- a/src/Common/dataAccess/deleteCollection.ts
+++ b/src/Common/dataAccess/deleteCollection.ts
@@ -31,10 +31,10 @@ export async function deleteCollection(databaseId: string, collectionId: string)
 }
 
 function deleteCollectionWithARM(databaseId: string, collectionId: string): Promise<void> {
-  const subscriptionId: string = userContext.subscriptionId;
-  const resourceGroup: string = userContext.resourceGroup;
-  const accountName: string = userContext.databaseAccount.name;
-  const defaultExperience: DefaultAccountExperienceType = userContext.defaultExperience;
+  const subscriptionId = userContext.subscriptionId;
+  const resourceGroup = userContext.resourceGroup;
+  const accountName = userContext.databaseAccount.name;
+  const defaultExperience = userContext.defaultExperience;
 
   switch (defaultExperience) {
     case DefaultAccountExperienceType.DocumentDB:

--- a/src/Common/dataAccess/deleteDatabase.test.ts
+++ b/src/Common/dataAccess/deleteDatabase.test.ts
@@ -6,6 +6,7 @@ import { AuthType } from "../../AuthType";
 import { updateUserContext } from "../../UserContext";
 import { DatabaseAccount } from "../../Contracts/DataModels";
 import { sendCachedDataMessage } from "../MessageHandler";
+import { DefaultAccountExperienceType } from "../../DefaultAccountExperienceType";
 
 describe("deleteDatabase", () => {
   it("should call ARM if logged in with AAD", async () => {
@@ -13,7 +14,8 @@ describe("deleteDatabase", () => {
     updateUserContext({
       databaseAccount: {
         name: "test"
-      } as DatabaseAccount
+      } as DatabaseAccount,
+      defaultExperience: DefaultAccountExperienceType.DocumentDB
     });
     (sendCachedDataMessage as jest.Mock).mockResolvedValue(undefined);
     await deleteDatabase("database");

--- a/src/Common/dataAccess/deleteDatabase.ts
+++ b/src/Common/dataAccess/deleteDatabase.ts
@@ -34,10 +34,10 @@ export async function deleteDatabase(databaseId: string): Promise<void> {
 }
 
 function deleteDatabaseWithARM(databaseId: string): Promise<void> {
-  const subscriptionId: string = userContext.subscriptionId;
-  const resourceGroup: string = userContext.resourceGroup;
-  const accountName: string = userContext.databaseAccount.name;
-  const defaultExperience: DefaultAccountExperienceType = userContext.defaultExperience;
+  const subscriptionId = userContext.subscriptionId;
+  const resourceGroup = userContext.resourceGroup;
+  const accountName = userContext.databaseAccount.name;
+  const defaultExperience = userContext.defaultExperience;
 
   switch (defaultExperience) {
     case DefaultAccountExperienceType.DocumentDB:

--- a/src/DefaultAccountExperienceType.ts
+++ b/src/DefaultAccountExperienceType.ts
@@ -1,0 +1,8 @@
+export enum DefaultAccountExperienceType {
+  DocumentDB = "DocumentDB",
+  Graph = "Graph",
+  MongoDB = "MongoDB",
+  Table = "Table",
+  Cassandra = "Cassandra",
+  ApiForMongoDB = "Azure Cosmos DB for MongoDB API"
+}

--- a/src/Explorer/Explorer.ts
+++ b/src/Explorer/Explorer.ts
@@ -482,7 +482,11 @@ export default class Explorer {
     this.notificationConsoleData = ko.observableArray<ConsoleData>([]);
     this.defaultExperience = ko.observable<string>();
     this.databaseAccount.subscribe(databaseAccount => {
-      this.defaultExperience(DefaultExperienceUtility.getDefaultExperienceFromDatabaseAccount(databaseAccount));
+      const defaultExperience: string = DefaultExperienceUtility.getDefaultExperienceFromDatabaseAccount(
+        databaseAccount
+      );
+      this.defaultExperience(defaultExperience);
+      updateUserContext({ defaultExperience: DefaultExperienceUtility.mapDefaultExperienceStringToEnum(defaultExperience) });
     });
 
     this.isPreferredApiDocumentDB = ko.computed(() => {

--- a/src/Explorer/Explorer.ts
+++ b/src/Explorer/Explorer.ts
@@ -486,7 +486,9 @@ export default class Explorer {
         databaseAccount
       );
       this.defaultExperience(defaultExperience);
-      updateUserContext({ defaultExperience: DefaultExperienceUtility.mapDefaultExperienceStringToEnum(defaultExperience) });
+      updateUserContext({
+        defaultExperience: DefaultExperienceUtility.mapDefaultExperienceStringToEnum(defaultExperience)
+      });
     });
 
     this.isPreferredApiDocumentDB = ko.computed(() => {

--- a/src/Shared/DefaultExperienceUtility.ts
+++ b/src/Shared/DefaultExperienceUtility.ts
@@ -1,6 +1,7 @@
 import * as _ from "underscore";
 import * as Constants from "../Common/Constants";
 import * as DataModels from "../Contracts/DataModels";
+import { DefaultAccountExperienceType } from "../DefaultAccountExperienceType";
 
 export class DefaultExperienceUtility {
   public static getDefaultExperienceFromDatabaseAccount(databaseAccount: DataModels.DatabaseAccount): string {
@@ -56,6 +57,25 @@ export class DefaultExperienceUtility {
         return Constants.DefaultAccountExperience.Graph;
       default:
         return Constants.DefaultAccountExperience.Default;
+    }
+  }
+
+  public static mapDefaultExperienceStringToEnum(defaultExperience: string): DefaultAccountExperienceType {
+    switch (defaultExperience) {
+      case Constants.DefaultAccountExperience.DocumentDB:
+        return DefaultAccountExperienceType.DocumentDB;
+      case Constants.DefaultAccountExperience.Graph:
+        return DefaultAccountExperienceType.Graph;
+      case Constants.DefaultAccountExperience.MongoDB:
+        return DefaultAccountExperienceType.MongoDB;
+      case Constants.DefaultAccountExperience.Table:
+        return DefaultAccountExperienceType.Table;
+      case Constants.DefaultAccountExperience.Cassandra:
+        return DefaultAccountExperienceType.Cassandra;
+      case Constants.DefaultAccountExperience.ApiForMongoDB:
+        return DefaultAccountExperienceType.ApiForMongoDB;
+      default:
+        throw new Error(`Unsupported default experience type: ${defaultExperience}`);
     }
   }
 

--- a/src/UserContext.ts
+++ b/src/UserContext.ts
@@ -1,4 +1,5 @@
 import { DatabaseAccount } from "./Contracts/DataModels";
+import { DefaultAccountExperienceType } from "./DefaultAccountExperienceType";
 
 interface UserContext {
   masterKey?: string;
@@ -9,6 +10,7 @@ interface UserContext {
   accessToken?: string;
   authorizationToken?: string;
   resourceToken?: string;
+  defaultExperience?: DefaultAccountExperienceType;
 }
 
 const userContext: Readonly<UserContext> = {} as const;


### PR DESCRIPTION
Currently deleteDatabase and deleteCollection always use the SQL URI for deleting database and collection. It should determine the correct URI to use based on the default experience.