### PR TITLE
Show submit button by default in GenericRightPaneComponent & other fixes

### DIFF
--- a/src/Explorer/Panes/GenericRightPaneComponent.tsx
+++ b/src/Explorer/Panes/GenericRightPaneComponent.tsx
@@ -16,7 +16,7 @@ export interface GenericRightPaneProps {
   onSubmit: () => void;
   submitButtonText: string;
   title: string;
-  isSubmitButtonVisible?: boolean;
+  isSubmitButtonHidden?: boolean;
 }
 
 export interface GenericRightPaneState {
@@ -108,7 +108,7 @@ export class GenericRightPaneComponent extends React.Component<GenericRightPaneP
       <div className="paneFooter">
         <div className="leftpanel-okbut">
           <PrimaryButton
-            style={{ visibility: this.props.isSubmitButtonVisible ? "visible" : "hidden" }}
+            style={{ visibility: this.props.isSubmitButtonHidden ? "hidden" : "visible" }}
             ariaLabel="Submit"
             title="Submit"
             onClick={this.props.onSubmit}

--- a/src/Explorer/Panes/PublishNotebookPaneAdapter.tsx
+++ b/src/Explorer/Panes/PublishNotebookPaneAdapter.tsx
@@ -52,7 +52,7 @@ export class PublishNotebookPaneAdapter implements ReactAdapter {
       submitButtonText: "Publish",
       onClose: () => this.close(),
       onSubmit: () => this.submit(),
-      isSubmitButtonVisible: this.isCodeOfConductAccepted
+      isSubmitButtonHidden: !this.isCodeOfConductAccepted
     };
 
     const publishNotebookPaneProps: PublishNotebookPaneProps = {

--- a/src/Explorer/Panes/PublishNotebookPaneComponent.tsx
+++ b/src/Explorer/Panes/PublishNotebookPaneComponent.tsx
@@ -285,7 +285,7 @@ export class PublishNotebookPaneComponent extends React.Component<PublishNoteboo
             <GalleryCardComponent
               data={{
                 id: undefined,
-                name: this.props.notebookName,
+                name: this.state.notebookName,
                 description: this.state.notebookDescription,
                 gitSha: undefined,
                 tags: this.state.notebookTags.split(","),

--- a/src/Explorer/Panes/UploadItemsPaneAdapter.tsx
+++ b/src/Explorer/Panes/UploadItemsPaneAdapter.tsx
@@ -39,7 +39,6 @@ export class UploadItemsPaneAdapter implements ReactAdapter {
       formErrorDetail: this.formErrorDetail,
       id: "uploaditemspane",
       isExecuting: this.isExecuting,
-      isSubmitButtonVisible: true,
       title: "Upload Items",
       submitButtonText: "Upload",
       onClose: () => this.close(),

--- a/src/Explorer/Tabs/NotebookV2Tab.ts
+++ b/src/Explorer/Tabs/NotebookV2Tab.ts
@@ -147,6 +147,30 @@ export default class NotebookTabV2 extends TabsBase {
     const cellCodeType = "code";
     const cellMarkdownType = "markdown";
     const cellRawType = "raw";
+
+    const saveButtonChildren = [];
+    if (this.container.notebookManager?.gitHubOAuthService.isLoggedIn()) {
+      saveButtonChildren.push({
+        iconName: "Copy",
+        onCommandClick: () => this.copyNotebook(),
+        commandButtonLabel: copyToLabel,
+        hasPopup: false,
+        disabled: false,
+        ariaLabel: copyToLabel
+      });
+    }
+
+    if (this.container.isGalleryPublishEnabled()) {
+      saveButtonChildren.push({
+        iconName: "PublishContent",
+        onCommandClick: async () => await this.publishToGallery(),
+        commandButtonLabel: publishLabel,
+        hasPopup: false,
+        disabled: false,
+        ariaLabel: publishLabel
+      });
+    }
+
     let buttons: CommandButtonComponentProps[] = [
       {
         iconSrc: SaveIcon,
@@ -156,34 +180,17 @@ export default class NotebookTabV2 extends TabsBase {
         hasPopup: false,
         disabled: false,
         ariaLabel: saveLabel,
-        children: this.container.isGalleryPublishEnabled()
-          ? [
-              {
-                iconName: "Save",
-                onCommandClick: () => this.notebookComponentAdapter.notebookSave(),
-                commandButtonLabel: saveLabel,
-                hasPopup: false,
-                disabled: false,
-                ariaLabel: saveLabel
-              },
-              {
-                iconName: "Copy",
-                onCommandClick: () => this.copyNotebook(),
-                commandButtonLabel: copyToLabel,
-                hasPopup: false,
-                disabled: false,
-                ariaLabel: copyToLabel
-              },
-              {
-                iconName: "PublishContent",
-                onCommandClick: async () => await this.publishToGallery(),
-                commandButtonLabel: publishLabel,
-                hasPopup: false,
-                disabled: false,
-                ariaLabel: publishLabel
-              }
-            ]
-          : undefined
+        children: saveButtonChildren.length && [
+          {
+            iconName: "Save",
+            onCommandClick: () => this.notebookComponentAdapter.notebookSave(),
+            commandButtonLabel: saveLabel,
+            hasPopup: false,
+            disabled: false,
+            ariaLabel: saveLabel
+          },
+          ...saveButtonChildren
+        ]
       },
       {
         iconSrc: null,

--- a/src/Explorer/Tree/ResourceTreeAdapter.tsx
+++ b/src/Explorer/Tree/ResourceTreeAdapter.tsx
@@ -546,41 +546,50 @@ export class ResourceTreeAdapter implements ReactAdapter {
           (activeTab as any).notebookPath() === item.path
         );
       },
-      contextMenu: createFileContextMenu
-        ? [
-            {
-              label: "Rename",
-              iconSrc: NotebookIcon,
-              onClick: () => this.container.renameNotebook(item)
-            },
-            {
-              label: "Delete",
-              iconSrc: DeleteIcon,
-              onClick: () => {
-                this.container.showOkCancelModalDialog(
-                  "Confirm delete",
-                  `Are you sure you want to delete "${item.name}"`,
-                  "Delete",
-                  () => this.container.deleteNotebookFile(item).then(() => this.triggerRender()),
-                  "Cancel",
-                  undefined
-                );
-              }
-            },
-            {
-              label: "Copy to ...",
-              iconSrc: CopyIcon,
-              onClick: () => this.copyNotebook(item)
-            },
-            {
-              label: "Download",
-              iconSrc: NotebookIcon,
-              onClick: () => this.container.downloadFile(item)
-            }
-          ]
-        : undefined,
+      contextMenu: createFileContextMenu && this.createFileContextMenu(item),
       data: item
     };
+  }
+
+  private createFileContextMenu(item: NotebookContentItem): TreeNodeMenuItem[] {
+    let items: TreeNodeMenuItem[] = [
+      {
+        label: "Rename",
+        iconSrc: NotebookIcon,
+        onClick: () => this.container.renameNotebook(item)
+      },
+      {
+        label: "Delete",
+        iconSrc: DeleteIcon,
+        onClick: () => {
+          this.container.showOkCancelModalDialog(
+            "Confirm delete",
+            `Are you sure you want to delete "${item.name}"`,
+            "Delete",
+            () => this.container.deleteNotebookFile(item).then(() => this.triggerRender()),
+            "Cancel",
+            undefined
+          );
+        }
+      },
+      {
+        label: "Copy to ...",
+        iconSrc: CopyIcon,
+        onClick: () => this.copyNotebook(item)
+      },
+      {
+        label: "Download",
+        iconSrc: NotebookIcon,
+        onClick: () => this.container.downloadFile(item)
+      }
+    ];
+
+    // "Copy to ..." isn't needed if github locations are not available
+    if (!this.container.notebookManager?.gitHubOAuthService.isLoggedIn()) {
+      items = items.filter(item => item.label !== "Copy to ...");
+    }
+
+    return items;
   }
 
   private copyNotebook = async (item: NotebookContentItem) => {


### PR DESCRIPTION
- Fix bug where "Submit" button is hidden by default for `GenericRightPaneComponent`
- Only show "Copy to ..." options when github is logged in
- Fix issue where updating notebook name wasn't updating the live preview in `PublishNotebookPaneComponent`