### PR TITLE
Switch back to using SDK to read databases and collections for Mongo API

### DIFF
--- a/src/Common/dataAccess/readCollections.ts
+++ b/src/Common/dataAccess/readCollections.ts
@@ -16,7 +16,11 @@ export async function readCollections(databaseId: string): Promise<DataModels.Co
   let collections: DataModels.Collection[];
   const clearMessage = logConsoleProgress(`Querying containers for database ${databaseId}`);
   try {
-    if (window.authType === AuthType.AAD && userContext.defaultExperience !== DefaultAccountExperienceType.MongoDB) {
+    if (
+      window.authType === AuthType.AAD &&
+      userContext.defaultExperience !== DefaultAccountExperienceType.MongoDB &&
+      userContext.defaultExperience !== DefaultAccountExperienceType.Table
+    ) {
       collections = await readCollectionsWithARM(databaseId);
     } else {
       const sdkResponse = await client()

--- a/src/Common/dataAccess/readCollections.ts
+++ b/src/Common/dataAccess/readCollections.ts
@@ -16,7 +16,7 @@ export async function readCollections(databaseId: string): Promise<DataModels.Co
   let collections: DataModels.Collection[];
   const clearMessage = logConsoleProgress(`Querying containers for database ${databaseId}`);
   try {
-    if (window.authType === AuthType.AAD) {
+    if (window.authType === AuthType.AAD && userContext.defaultExperience !== DefaultAccountExperienceType.MongoDB) {
       collections = await readCollectionsWithARM(databaseId);
     } else {
       const sdkResponse = await client()

--- a/src/Common/dataAccess/readDatabases.ts
+++ b/src/Common/dataAccess/readDatabases.ts
@@ -15,7 +15,7 @@ export async function readDatabases(): Promise<DataModels.Database[]> {
   let databases: DataModels.Database[];
   const clearMessage = logConsoleProgress(`Querying databases`);
   try {
-    if (window.authType === AuthType.AAD) {
+    if (window.authType === AuthType.AAD && userContext.defaultExperience !== DefaultAccountExperienceType.MongoDB) {
       databases = await readDatabasesWithARM();
     } else {
       const sdkResponse = await client()

--- a/src/Common/dataAccess/readDatabases.ts
+++ b/src/Common/dataAccess/readDatabases.ts
@@ -15,7 +15,11 @@ export async function readDatabases(): Promise<DataModels.Database[]> {
   let databases: DataModels.Database[];
   const clearMessage = logConsoleProgress(`Querying databases`);
   try {
-    if (window.authType === AuthType.AAD && userContext.defaultExperience !== DefaultAccountExperienceType.MongoDB) {
+    if (
+      window.authType === AuthType.AAD &&
+      userContext.defaultExperience !== DefaultAccountExperienceType.MongoDB &&
+      userContext.defaultExperience !== DefaultAccountExperienceType.Table
+    ) {
       databases = await readDatabasesWithARM();
     } else {
       const sdkResponse = await client()


### PR DESCRIPTION
After we moved readDatabases and readCollections to RP, we found that for Mongo API, the resources that the calls return are missing the `ExtendedResourceProperties` such as `_rid`, `_self`, etc, which are used in several places in data explorer. This causes a bunch of issues for customers using Mongo API so we are switching back to using SDK to read databases and collections for Mongo.