### PR TITLE
Switch back to SDK for deleteDatabase and use RP for readCollections for table API

### DIFF
--- a/src/Common/dataAccess/deleteDatabase.ts
+++ b/src/Common/dataAccess/deleteDatabase.ts
@@ -15,7 +15,7 @@ export async function deleteDatabase(databaseId: string): Promise<void> {
   const clearMessage = logConsoleProgress(`Deleting database ${databaseId}`);
 
   try {
-    if (window.authType === AuthType.AAD) {
+    if (window.authType === AuthType.AAD && userContext.defaultExperience !== DefaultAccountExperienceType.Table) {
       await deleteDatabaseWithARM(databaseId);
     } else {
       await client()

--- a/src/Common/dataAccess/readCollections.ts
+++ b/src/Common/dataAccess/readCollections.ts
@@ -16,11 +16,7 @@ export async function readCollections(databaseId: string): Promise<DataModels.Co
   let collections: DataModels.Collection[];
   const clearMessage = logConsoleProgress(`Querying containers for database ${databaseId}`);
   try {
-    if (
-      window.authType === AuthType.AAD &&
-      userContext.defaultExperience !== DefaultAccountExperienceType.MongoDB &&
-      userContext.defaultExperience !== DefaultAccountExperienceType.Table
-    ) {
+    if (window.authType === AuthType.AAD && userContext.defaultExperience !== DefaultAccountExperienceType.MongoDB) {
       collections = await readCollectionsWithARM(databaseId);
     } else {
       const sdkResponse = await client()


### PR DESCRIPTION
`deleteDatabase`: RP does not support any operation on the database level for table API so we have to switch back to using SDK.
`readCollections`: I moved this call back to SDK but it actually works using RP as well. Therefore, moving the table call back to RP.