### PR TITLE
Fix settings tab for table API

### DIFF
--- a/src/Common/dataAccess/readCollections.ts
+++ b/src/Common/dataAccess/readCollections.ts
@@ -16,7 +16,11 @@ export async function readCollections(databaseId: string): Promise<DataModels.Co
   let collections: DataModels.Collection[];
   const clearMessage = logConsoleProgress(`Querying containers for database ${databaseId}`);
   try {
-    if (window.authType === AuthType.AAD && userContext.defaultExperience !== DefaultAccountExperienceType.MongoDB) {
+    if (
+      window.authType === AuthType.AAD &&
+      userContext.defaultExperience !== DefaultAccountExperienceType.MongoDB &&
+      userContext.defaultExperience !== DefaultAccountExperienceType.Table
+    ) {
       collections = await readCollectionsWithARM(databaseId);
     } else {
       const sdkResponse = await client()


### PR DESCRIPTION
The settings tab is not showing the correct indexing policy and ttl setting because we recently moved to using RP to read tables and RP does not expose these properties for table API. We need to switch back to using SDK in `readCollections` again.