### PR TITLE
Fix settings tab issue for cassandra and add feature flag

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -134,6 +134,7 @@ export class Features {
   public static readonly enableAutoPilotV2 = "enableautopilotv2";
   public static readonly ttl90Days = "ttl90days";
   public static readonly enableRightPanelV2 = "enablerightpanelv2";
+  public static readonly enableSDKoperations = "enablesdkoperations";
 }
 
 export class AfecFeatures {

--- a/src/Common/dataAccess/deleteCollection.ts
+++ b/src/Common/dataAccess/deleteCollection.ts
@@ -15,7 +15,7 @@ import { refreshCachedResources } from "../DataAccessUtilityBase";
 export async function deleteCollection(databaseId: string, collectionId: string): Promise<void> {
   const clearMessage = logConsoleProgress(`Deleting container ${collectionId}`);
   try {
-    if (window.authType === AuthType.AAD) {
+    if (window.authType === AuthType.AAD && !userContext.useSDKOperations) {
       await deleteCollectionWithARM(databaseId, collectionId);
     } else {
       await client()

--- a/src/Common/dataAccess/deleteDatabase.ts
+++ b/src/Common/dataAccess/deleteDatabase.ts
@@ -15,7 +15,11 @@ export async function deleteDatabase(databaseId: string): Promise<void> {
   const clearMessage = logConsoleProgress(`Deleting database ${databaseId}`);
 
   try {
-    if (window.authType === AuthType.AAD && userContext.defaultExperience !== DefaultAccountExperienceType.Table) {
+    if (
+      window.authType === AuthType.AAD &&
+      userContext.defaultExperience !== DefaultAccountExperienceType.Table &&
+      !userContext.useSDKOperations
+    ) {
       await deleteDatabaseWithARM(databaseId);
     } else {
       await client()

--- a/src/Common/dataAccess/readCollections.ts
+++ b/src/Common/dataAccess/readCollections.ts
@@ -16,7 +16,11 @@ export async function readCollections(databaseId: string): Promise<DataModels.Co
   let collections: DataModels.Collection[];
   const clearMessage = logConsoleProgress(`Querying containers for database ${databaseId}`);
   try {
-    if (window.authType === AuthType.AAD && userContext.defaultExperience !== DefaultAccountExperienceType.MongoDB) {
+    if (
+      window.authType === AuthType.AAD &&
+      !userContext.useSDKOperations &&
+      userContext.defaultExperience !== DefaultAccountExperienceType.MongoDB
+    ) {
       collections = await readCollectionsWithARM(databaseId);
     } else {
       const sdkResponse = await client()

--- a/src/Common/dataAccess/readDatabases.ts
+++ b/src/Common/dataAccess/readDatabases.ts
@@ -17,8 +17,10 @@ export async function readDatabases(): Promise<DataModels.Database[]> {
   try {
     if (
       window.authType === AuthType.AAD &&
+      !userContext.useSDKOperations &&
       userContext.defaultExperience !== DefaultAccountExperienceType.MongoDB &&
-      userContext.defaultExperience !== DefaultAccountExperienceType.Table
+      userContext.defaultExperience !== DefaultAccountExperienceType.Table &&
+      userContext.defaultExperience !== DefaultAccountExperienceType.Cassandra
     ) {
       databases = await readDatabasesWithARM();
     } else {

--- a/src/Explorer/Explorer.ts
+++ b/src/Explorer/Explorer.ts
@@ -975,6 +975,10 @@ export default class Explorer {
         this.sparkClusterConnectionInfo.valueHasMutated();
       }
 
+      if (this.isFeatureEnabled(Constants.Features.enableSDKoperations)) {
+        updateUserContext({ useSDKOperations: true });
+      }
+
       featureSubcription.dispose();
     });
 

--- a/src/UserContext.ts
+++ b/src/UserContext.ts
@@ -11,6 +11,7 @@ interface UserContext {
   authorizationToken?: string;
   resourceToken?: string;
   defaultExperience?: DefaultAccountExperienceType;
+  useSDKOperations?: boolean;
 }
 
 const userContext: Readonly<UserContext> = {} as const;


### PR DESCRIPTION
For cassandra keyspaces with shared throughput, the "Scale" tab doesn't appear in the resource tree because the keyspaces that we get from RP do not have the `_self` property which is used to find the corresponding database offer. Without the offer, the resource tree is unable to determine whether the throughput is shared or not.

We have to revert readCollections back to using SDK for Cassandra. In addition, I added a feature flag `enablesdkoperations` to allow us to easily switch back to using SDK calls when we find issues with RP in the future.