### PR TITLE
Use edge instead of chrome for emulator e2e test

### DIFF
--- a/cypress/package.json
+++ b/cypress/package.json
@@ -7,7 +7,7 @@
     "test": "cypress run",
     "wait-for-server": "wait-on -t 240000 -i 5000 -v https-get://0.0.0.0:1234/",
     "test:sql": "cypress run --browser chrome --spec \"./integration/dataexplorer/SQL/*\"",
-    "test:ci": "wait-on -t 240000 -i 5000 -v https-get://0.0.0.0:1234/ https-get://0.0.0.0:8081/_explorer/index.html && cypress run --browser chrome --headless",
+    "test:ci": "wait-on -t 240000 -i 5000 -v https-get://0.0.0.0:1234/ https-get://0.0.0.0:8081/_explorer/index.html && cypress run --browser edge --headless",
     "test:debug": "cypress open"
   },
   "devDependencies": {


### PR DESCRIPTION
The emulator e2e test is failing with the following error:

> Can't run because you've entered an invalid browser name.
> 
> Browser: 'chrome' was not found on your system or is not supported by Cypress.
> 
> Cypress supports the following browsers:
> - chrome
> - chromium
> - edge
> - electron
> - firefox (Cypress support in beta)
> 
> You can also use a custom browser: https://on.cypress.io/customize-browsers
> 
> Available browsers found on your system are:
> - firefox
> - edge
> - electron

This fix will change the browser from chrome to edge for the emulator e2e test temporarily while we investigate why chrome is missing from our system.