### PR TITLE
Fix broken terminals

### DIFF
--- a/src/Shared/appInsights.ts
+++ b/src/Shared/appInsights.ts
@@ -2,8 +2,7 @@ import { ApplicationInsights } from "@microsoft/applicationinsights-web";
 
 const appInsights = new ApplicationInsights({
   config: {
-    instrumentationKey: "fa645d97-6237-4656-9559-0ee0cb55ee49",
-    disableFetchTracking: false
+    instrumentationKey: "fa645d97-6237-4656-9559-0ee0cb55ee49"
   }
 });
 appInsights.loadAppInsights();


### PR DESCRIPTION
When fetch tracking is enabled in appInsights it adds `request-id` in Request headers which is not allowed by Nginx used by the NotebooksService app pod. This leads to failed API calls when launching a terminal.