### PR TITLE
Notebooks: Ability to download file from notebooks container

### DIFF
--- a/src/Explorer/Notebook/NotebookContentClient.ts
+++ b/src/Explorer/Notebook/NotebookContentClient.ts
@@ -195,8 +195,9 @@ export class NotebookContentClient {
   }
 
   public readFileContent(filePath: string): Promise<string> {
+    const fileType = NotebookUtil.isNotebookFile(filePath) ? "notebook" : "file";
     return this.contentProvider
-      .get(this.getServerConfig(), filePath, { type: "notebook", format: "text", content: 1 })
+      .get(this.getServerConfig(), filePath, { type: fileType, format: "text", content: 1 })
       .toPromise()
       .then(xhr => {
         const content = (xhr.response as any).content;


### PR DESCRIPTION
Today, if we have non notebook file (csv, xlsx) in the container and we try to download the file, it fails. That is because, the filetype is always defined as notebook in the call to content provider's get method. Fixing it to use the right type in this change. This change fixes the csv issue. With XLSX, there is more investigation needed since it complains about encoding. Will checkin this fix for csv to unblock the customer. 