### PR TITLE
Fix file downloads from notebooks container

### DIFF
--- a/src/Explorer/Explorer.ts
+++ b/src/Explorer/Explorer.ts
@@ -87,6 +87,7 @@ import { ContextualPaneBase } from "./Panes/ContextualPaneBase";
 import TabsBase from "./Tabs/TabsBase";
 import { CommandButtonComponentProps } from "./Controls/CommandButton/CommandButtonComponent";
 import { updateUserContext, userContext } from "../UserContext";
+import { stringToBlob } from "../Utils/BlobUtils";
 
 BindingHandlersRegisterer.registerBindingHandlers();
 // Hold a reference to ComponentRegisterer to prevent transpiler to ignore import
@@ -2623,7 +2624,7 @@ export default class Explorer {
 
     return this.notebookManager?.notebookContentClient.readFileContent(notebookFile.path).then(
       (content: string) => {
-        const blob = new Blob([content], { type: "octet/stream" });
+        const blob = stringToBlob(content, "text/plain");
         if (navigator.msSaveBlob) {
           // for IE and Edge
           navigator.msSaveBlob(blob, notebookFile.name);

--- a/src/Explorer/Explorer.ts
+++ b/src/Explorer/Explorer.ts
@@ -2622,6 +2622,8 @@ export default class Explorer {
       throw new Error(error);
     }
 
+    const clearMessage = NotificationConsoleUtils.logConsoleProgress(`Downloading ${notebookFile.path}`);
+
     return this.notebookManager?.notebookContentClient.readFileContent(notebookFile.path).then(
       (content: string) => {
         const blob = stringToBlob(content, "text/plain");
@@ -2641,12 +2643,16 @@ export default class Explorer {
           downloadLink.click();
           downloadLink.remove();
         }
+
+        clearMessage();
       },
       (error: any) => {
         NotificationConsoleUtils.logConsoleMessage(
           ConsoleDataType.Error,
           `Could not download notebook ${JSON.stringify(error)}`
         );
+
+        clearMessage();
       }
     );
   }

--- a/src/Utils/BlobUtils.ts
+++ b/src/Utils/BlobUtils.ts
@@ -1,0 +1,17 @@
+export const stringToBlob = (data: string, contentType: string, sliceSize = 512): Blob => {
+  const byteArrays = [];
+
+  for (let offset = 0; offset < data.length; offset += sliceSize) {
+    const slice = data.slice(offset, offset + sliceSize);
+
+    const byteNumbers = new Array(slice.length);
+    for (let i = 0; i < slice.length; i++) {
+      byteNumbers[i] = slice.charCodeAt(i);
+    }
+
+    const byteArray = new Uint8Array(byteNumbers);
+    byteArrays.push(byteArray);
+  }
+
+  return new Blob(byteArrays, { type: contentType });
+};


### PR DESCRIPTION
- Fix `NotebookContentClient.readFileContent` to return content string for `text`, `json`, and `base64` files
- Fix how we're constructing `Blob` from a `string`

Verified that the following scenarios now work:
- Downloading `.csv`, `.xlsx`, `.txt`, `.ipynb` files from container works
- `Copy To...` works for `.csv`, `.txt`, `.ipynb` files from container to github

TODO
- `Copy To...` doesn't work for `.xlsx` from container to github correctly. It copies the file but it is corrupted.