### PR TITLE
Added alert role to query tables tab error

### DIFF
--- a/src/Explorer/Tabs/QueryTablesTab.html
+++ b/src/Explorer/Tabs/QueryTablesTab.html
@@ -17,7 +17,7 @@
     <div class="error-bar">
       <div class="error-message" aria-label="Error Message" data-bind="visible: hasQueryError">
         <span><img class="entity-error-Img" src="/error_red.svg"/></span>
-        <span class="error-text" data-bind="text: queryErrorMessage"></span>
+        <span class="error-text" role="alert" data-bind="text: queryErrorMessage"></span>
       </div>
     </div>
     <!-- Tables Query Tab Errors - End-->


### PR DESCRIPTION
Added alert role for screen readers. We may want to hold off on this change until we can display a friendly error message.