### PR TITLE
Allow remote config to set valid origins

### DIFF
--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -81,7 +81,9 @@ export async function initializeConfiguration(): Promise<ConfigContext> {
         const { allowedParentFrameOrigins, ...externalConfig } = await response.json();
         Object.assign(configContext, externalConfig);
         if (allowedParentFrameOrigins && allowedParentFrameOrigins.length > 0) {
-          configContext.allowedParentFrameOrigins = [...configContext.allowedParentFrameOrigins];
+          updateConfigContext({
+            allowedParentFrameOrigins: [...configContext.allowedParentFrameOrigins, ...allowedParentFrameOrigins]
+          });
         }
       } catch (error) {
         console.error("Unable to parse json in config file");

--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -31,9 +31,9 @@ interface ConfigContext {
 let configContext: Readonly<ConfigContext> = {
   platform: Platform.Portal,
   allowedParentFrameOrigins: [
-    `^https:\\/\\/[\\.\\w]+azure.com$`,
-    `^https:\\/\\/[\\.\\w]+azure.cn$`,
-    `^https:\\/\\/[\\.\\w]+azure.us$`,
+    `^https:\\/\\/cosmos.azure.(com|cn|us)$`,
+    `^https:\\/\\/[\\.\\w]+.portal.azure.(com|cn|us)$`,
+    `^https:\\/\\/[\\.\\w]+.ext.azure.(com|cn|us)$`,
     `^https:\\/\\/[\\.\\w]+microsoftazure.de$`
   ],
   // Webpack injects this at build time

--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -6,7 +6,7 @@ export enum Platform {
 
 interface ConfigContext {
   platform: Platform;
-  allowedParentFrameOrigins: RegExp;
+  allowedParentFrameOrigins: string[];
   gitSha?: string;
   proxyPath?: string;
   AAD_ENDPOINT: string;
@@ -30,7 +30,12 @@ interface ConfigContext {
 // Default configuration
 let configContext: Readonly<ConfigContext> = {
   platform: Platform.Portal,
-  allowedParentFrameOrigins: /^https:\/\/portal\.azure\.com$|^https:\/\/portal\.azure\.us$|^https:\/\/portal\.azure\.cn$|^https:\/\/portal\.microsoftazure\.de$|^https:\/\/.+\.portal\.azure\.com$|^https:\/\/.+\.portal\.azure\.us$|^https:\/\/.+\.portal\.azure\.cn$|^https:\/\/.+\.portal\.microsoftazure\.de$|^https:\/\/main\.documentdb\.ext\.azure\.com$|^https:\/\/main\.documentdb\.ext\.microsoftazure\.de$|^https:\/\/main\.documentdb\.ext\.azure\.cn$|^https:\/\/main\.documentdb\.ext\.azure\.us$/,
+  allowedParentFrameOrigins: [
+    `^https:\\/\\/[\\.\\w]+azure.com$`,
+    `^https:\\/\\/[\\.\\w]+azure.cn$`,
+    `^https:\\/\\/[\\.\\w]+azure.us$`,
+    `^https:\\/\\/[\\.\\w]+microsoftazure.de$`
+  ],
   // Webpack injects this at build time
   gitSha: process.env.GIT_SHA,
   hostedExplorerURL: "https://cosmos.azure.com/",
@@ -73,8 +78,11 @@ export async function initializeConfiguration(): Promise<ConfigContext> {
     const response = await fetch("./config.json");
     if (response.status === 200) {
       try {
-        const externalConfig = await response.json();
+        const { allowedParentFrameOrigins, ...externalConfig } = await response.json();
         Object.assign(configContext, externalConfig);
+        if (allowedParentFrameOrigins && allowedParentFrameOrigins.length > 0) {
+          configContext.allowedParentFrameOrigins = [...configContext.allowedParentFrameOrigins];
+        }
       } catch (error) {
         console.error("Unable to parse json in config file");
         console.error(error);

--- a/src/Utils/MessageValidation.test.ts
+++ b/src/Utils/MessageValidation.test.ts
@@ -15,6 +15,7 @@ test.each`
   ${"https://main.documentdb.ext.azure.cn"}          | ${false}
   ${"https://main.documentdb.ext.microsoftazure.de"} | ${false}
   ${"https://random.domain"}                         | ${true}
+  ${"https://malicious.cloudapp.azure.com"}          | ${true}
 `("returns $expected when called with $domain", ({ domain, expected }) => {
   expect(isInvalidParentFrameOrigin({ origin: domain } as MessageEvent)).toBe(expected);
 });

--- a/src/Utils/MessageValidation.test.ts
+++ b/src/Utils/MessageValidation.test.ts
@@ -1,0 +1,20 @@
+import { isInvalidParentFrameOrigin } from "./MessageValidation";
+
+test.each`
+  domain                                             | expected
+  ${"https://cosmos.azure.com"}                      | ${false}
+  ${"https://cosmos.azure.us"}                       | ${false}
+  ${"https://cosmos.azure.cn"}                       | ${false}
+  ${"https://cosmos.microsoftazure.de"}              | ${false}
+  ${"https://subdomain.portal.azure.com"}            | ${false}
+  ${"https://subdomain.portal.azure.us"}             | ${false}
+  ${"https://subdomain.portal.azure.cn"}             | ${false}
+  ${"https://subdomain.microsoftazure.de"}           | ${false}
+  ${"https://main.documentdb.ext.azure.com"}         | ${false}
+  ${"https://main.documentdb.ext.azure.us"}          | ${false}
+  ${"https://main.documentdb.ext.azure.cn"}          | ${false}
+  ${"https://main.documentdb.ext.microsoftazure.de"} | ${false}
+  ${"https://random.domain"}                         | ${true}
+`("returns $expected when called with $domain", ({ domain, expected }) => {
+  expect(isInvalidParentFrameOrigin({ origin: domain } as MessageEvent)).toBe(expected);
+});

--- a/src/Utils/MessageValidation.ts
+++ b/src/Utils/MessageValidation.ts
@@ -4,13 +4,18 @@ export function isInvalidParentFrameOrigin(event: MessageEvent): boolean {
   return !isValidOrigin(configContext.allowedParentFrameOrigins, event);
 }
 
-function isValidOrigin(allowedOrigins: RegExp, event: MessageEvent): boolean {
+function isValidOrigin(allowedOrigins: string[], event: MessageEvent): boolean {
   const eventOrigin = (event && event.origin) || "";
   const windowOrigin = (window && window.origin) || "";
   if (eventOrigin === windowOrigin) {
     return true;
   }
 
-  const result = allowedOrigins && allowedOrigins.test(eventOrigin);
-  return result;
+  for (const origin of allowedOrigins) {
+    const result = new RegExp(origin).test(eventOrigin);
+    if (result) {
+      return true;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
Allow injection of valid origins via config.json file. Will enable us to deploy to new targets.