### PR TITLE
Fixed aria label for autopilot throughput

### DIFF
--- a/src/Explorer/Controls/ThroughputInput/ThroughputInputComponentAutoscaleV3.html
+++ b/src/Explorer/Controls/ThroughputInput/ThroughputInputComponentAutoscaleV3.html
@@ -84,7 +84,7 @@
         step: step,
         'class':'migration collid select-font-size',
         min: minAutoPilotThroughput,
-        'aria-label': ariaLabel,
+        'aria-label': 'Max request units per second',
         type: isAutoscaleThroughputInputFieldRequired() ? 'number' : 'hidden',
         css: {
           dirty: maxAutoPilotThroughputSet.editableIsDirty


### PR DESCRIPTION
The ariaLabel parameter is used for another text field in this component and only one text field is shown at a time. Hard coding aria label to match the hard coded label for this text field. 