### PR TITLE
[Accessibility] Focuses header control element on Add Row click in Cassandra

### DIFF
--- a/src/Explorer/Panes/Tables/AddTableEntityPane.ts
+++ b/src/Explorer/Panes/Tables/AddTableEntityPane.ts
@@ -80,7 +80,7 @@ export default class AddTableEntityPane extends TableEntityPane {
       this.updateIsActionEnabled();
       super.open();
     }
-    const focusElement = document.getElementById("addTableEntityValue");
+    const focusElement = document.getElementById("closeAddEntityPane");
     focusElement && focusElement.focus();
   }
 

--- a/src/Explorer/Panes/Tables/TableAddEntityPane.html
+++ b/src/Explorer/Panes/Tables/TableAddEntityPane.html
@@ -21,6 +21,7 @@
         <div class="firstdivbg headerline">
           <span role="heading" aria-level="2" data-bind="text: title"></span>
           <div
+            id="closeAddEntityPane"
             class="closeImg"
             role="button"
             aria-label="Close pane"


### PR DESCRIPTION
This PR focuses the first interactive element in the add row pane. The current focus attempts to focus the first entity value, however it doesn't seem to ever actually focus the element. In the accessibility report, I found it a bit confusing that it expected to select the first interactive element in the header, but went with what was written rather than my intuition, and can adjust if that's wrong.

https://msdata.visualstudio.com/CosmosDB/_queries/query/b7017577-e55f-4ce9-a968-0f12c1b1ccaf (requires access)