### PR TITLE
Fix focus when adding and removing a unique key

### DIFF
--- a/src/Explorer/Controls/DynamicList/DynamicListComponent.ts
+++ b/src/Explorer/Controls/DynamicList/DynamicListComponent.ts
@@ -86,7 +86,7 @@ export class DynamicListViewModel extends WaitsForTemplateViewModel {
   public onRemoveItemKeyPress = (data: any, event: KeyboardEvent, source: any): boolean => {
     if (event.keyCode === KeyCodes.Enter || event.keyCode === KeyCodes.Space) {
       this.removeItem(data, event);
-      document.querySelector(".dynamicListItem:last-of-type input").focus();
+      (document.querySelector(".dynamicListItem:last-of-type input") as HTMLElement).focus();
       event.stopPropagation();
       return false;
     }
@@ -95,7 +95,7 @@ export class DynamicListViewModel extends WaitsForTemplateViewModel {
 
   public addItem(): void {
     this.listItems.push({ value: ko.observable("") });
-    document.querySelector(".dynamicListItem:last-of-type input").focus();    
+    (document.querySelector(".dynamicListItem:last-of-type input") as HTMLElement).focus();
   }
 
   public onAddItemKeyPress = (source: any, event: KeyboardEvent): boolean => {

--- a/src/Explorer/Controls/DynamicList/DynamicListComponent.ts
+++ b/src/Explorer/Controls/DynamicList/DynamicListComponent.ts
@@ -86,6 +86,7 @@ export class DynamicListViewModel extends WaitsForTemplateViewModel {
   public onRemoveItemKeyPress = (data: any, event: KeyboardEvent, source: any): boolean => {
     if (event.keyCode === KeyCodes.Enter || event.keyCode === KeyCodes.Space) {
       this.removeItem(data, event);
+      document.querySelector(".dynamicListItem:last-of-type input").focus();
       event.stopPropagation();
       return false;
     }
@@ -94,7 +95,7 @@ export class DynamicListViewModel extends WaitsForTemplateViewModel {
 
   public addItem(): void {
     this.listItems.push({ value: ko.observable("") });
-    document.getElementById("uniqueKeyItems").focus();
+    document.querySelector(".dynamicListItem:last-of-type input").focus();    
   }
 
   public onAddItemKeyPress = (source: any, event: KeyboardEvent): boolean => {


### PR DESCRIPTION
A11Y Bug 835065

After pressing enter key on the remove item control, then the visual focus indicator should move to the edit field. 
Also did the same when adding a key as it is annoying to tab until I get to the newly added input to enter my path.