### PR TITLE
[Accessibility] Add horizontal scroll bar if tooltip box goes outside of panel boundary

### DIFF
--- a/less/documentDB.less
+++ b/less/documentDB.less
@@ -1739,7 +1739,7 @@ input::-webkit-calendar-picker-indicator {
     padding-right: 34px;
     color: @BaseDark;
     overflow-y: auto;
-    overflow-x: hidden;
+    overflow-x: auto;
     margin: (2 * @MediumSpace) 0px;
 }
 


### PR DESCRIPTION
Currently if we apply text spacing, the tooltip of the info icon goes outside of the boundary of the add collection panel and becomes partially invisible:
![image](https://user-images.githubusercontent.com/56978073/93435169-e41e1a80-f87d-11ea-8858-e90300132643.png)

In order to show the complete tooltip, we can either add a horizontal scroll bar or remove the `width` and `min-width` setting of the tooltip. However, the latter fix will also make the width of the tooltip box too narrow when text spacing is off so I think the best fix is to simply add a horizontal scroll bar by changing the horizontal overflow from `hidden` to `auto`.