### PR TITLE
Fix inaccessible link by keyboard nav in info bubble

### DIFF
--- a/src/Explorer/Panes/AddCollectionPane.html
+++ b/src/Explorer/Panes/AddCollectionPane.html
@@ -517,13 +517,13 @@
                   <div>
                       <span class="mandatoryStar">*</span>
                       <span class="addCollectionLabel">Analytical store</span>
-                      <span class="infoTooltip" role="tooltip" tabindex="0">
+                      <span class="infoTooltip" role="tooltip" tabindex="0" data-bind="event: { focus: function(data, event) { transferFocus('tooltip1', 'link1') } }">
                           <img class="infoImg" src="/info-bubble.svg" alt="More information">
-                          <span class="tooltiptext infoTooltipWidth">
+                          <span id="tooltip1" class="tooltiptext infoTooltipWidth" data-bind="event: { mouseout: onMouseOut }">
                               Enable analytical store capability to perform near real-time analytics on your operational
                               data, without impacting the performance of transactional workloads.
-                              Learn more <a class="errorLink" href="https://aka.ms/analytical-store-overview"
-                                  target="_blank">here</a>
+                              Learn more <a id="link1" class="errorLink" href="https://aka.ms/analytical-store-overview"
+                                  target="_blank" data-bind="event: { focusout: onFocusOut }">here</a>
                           </span>
                       </span>
                   </div>

--- a/src/Explorer/Panes/AddCollectionPane.html
+++ b/src/Explorer/Panes/AddCollectionPane.html
@@ -523,7 +523,7 @@
                               Enable analytical store capability to perform near real-time analytics on your operational
                               data, without impacting the performance of transactional workloads.
                               Learn more <a id="link1" class="errorLink" href="https://aka.ms/analytical-store-overview"
-                                  target="_blank" data-bind="event: { focusout: onFocusOut }">here</a>
+                                  target="_blank" data-bind="event: { focusout: onFocusOut, keydown: onKeyDown.bind($data, 'largePartitionKey') }">here</a>
                           </span>
                       </span>
                   </div>

--- a/src/Explorer/Panes/AddCollectionPane.ts
+++ b/src/Explorer/Panes/AddCollectionPane.ts
@@ -721,6 +721,19 @@ export default class AddCollectionPane extends ContextualPaneBase {
     TelemetryProcessor.trace(Action.CreateCollection, ActionModifiers.Open, addCollectionPaneOpenMessage);
   }
 
+  private transferFocus(elementIdToKeepVisible: string, elementIdToFocus: string): void {
+    document.getElementById(elementIdToKeepVisible).style.visibility = "visible";
+    document.getElementById(elementIdToFocus).focus();
+  }
+
+  private onFocusOut(_: any, event: any): void {
+    event.target.parentElement.style.visibility = "";
+  }
+
+  private onMouseOut(_: any, event: any): void {
+    event.target.style.visibility = "";
+  }
+
   private _onDatabasesChange(newDatabaseIds: ViewModels.Database[]) {
     const cachedDatabaseIdsList = _.map(newDatabaseIds, (database: ViewModels.Database) => {
       if (database && database.offer && database.offer()) {

--- a/src/Explorer/Panes/AddCollectionPane.ts
+++ b/src/Explorer/Panes/AddCollectionPane.ts
@@ -734,6 +734,16 @@ export default class AddCollectionPane extends ContextualPaneBase {
     event.target.style.visibility = "";
   }
 
+  private onKeyDown(previousActiveElementId: string, _: any, event: KeyboardEvent): boolean {
+    if (event.shiftKey && event.keyCode == Constants.KeyCodes.Tab) {
+      document.getElementById(previousActiveElementId).focus();
+      return false;
+    } else {
+      // Execute default action
+      return true;
+    }
+  }
+
   private _onDatabasesChange(newDatabaseIds: ViewModels.Database[]) {
     const cachedDatabaseIdsList = _.map(newDatabaseIds, (database: ViewModels.Database) => {
       if (database && database.offer && database.offer()) {


### PR DESCRIPTION
The "New Container" pane contains info bubbles next to some inputs: there's an (i) display that can be hovered over or focused to show/hide the bubble text.
The info bubble text is made visible/not visible by CSS using `:hover` and `:focus` pseudo-classes.

One info bubble text contains a hyper-link. Using the mouse and hovering over the (i) will show the text which will stay visible when moving the mouse to the link, because the link is a child of a `:hover`'ed text.
This is not the case with keyboard navigation (tab key to move focus). First the text will appear, because (i) is focused. When hitting Tab again, the text will disappear and focus will move to the next element in the form, instead of the hyperlink (which is now hidden), because of the css rule that only shows the text when (i) is focused (or hovered on).

The original design was not meant to handle active items inside the info bubble, but since it works for mouse, I've opted for a minimally invasive fix to make it work for keyboard nav with the existing css rule, rather than refactoring the entire css rules for all the info bubbles (by either introducing classnames or using some library).

The fix maintains the info bubble visible when focusing on the (i) with Tab and automatically moves the focus to the link.
It works with one link inside the bubble. The bubble disappears as expected when focus is lost except under one scenario:
- user mouses over another info bubble (you'll see two info bubbles)
Otherwise, mouse behavior is the same as before.

I think this is good enough to ship, until we port this to react. Also, this design allows other bubbles to do the same.
