### PR TITLE
Tabbing Fix on CreateCollection pane

### DIFF
--- a/src/Explorer/Panes/AddCollectionPane.html
+++ b/src/Explorer/Panes/AddCollectionPane.html
@@ -522,7 +522,7 @@
                           <span class="tooltiptext infoTooltipWidth">
                               Enable analytical store capability to perform near real-time analytics on your operational
                               data, without impacting the performance of transactional workloads.
-                              Learn more <a class="errorLink" href="https://aka.ms/analytical-store-overview"
+                              Learn more <a class="errorLink" tabindex="-1" href="https://aka.ms/analytical-store-overview"
                                   target="_blank">here</a>
                           </span>
                       </span>
@@ -569,7 +569,7 @@
                       Azure Synapse Link is required for creating an analytical
                       store container. Enable Synapse Link for this
                       Cosmos DB account.
-                      <span><a class="errorLink" href="https://aka.ms/cosmosdb-synapselink" target="_blank">Learn
+                      <span><a class="errorLink" tabindex="0" href="https://aka.ms/cosmosdb-synapselink" target="_blank">Learn
                               more</a></span>
                   </div>
 


### PR DESCRIPTION
- Fix for this bug :https://msdata.visualstudio.com/CosmosDB/_workitems/edit/835100/?triage=true
- Earlier, when analytical storage is not enabled, tabbing when focus is on the analytical storage tool tip does not immediately change focus to the "Learn More" anchor link
- This was because of the Anchor link present in the tool tip of analytical storage. The next tab press makes the tool tip disappear while trying to focus the anchor link in the tool tip, leading to a weird state.
- Fix was to remove the anchor link in the tooltip from the natural tabbing flow (added tabIndex="-1"), and add focus (tabindex="0") to the "Learn More" anchor link.