### PR TITLE
Fix incorrect usage of TelemetryProcessor

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -562,3 +562,11 @@ export class AnalyticalStorageTtl {
   public static readonly Infinite: number = -1;
   public static readonly Disabled: number = 0;
 }
+
+export class TerminalQueryParams {
+  public static readonly Terminal = "terminal";
+  public static readonly Server = "server";
+  public static readonly Token = "token";
+  public static readonly SubscriptionId = "subscriptionId";
+  public static readonly TerminalEndpoint = "terminalEndpoint";
+}

--- a/src/Common/MessageHandler.test.ts
+++ b/src/Common/MessageHandler.test.ts
@@ -25,34 +25,4 @@ describe("Message Handler", () => {
     MessageHandler.runGarbageCollector();
     expect(MessageHandler.RequestMap["123"]).toBeUndefined();
   });
-
-  describe("getDataExplorerWindow", () => {
-    it("should return current window if current window has dataExplorerPlatform property", () => {
-      const currentWindow: Window = { dataExplorerPlatform: 0 } as any;
-
-      expect(MessageHandler.getDataExplorerWindow(currentWindow)).toEqual(currentWindow);
-    });
-
-    it("should return current window's parent if current window's parent has dataExplorerPlatform property", () => {
-      const parentWindow: Window = { dataExplorerPlatform: 0 } as any;
-      const currentWindow: Window = { parent: parentWindow } as any;
-
-      expect(MessageHandler.getDataExplorerWindow(currentWindow)).toEqual(parentWindow);
-    });
-
-    it("should return undefined if none of the windows in the hierarchy have dataExplorerPlatform property and window's parent is reference to itself", () => {
-      const parentWindow: Window = {} as any;
-      (parentWindow as any).parent = parentWindow; // If a window does not have a parent, its parent property is a reference to itself.
-      const currentWindow: Window = { parent: parentWindow } as any;
-
-      expect(MessageHandler.getDataExplorerWindow(currentWindow)).toBeUndefined();
-    });
-
-    it("should return undefined if none of the windows in the hierarchy have dataExplorerPlatform property and window's parent is not defined", () => {
-      const parentWindow: Window = {} as any;
-      const currentWindow: Window = { parent: parentWindow } as any;
-
-      expect(MessageHandler.getDataExplorerWindow(currentWindow)).toBeUndefined();
-    });
-  });
 });

--- a/src/Common/MessageHandler.ts
+++ b/src/Common/MessageHandler.ts
@@ -2,6 +2,7 @@ import { MessageTypes } from "../Contracts/ExplorerContracts";
 import Q from "q";
 import * as _ from "underscore";
 import * as Constants from "./Constants";
+import { getDataExplorerWindow } from "../Utils/WindowUtils";
 
 export interface CachedDataPromise<T> {
   deferred: Q.Deferred<T>;
@@ -60,25 +61,6 @@ export function sendMessage(data: any): void {
     }
   }
 }
-
-// Only exported for unit tests
-export const getDataExplorerWindow = (currentWindow: Window): Window | undefined => {
-  // Start with the current window and traverse up the parent hierarchy to find a window
-  // with `dataExplorerPlatform` property
-  let dataExplorerWindow: Window | undefined = currentWindow;
-  // TODO: Need to `any` here since the window imports Explorer which can't be in strict mode yet
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  while (dataExplorerWindow && (dataExplorerWindow as any).dataExplorerPlatform == undefined) {
-    // If a window does not have a parent, its parent property is a reference to itself.
-    if (dataExplorerWindow.parent == dataExplorerWindow) {
-      dataExplorerWindow = undefined;
-    } else {
-      dataExplorerWindow = dataExplorerWindow.parent;
-    }
-  }
-
-  return dataExplorerWindow;
-};
 
 export function canSendMessage(): boolean {
   return window.parent !== window;

--- a/src/Explorer/Controls/Notebook/NotebookTerminalComponent.tsx
+++ b/src/Explorer/Controls/Notebook/NotebookTerminalComponent.tsx
@@ -9,6 +9,7 @@ import * as NotificationConsoleUtils from "../../../Utils/NotificationConsoleUti
 import { ConsoleDataType } from "../../Menus/NotificationConsole/NotificationConsoleComponent";
 import { StringUtils } from "../../../Utils/StringUtils";
 import { userContext } from "../../../UserContext";
+import { TerminalQueryParams } from "../../../Common/Constants";
 
 export interface NotebookTerminalComponentProps {
   notebookServerInfo: DataModels.NotebookWorkspaceConnectionInfo;
@@ -33,11 +34,11 @@ export class NotebookTerminalComponent extends React.Component<NotebookTerminalC
 
   public getTerminalParams(): Map<string, string> {
     let params: Map<string, string> = new Map<string, string>();
-    params.set("terminal", "true");
+    params.set(TerminalQueryParams.Terminal, "true");
 
     const terminalEndpoint: string = this.tryGetTerminalEndpoint();
     if (terminalEndpoint) {
-      params.set("terminalEndpoint", terminalEndpoint);
+      params.set(TerminalQueryParams.TerminalEndpoint, terminalEndpoint);
     }
 
     return params;
@@ -76,12 +77,12 @@ export class NotebookTerminalComponent extends React.Component<NotebookTerminalC
       return "";
     }
 
-    params.set("server", serverInfo.notebookServerEndpoint);
+    params.set(TerminalQueryParams.Server, serverInfo.notebookServerEndpoint);
     if (serverInfo.authToken && serverInfo.authToken.length > 0) {
-      params.set("token", serverInfo.authToken);
+      params.set(TerminalQueryParams.Token, serverInfo.authToken);
     }
 
-    params.set("subscriptionId", userContext.subscriptionId);
+    params.set(TerminalQueryParams.SubscriptionId, userContext.subscriptionId);
 
     let result: string = "terminal.html?";
     for (let key of params.keys()) {

--- a/src/Explorer/Controls/Notebook/NotebookTerminalComponent.tsx
+++ b/src/Explorer/Controls/Notebook/NotebookTerminalComponent.tsx
@@ -8,6 +8,7 @@ import * as Logger from "../../../Common/Logger";
 import * as NotificationConsoleUtils from "../../../Utils/NotificationConsoleUtils";
 import { ConsoleDataType } from "../../Menus/NotificationConsole/NotificationConsoleComponent";
 import { StringUtils } from "../../../Utils/StringUtils";
+import { userContext } from "../../../UserContext";
 
 export interface NotebookTerminalComponentProps {
   notebookServerInfo: DataModels.NotebookWorkspaceConnectionInfo;
@@ -79,6 +80,8 @@ export class NotebookTerminalComponent extends React.Component<NotebookTerminalC
     if (serverInfo.authToken && serverInfo.authToken.length > 0) {
       params.set("token", serverInfo.authToken);
     }
+
+    params.set("subscriptionId", userContext.subscriptionId);
 
     let result: string = "terminal.html?";
     for (let key of params.keys()) {

--- a/src/Explorer/Panes/DeleteCollectionConfirmationPane.test.ts
+++ b/src/Explorer/Panes/DeleteCollectionConfirmationPane.test.ts
@@ -134,11 +134,9 @@ describe("Delete Collection Confirmation Pane", () => {
         expect(telemetryProcessorSpy.called).toBe(true);
         let deleteFeedback = new DeleteFeedback(SubscriptionId, AccountName, DataModels.ApiKind.SQL, Feedback);
         expect(
-          telemetryProcessorSpy.calledWith(
-            Action.DeleteCollection,
-            ActionModifiers.Mark,
-            JSON.stringify(deleteFeedback, Object.getOwnPropertyNames(deleteFeedback))
-          )
+          telemetryProcessorSpy.calledWith(Action.DeleteCollection, ActionModifiers.Mark, {
+            message: JSON.stringify(deleteFeedback, Object.getOwnPropertyNames(deleteFeedback))
+          })
         ).toBe(true);
       });
     });

--- a/src/Explorer/Panes/DeleteCollectionConfirmationPane.ts
+++ b/src/Explorer/Panes/DeleteCollectionConfirmationPane.ts
@@ -88,11 +88,9 @@ export default class DeleteCollectionConfirmationPane extends ContextualPaneBase
             this.containerDeleteFeedback()
           );
 
-          TelemetryProcessor.trace(
-            Action.DeleteCollection,
-            ActionModifiers.Mark,
-            JSON.stringify(deleteFeedback, Object.getOwnPropertyNames(deleteFeedback))
-          );
+          TelemetryProcessor.trace(Action.DeleteCollection, ActionModifiers.Mark, {
+            message: JSON.stringify(deleteFeedback, Object.getOwnPropertyNames(deleteFeedback))
+          });
 
           this.containerDeleteFeedback("");
         }

--- a/src/Explorer/Panes/DeleteDatabaseConfirmationPane.test.ts
+++ b/src/Explorer/Panes/DeleteDatabaseConfirmationPane.test.ts
@@ -120,11 +120,9 @@ describe("Delete Database Confirmation Pane", () => {
 
       return pane.submit().then(() => {
         let deleteFeedback = new DeleteFeedback(SubscriptionId, AccountName, DataModels.ApiKind.SQL, Feedback);
-        expect(TelemetryProcessor.trace).toHaveBeenCalledWith(
-          Action.DeleteDatabase,
-          ActionModifiers.Mark,
-          JSON.stringify(deleteFeedback, Object.getOwnPropertyNames(deleteFeedback))
-        );
+        expect(TelemetryProcessor.trace).toHaveBeenCalledWith(Action.DeleteDatabase, ActionModifiers.Mark, {
+          message: JSON.stringify(deleteFeedback, Object.getOwnPropertyNames(deleteFeedback))
+        });
       });
     });
   });

--- a/src/Explorer/Panes/DeleteDatabaseConfirmationPane.ts
+++ b/src/Explorer/Panes/DeleteDatabaseConfirmationPane.ts
@@ -97,11 +97,9 @@ export default class DeleteDatabaseConfirmationPane extends ContextualPaneBase {
             this.databaseDeleteFeedback()
           );
 
-          TelemetryProcessor.trace(
-            Action.DeleteDatabase,
-            ActionModifiers.Mark,
-            JSON.stringify(deleteFeedback, Object.getOwnPropertyNames(deleteFeedback))
-          );
+          TelemetryProcessor.trace(Action.DeleteDatabase, ActionModifiers.Mark, {
+            message: JSON.stringify(deleteFeedback, Object.getOwnPropertyNames(deleteFeedback))
+          });
 
           this.databaseDeleteFeedback("");
         }

--- a/src/Explorer/Tabs/MongoShellTab.ts
+++ b/src/Explorer/Tabs/MongoShellTab.ts
@@ -142,7 +142,7 @@ export default class MongoShellTab extends TabsBase {
       return;
     }
 
-    const dataToLog: string = event.data.data.logData;
+    const dataToLog = { message: event.data.data.logData };
     const logType: string = event.data.data.logType;
     const shellTraceId: string = event.data.data.traceId || "none";
 

--- a/src/Terminal/index.ts
+++ b/src/Terminal/index.ts
@@ -6,7 +6,8 @@ import { ServerConnection } from "@jupyterlab/services";
 import { JupyterLabAppFactory } from "./JupyterLabAppFactory";
 import { Action } from "../Shared/Telemetry/TelemetryConstants";
 import * as TelemetryProcessor from "../Shared/Telemetry/TelemetryProcessor";
-import { updateUserContext, userContext } from "../UserContext";
+import { updateUserContext } from "../UserContext";
+import { TerminalQueryParams } from "../Common/Constants";
 
 const getUrlVars = (): { [key: string]: string } => {
   const vars: { [key: string]: string } = {};
@@ -19,22 +20,22 @@ const getUrlVars = (): { [key: string]: string } => {
 
 const createServerSettings = (urlVars: { [key: string]: string }): ServerConnection.ISettings => {
   let body: BodyInit;
-  if (urlVars.hasOwnProperty("terminalEndpoint")) {
+  if (urlVars.hasOwnProperty(TerminalQueryParams.TerminalEndpoint)) {
     body = JSON.stringify({
-      endpoint: urlVars["terminalEndpoint"]
+      endpoint: urlVars[TerminalQueryParams.TerminalEndpoint]
     });
   }
 
-  const server = urlVars["server"];
+  const server = urlVars[TerminalQueryParams.Server];
   let options: Partial<ServerConnection.ISettings> = {
     baseUrl: server,
     init: { body },
     fetch: window.parent.fetch
   };
-  if (urlVars.hasOwnProperty("token")) {
+  if (urlVars.hasOwnProperty(TerminalQueryParams.Token)) {
     options = {
       baseUrl: server,
-      token: urlVars["token"],
+      token: urlVars[TerminalQueryParams.Token],
       init: { body },
       fetch: window.parent.fetch
     };
@@ -48,7 +49,7 @@ const main = async (): Promise<void> => {
 
   // Initialize userContext. Currently only subscrptionId is required by TelemetryProcessor
   updateUserContext({
-    subscriptionId: urlVars["subscriptionId"]
+    subscriptionId: urlVars[TerminalQueryParams.SubscriptionId]
   });
 
   const serverSettings = createServerSettings(urlVars);
@@ -58,7 +59,7 @@ const main = async (): Promise<void> => {
   });
 
   try {
-    if (urlVars.hasOwnProperty("terminal")) {
+    if (urlVars.hasOwnProperty(TerminalQueryParams.Terminal)) {
       await JupyterLabAppFactory.createTerminalApp(serverSettings);
     } else {
       throw new Error("Only terminal is supported");

--- a/src/Terminal/index.ts
+++ b/src/Terminal/index.ts
@@ -6,6 +6,7 @@ import { ServerConnection } from "@jupyterlab/services";
 import { JupyterLabAppFactory } from "./JupyterLabAppFactory";
 import { Action } from "../Shared/Telemetry/TelemetryConstants";
 import * as TelemetryProcessor from "../Shared/Telemetry/TelemetryProcessor";
+import { updateUserContext, userContext } from "../UserContext";
 
 const getUrlVars = (): { [key: string]: string } => {
   const vars: { [key: string]: string } = {};
@@ -44,6 +45,12 @@ const createServerSettings = (urlVars: { [key: string]: string }): ServerConnect
 
 const main = async (): Promise<void> => {
   const urlVars = getUrlVars();
+
+  // Initialize userContext. Currently only subscrptionId is required by TelemetryProcessor
+  updateUserContext({
+    subscriptionId: urlVars["subscriptionId"]
+  });
+
   const serverSettings = createServerSettings(urlVars);
 
   const startTime = TelemetryProcessor.traceStart(Action.OpenTerminal, {

--- a/src/Utils/WindowUtils.test.ts
+++ b/src/Utils/WindowUtils.test.ts
@@ -1,0 +1,49 @@
+import { getDataExplorerWindow } from "./WindowUtils";
+
+const createWindow = (dataExplorerPlatform: unknown, parent: Window): Window => {
+  // TODO: Need to `any` here since we're creating a mock window object
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mockWindow: any = {};
+  if (dataExplorerPlatform !== undefined) {
+    mockWindow.dataExplorerPlatform = dataExplorerPlatform;
+  }
+  if (parent) {
+    mockWindow.parent = parent;
+  }
+  return mockWindow;
+};
+
+describe("WindowUtils", () => {
+  describe("getDataExplorerWindow", () => {
+    it("should return current window if current window has dataExplorerPlatform property", () => {
+      const currentWindow = createWindow(0, undefined);
+
+      expect(getDataExplorerWindow(currentWindow)).toEqual(currentWindow);
+    });
+
+    it("should return current window's parent if current window's parent has dataExplorerPlatform property", () => {
+      const parentWindow = createWindow(0, undefined);
+      const currentWindow = createWindow(undefined, parentWindow);
+
+      expect(getDataExplorerWindow(currentWindow)).toEqual(parentWindow);
+    });
+
+    it("should return undefined if none of the windows in the hierarchy have dataExplorerPlatform property and window's parent is reference to itself", () => {
+      const parentWindow = createWindow(undefined, undefined);
+
+      // TODO: Need to `any` here since parent is a readonly property
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (parentWindow as any).parent = parentWindow; // If a window does not have a parent, its parent property is a reference to itself.
+      const currentWindow = createWindow(undefined, parentWindow);
+
+      expect(getDataExplorerWindow(currentWindow)).toBeUndefined();
+    });
+
+    it("should return undefined if none of the windows in the hierarchy have dataExplorerPlatform property and window's parent is not defined", () => {
+      const parentWindow = createWindow(undefined, undefined);
+      const currentWindow = createWindow(undefined, parentWindow);
+
+      expect(getDataExplorerWindow(currentWindow)).toBeUndefined();
+    });
+  });
+});

--- a/src/Utils/WindowUtils.ts
+++ b/src/Utils/WindowUtils.ts
@@ -1,0 +1,17 @@
+export const getDataExplorerWindow = (currentWindow: Window): Window | undefined => {
+  // Start with the current window and traverse up the parent hierarchy to find a window
+  // with `dataExplorerPlatform` property
+  let dataExplorerWindow: Window | undefined = currentWindow;
+  // TODO: Need to `any` here since the window imports Explorer which can't be in strict mode yet
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  while (dataExplorerWindow && (dataExplorerWindow as any).dataExplorerPlatform === undefined) {
+    // If a window does not have a parent, its parent property is a reference to itself.
+    if (dataExplorerWindow.parent === dataExplorerWindow) {
+      dataExplorerWindow = undefined;
+    } else {
+      dataExplorerWindow = dataExplorerWindow.parent;
+    }
+  }
+
+  return dataExplorerWindow;
+};


### PR DESCRIPTION
In TelemetryProcessor's traceSuccess there are 2 optional parameters with the first one being unknown type. This lead to some incorrect usage of TelemetryProcessor functions.

- Remove unknown parameter type from TelemetryProcessor functions to catch incorrect usage at compile time
- Update TelemetryProcessor.getData to work for iframes

This fixes the issue where OpenTerminal log doesn't contain "success" actionModifier