### PR TITLE
Fix resource tree refresh issue

### DIFF
--- a/src/Explorer/Tree/Database.ts
+++ b/src/Explorer/Tree/Database.ts
@@ -290,6 +290,10 @@ export default class Database implements ViewModels.Database {
   }
 
   private deleteCollectionsFromList(collectionsToRemove: Collection[]): void {
+    if (collectionsToRemove.length === 0) {
+      return;
+    }
+
     const collectionsToKeep: Collection[] = [];
 
     ko.utils.arrayForEach(this.collections(), (collection: Collection) => {

--- a/src/Explorer/Tree/ResourceTreeAdapter.tsx
+++ b/src/Explorer/Tree/ResourceTreeAdapter.tsx
@@ -64,7 +64,7 @@ export class ResourceTreeAdapter implements ReactAdapter {
 
     this.container.nonSystemDatabases.subscribe((databases: ViewModels.Database[]) => {
       // Clean up old databases
-      this.cleanupDatabasesKoSubs(databases.map((database: ViewModels.Database) => database.id()));
+      this.cleanupDatabasesKoSubs();
 
       databases.forEach((database: ViewModels.Database) => this.watchDatabase(database));
       this.triggerRender();
@@ -799,12 +799,10 @@ export class ResourceTreeAdapter implements ReactAdapter {
     this.koSubsCollectionIdMap.push(collectionId, sub);
   }
 
-  private cleanupDatabasesKoSubs(existingDatabaseIds: string[]): void {
-    existingDatabaseIds.forEach((databaseId: string) => {
-      if (this.koSubsDatabaseIdMap.has(databaseId)) {
-        this.koSubsDatabaseIdMap.get(databaseId).forEach((sub: ko.Subscription) => sub.dispose());
-        this.koSubsDatabaseIdMap.delete(databaseId);
-      }
+  private cleanupDatabasesKoSubs(): void {
+    this.koSubsDatabaseIdMap.keys().forEach((databaseId: string) => {
+      this.koSubsDatabaseIdMap.get(databaseId).forEach((sub: ko.Subscription) => sub.dispose());
+      this.koSubsDatabaseIdMap.delete(databaseId);
 
       if (this.databaseCollectionIdMap.has(databaseId)) {
         this.databaseCollectionIdMap

--- a/src/Explorer/Tree/ResourceTreeAdapter.tsx
+++ b/src/Explorer/Tree/ResourceTreeAdapter.tsx
@@ -800,11 +800,7 @@ export class ResourceTreeAdapter implements ReactAdapter {
   }
 
   private cleanupDatabasesKoSubs(existingDatabaseIds: string[]): void {
-    const databaseIdsToRemove = this.databaseCollectionIdMap
-      .keys()
-      .filter((id: string) => existingDatabaseIds.indexOf(id) === -1);
-
-    databaseIdsToRemove.forEach((databaseId: string) => {
+    existingDatabaseIds.forEach((databaseId: string) => {
       if (this.koSubsDatabaseIdMap.has(databaseId)) {
         this.koSubsDatabaseIdMap.get(databaseId).forEach((sub: ko.Subscription) => sub.dispose());
         this.koSubsDatabaseIdMap.delete(databaseId);

--- a/test/container.spec.ts
+++ b/test/container.spec.ts
@@ -1,10 +1,10 @@
 import "expect-puppeteer";
-import crypto from 'crypto'
+import crypto from "crypto";
 
 jest.setTimeout(300000);
 
-describe('Collection Add and Delete SQL spec', () => {
-  it('creates a collection', async () => {
+describe("Collection Add and Delete SQL spec", () => {
+  it("creates a collection", async () => {
     try {
       const dbId = `TestDatabase${crypto.randomBytes(8).toString("hex")}`;
       const collectionId = `TestCollection${crypto.randomBytes(8).toString("hex")}`;
@@ -13,11 +13,10 @@ describe('Collection Add and Delete SQL spec', () => {
       page.goto(prodUrl);
 
       // log in with connection string
-      const handle = await page.waitForSelector('iframe');
+      const handle = await page.waitForSelector("iframe");
       const frame = await handle.contentFrame();
-      await frame.waitFor('div > p.switchConnectTypeText', { visible: true });
-      await frame.click('div > p.switchConnectTypeText');
-      const connStr = process.env.PORTAL_RUNNER_CONNECTION_STRING;
+      await frame.waitFor("div > p.switchConnectTypeText", { visible: true });
+      await frame.click("div > p.switchConnectTypeText");
       await frame.type("input[class='inputToken']", connStr);
       await frame.click("input[value='Connect']");
 
@@ -25,30 +24,30 @@ describe('Collection Add and Delete SQL spec', () => {
       await frame.waitFor('button[data-test="New Container"]', { visible: true });
       await frame.waitForSelector('div[class="splashScreen"] > div[class="title"]', { visible: true });
       await frame.click('button[data-test="New Container"]');
-      
+
       // check new database
       await frame.waitFor('input[data-test="addCollection-createNewDatabase"]');
       await frame.click('input[data-test="addCollection-createNewDatabase"]');
 
       // check shared throughput
       await frame.waitFor('input[data-test="addCollectionPane-databaseSharedThroughput"]');
-      await frame.click('input[data-test="addCollectionPane-databaseSharedThroughput"]')   ;   
+      await frame.click('input[data-test="addCollectionPane-databaseSharedThroughput"]');
 
       // type database id
       await frame.waitFor('input[data-test="addCollection-newDatabaseId"]');
-      await frame.type('input[data-test="addCollection-newDatabaseId"]', dbId);      
+      await frame.type('input[data-test="addCollection-newDatabaseId"]', dbId);
 
       // type collection id
       await frame.waitFor('input[data-test="addCollection-collectionId"]');
-      await frame.type('input[data-test="addCollection-collectionId"]', collectionId); 
+      await frame.type('input[data-test="addCollection-collectionId"]', collectionId);
 
       // type partition key value
       await frame.waitFor('input[data-test="addCollection-partitionKeyValue"]');
       await frame.type('input[data-test="addCollection-partitionKeyValue"]', sharedKey);
 
       // click submit
-      await frame.waitFor('#submitBtnAddCollection');
-      await frame.click('#submitBtnAddCollection');
+      await frame.waitFor("#submitBtnAddCollection");
+      await frame.click("#submitBtnAddCollection");
 
       // validate created
       // open database menu
@@ -57,26 +56,24 @@ describe('Collection Add and Delete SQL spec', () => {
 
       await frame.click(`div[data-test="${dbId}"]`);
       await frame.waitFor(`span[title="${collectionId}"]`, { visible: true });
-      await frame.waitFor(3000)
-      await frame.waitFor(`span[title="${collectionId}"]`, { visible: true });
-      
+
       // delete container
 
       // click context menu for container
       await frame.waitFor(`div[data-test="${collectionId}"] > div > button`, { visible: true });
       await frame.waitFor(`span[title="${collectionId}"]`, { visible: true });
       await frame.click(`div[data-test="${collectionId}"] > div > button`);
-      await frame.waitFor(2000)
+
       // click delete container
       await frame.waitFor('span[class="treeComponentMenuItemLabel deleteCollectionMenuItemLabel"]', { visible: true });
       await frame.click('span[class="treeComponentMenuItemLabel deleteCollectionMenuItemLabel"]');
 
       // confirm delete container
-      await frame.waitFor('input[data-test="confirmCollectionId"]', { visible: true })
+      await frame.waitFor('input[data-test="confirmCollectionId"]', { visible: true });
       await frame.type('input[data-test="confirmCollectionId"]', collectionId.trim());
 
       // click delete
-      await frame.waitFor('input[data-test="deleteCollection"]', { visible: true })
+      await frame.waitFor('input[data-test="deleteCollection"]', { visible: true });
       await frame.click('input[data-test="deleteCollection"]');
       await frame.waitFor(5000);
       await frame.waitForSelector('div[class="splashScreen"] > div[class="title"]', { visible: true });
@@ -101,8 +98,8 @@ describe('Collection Add and Delete SQL spec', () => {
       await frame.waitForSelector('div[class="splashScreen"] > div[class="title"]', { visible: true });
       await expect(page).not.toMatchElement(`div[data-test="${dbId}"]`);
     } catch (error) {
-      await page.screenshot({path: 'failure.png'});
+      await page.screenshot({ path: "failure.png" });
       throw error;
-    } 
-  }) 
-})
+    }
+  });
+});

--- a/test/container.spec.ts
+++ b/test/container.spec.ts
@@ -56,6 +56,7 @@ describe("Collection Add and Delete SQL spec", () => {
       await frame.waitForSelector('div[class="splashScreen"] > div[class="title"]', { visible: true });
 
       await frame.click(`div[data-test="${dbId}"]`);
+      await frame.waitFor(3000)
       await frame.waitFor(`span[title="${collectionId}"]`, { visible: true });
 
       // delete container

--- a/test/container.spec.ts
+++ b/test/container.spec.ts
@@ -17,6 +17,7 @@ describe("Collection Add and Delete SQL spec", () => {
       const frame = await handle.contentFrame();
       await frame.waitFor("div > p.switchConnectTypeText", { visible: true });
       await frame.click("div > p.switchConnectTypeText");
+      const connStr = process.env.PORTAL_RUNNER_CONNECTION_STRING;
       await frame.type("input[class='inputToken']", connStr);
       await frame.click("input[value='Connect']");
 

--- a/test/container.spec.ts
+++ b/test/container.spec.ts
@@ -64,6 +64,7 @@ describe("Collection Add and Delete SQL spec", () => {
       await frame.waitFor(`div[data-test="${collectionId}"] > div > button`, { visible: true });
       await frame.waitFor(`span[title="${collectionId}"]`, { visible: true });
       await frame.click(`div[data-test="${collectionId}"] > div > button`);
+      await frame.waitFor(2000)
 
       // click delete container
       await frame.waitFor('span[class="treeComponentMenuItemLabel deleteCollectionMenuItemLabel"]', { visible: true });


### PR DESCRIPTION
Currently the resource tree would re-render a total of 5 times when a database node is expanded. 

The first two re-renders are triggered when:
1. A node is selected (expanding a database node also selects it).
2. The collections of a database have finished loading.

The second re-render is expected. The resource tree must re-render after the collections have been loaded. The first one is also necessary because when a node is selected, we not only need to highlight the selected node, but we also need to remove the hightlighting from the previous selected node.

The third re-render is also triggered by loading the collections. This is because we have a duplicate subscription to `database.collections`. The `cleanupDatabasesKoSubs` function is supposed to remove any duplicate subscriptions but due to a bug in the code, it never does.

The fourth and fifth re-render are both triggered by `Database.deleteCollectionsFromList`. However, in the case of expanding a database node, there's no collection to delete. It still triggers a re-render because it doesn't check if the collections to delete array is empty. Then the fifth re-render is triggered because of the duplicate subscription issue.

This PR will remove the last three re-renders by properly cleaning up duplicate subscriptions and adding a check to see if there's no collection to delete.



