### PR TITLE
Fix some content becomes hidden after zooming to 200%

### DIFF
--- a/less/documentDB.less
+++ b/less/documentDB.less
@@ -2078,7 +2078,7 @@ a:link {
 .resourceTreeAndTabs {
     display: flex;
     flex: 1 1 auto;
-    overflow: hidden;
+    overflow: auto;
     height: 100%;
 }
 


### PR DESCRIPTION
After zooming to 200%, some content on the right side of data explorer becomes hidden and there's no horizontal scroll bar to make it visible. This PR adds a scroll bar to allow users to access the hidden content.