### PR TITLE
Cleanup extension endpoint loading

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -170,89 +170,8 @@ export enum MongoBackendEndpointType {
   remote
 }
 
-export class MongoBackend {
-  public static localhostEndpoint: string = "/api/mongo/explorer";
-  public static centralUsEndpoint: string = "https://main.documentdb.ext.azure.com/api/mongo/explorer";
-  public static northEuropeEndpoint: string = "https://main.documentdb.ext.azure.com/api/mongo/explorer";
-  public static southEastAsiaEndpoint: string = "https://main.documentdb.ext.azure.com/api/mongo/explorer";
-
-  public static endpointsByRegion: any = {
-    default: MongoBackend.centralUsEndpoint,
-    northeurope: MongoBackend.northEuropeEndpoint,
-    ukwest: MongoBackend.northEuropeEndpoint,
-    uksouth: MongoBackend.northEuropeEndpoint,
-    westeurope: MongoBackend.northEuropeEndpoint,
-    australiaeast: MongoBackend.southEastAsiaEndpoint,
-    australiasoutheast: MongoBackend.southEastAsiaEndpoint,
-    centralindia: MongoBackend.southEastAsiaEndpoint,
-    eastasia: MongoBackend.southEastAsiaEndpoint,
-    japaneast: MongoBackend.southEastAsiaEndpoint,
-    japanwest: MongoBackend.southEastAsiaEndpoint,
-    koreacentral: MongoBackend.southEastAsiaEndpoint,
-    koreasouth: MongoBackend.southEastAsiaEndpoint,
-    southeastasia: MongoBackend.southEastAsiaEndpoint,
-    southindia: MongoBackend.southEastAsiaEndpoint,
-    westindia: MongoBackend.southEastAsiaEndpoint
-  };
-
-  public static endpointsByEnvironment: any = {
-    default: MongoBackendEndpointType.local,
-    localhost: MongoBackendEndpointType.local,
-    prod1: MongoBackendEndpointType.remote,
-    prod2: MongoBackendEndpointType.remote
-  };
-}
-
 // TODO: 435619 Add default endpoints per cloud and use regional only when available
 export class CassandraBackend {
-  public static readonly localhostEndpoint: string = "https://localhost:12901/";
-  public static readonly devEndpoint: string = "https://platformproxycassandradev.azurewebsites.net/";
-
-  public static readonly centralUsEndpoint: string = "https://main.documentdb.ext.azure.com/";
-  public static readonly northEuropeEndpoint: string = "https://main.documentdb.ext.azure.com/";
-  public static readonly southEastAsiaEndpoint: string = "https://main.documentdb.ext.azure.com/";
-
-  public static readonly bf_default: string = "https://main.documentdb.ext.microsoftazure.de/";
-  public static readonly mc_default: string = "https://main.documentdb.ext.azure.cn/";
-  public static readonly ff_default: string = "https://main.documentdb.ext.azure.us/";
-
-  public static readonly endpointsByRegion: any = {
-    default: CassandraBackend.centralUsEndpoint,
-    northeurope: CassandraBackend.northEuropeEndpoint,
-    ukwest: CassandraBackend.northEuropeEndpoint,
-    uksouth: CassandraBackend.northEuropeEndpoint,
-    westeurope: CassandraBackend.northEuropeEndpoint,
-    australiaeast: CassandraBackend.southEastAsiaEndpoint,
-    australiasoutheast: CassandraBackend.southEastAsiaEndpoint,
-    centralindia: CassandraBackend.southEastAsiaEndpoint,
-    eastasia: CassandraBackend.southEastAsiaEndpoint,
-    japaneast: CassandraBackend.southEastAsiaEndpoint,
-    japanwest: CassandraBackend.southEastAsiaEndpoint,
-    koreacentral: CassandraBackend.southEastAsiaEndpoint,
-    koreasouth: CassandraBackend.southEastAsiaEndpoint,
-    southeastasia: CassandraBackend.southEastAsiaEndpoint,
-    southindia: CassandraBackend.southEastAsiaEndpoint,
-    westindia: CassandraBackend.southEastAsiaEndpoint,
-
-    // Black Forest
-    germanycentral: CassandraBackend.bf_default,
-    germanynortheast: CassandraBackend.bf_default,
-
-    // Fairfax
-    usdodeast: CassandraBackend.ff_default,
-    usdodcentral: CassandraBackend.ff_default,
-    usgovarizona: CassandraBackend.ff_default,
-    usgoviowa: CassandraBackend.ff_default,
-    usgovtexas: CassandraBackend.ff_default,
-    usgovvirginia: CassandraBackend.ff_default,
-
-    // Mooncake
-    chinaeast: CassandraBackend.mc_default,
-    chinaeast2: CassandraBackend.mc_default,
-    chinanorth: CassandraBackend.mc_default,
-    chinanorth2: CassandraBackend.mc_default
-  };
-
   public static readonly createOrDeleteApi: string = "api/cassandra/createordelete";
   public static readonly guestCreateOrDeleteApi: string = "api/guest/cassandra/createordelete";
   public static readonly queryApi: string = "api/cassandra";

--- a/src/Common/EnvironmentUtility.ts
+++ b/src/Common/EnvironmentUtility.ts
@@ -1,49 +1,8 @@
-import * as Constants from "../Common/Constants";
-import * as ViewModels from "../Contracts/ViewModels";
-import { AuthType } from "../AuthType";
-import { StringUtils } from "../Utils/StringUtils";
-import Explorer from "../Explorer/Explorer";
-
 export default class EnvironmentUtility {
-  public static getMongoBackendEndpoint(serverId: string, location: string, extensionEndpoint: string = ""): string {
-    const defaultEnvironment: string = "default";
-    const defaultLocation: string = "default";
-    let environment: string = serverId;
-    const endpointType: Constants.MongoBackendEndpointType =
-      Constants.MongoBackend.endpointsByEnvironment[environment] ||
-      Constants.MongoBackend.endpointsByEnvironment[defaultEnvironment];
-    if (endpointType === Constants.MongoBackendEndpointType.local) {
-      return `${extensionEndpoint}${Constants.MongoBackend.localhostEndpoint}`;
-    }
-
-    const normalizedLocation = EnvironmentUtility.normalizeRegionName(location);
-    return (
-      Constants.MongoBackend.endpointsByRegion[normalizedLocation] ||
-      Constants.MongoBackend.endpointsByRegion[defaultLocation]
-    );
-  }
-
-  public static isAadUser(): boolean {
-    return window.authType === AuthType.AAD;
-  }
-
-  public static getCassandraBackendEndpoint(explorer: Explorer): string {
-    const defaultLocation: string = "default";
-    const location: string = EnvironmentUtility.normalizeRegionName(explorer.databaseAccount().location);
-    return (
-      Constants.CassandraBackend.endpointsByRegion[location] ||
-      Constants.CassandraBackend.endpointsByRegion[defaultLocation]
-    );
-  }
-
   public static normalizeArmEndpointUri(uri: string): string {
     if (uri && uri.slice(-1) !== "/") {
       return `${uri}/`;
     }
     return uri;
-  }
-
-  private static normalizeRegionName(region: string): string {
-    return region && StringUtils.stripSpacesFromString(region.toLocaleLowerCase());
   }
 }

--- a/src/Common/MongoProxyClient.test.ts
+++ b/src/Common/MongoProxyClient.test.ts
@@ -1,9 +1,8 @@
 import { AuthType } from "../AuthType";
-import { configContext, resetConfigContext, updateConfigContext } from "../ConfigContext";
+import { resetConfigContext, updateConfigContext } from "../ConfigContext";
 import { DatabaseAccount } from "../Contracts/DataModels";
 import { Collection } from "../Contracts/ViewModels";
 import DocumentId from "../Explorer/Tree/DocumentId";
-import { ResourceProviderClient } from "../ResourceProvider/ResourceProviderClient";
 import { updateUserContext } from "../UserContext";
 import { deleteDocument, getEndpoint, queryDocuments, readDocument, updateDocument } from "./MongoProxyClient";
 jest.mock("../ResourceProvider/ResourceProviderClient.ts");
@@ -237,19 +236,19 @@ describe("MongoProxyClient", () => {
     });
 
     it("returns a production endpoint", () => {
-      const endpoint = getEndpoint(databaseAccount as DatabaseAccount);
+      const endpoint = getEndpoint();
       expect(endpoint).toEqual("https://main.documentdb.ext.azure.com/api/mongo/explorer");
     });
 
     it("returns a development endpoint", () => {
       updateConfigContext({ MONGO_BACKEND_ENDPOINT: "https://localhost:1234" });
-      const endpoint = getEndpoint(databaseAccount as DatabaseAccount);
+      const endpoint = getEndpoint();
       expect(endpoint).toEqual("https://localhost:1234/api/mongo/explorer");
     });
 
     it("returns a guest endpoint", () => {
       window.authType = AuthType.EncryptedToken;
-      const endpoint = getEndpoint(databaseAccount as DatabaseAccount);
+      const endpoint = getEndpoint();
       expect(endpoint).toEqual("https://main.documentdb.ext.azure.com/api/guest/mongo/explorer");
     });
   });

--- a/src/Common/MongoProxyClient.ts
+++ b/src/Common/MongoProxyClient.ts
@@ -10,7 +10,6 @@ import DocumentId from "../Explorer/Tree/DocumentId";
 import * as NotificationConsoleUtils from "../Utils/NotificationConsoleUtils";
 import { ApiType, HttpHeaders, HttpStatusCodes } from "./Constants";
 import { userContext } from "../UserContext";
-import EnvironmentUtility from "./EnvironmentUtility";
 import { MinimalQueryIterator } from "./IteratorUtilities";
 import { sendMessage } from "./MessageHandler";
 
@@ -78,7 +77,7 @@ export function queryDocuments(
       collection && collection.partitionKey && !collection.partitionKey.systemKey ? collection.partitionKeyProperty : ""
   };
 
-  const endpoint = getEndpoint(databaseAccount) || "";
+  const endpoint = getEndpoint() || "";
 
   const headers = {
     ...defaultHeaders,
@@ -139,7 +138,7 @@ export function readDocument(
       documentId && documentId.partitionKey && !documentId.partitionKey.systemKey ? documentId.partitionKeyProperty : ""
   };
 
-  const endpoint = getEndpoint(databaseAccount);
+  const endpoint = getEndpoint();
   return window
     .fetch(`${endpoint}?${queryString.stringify(params)}`, {
       method: "GET",
@@ -179,7 +178,7 @@ export function createDocument(
     pk: collection && collection.partitionKey && !collection.partitionKey.systemKey ? partitionKeyProperty : ""
   };
 
-  const endpoint = getEndpoint(databaseAccount);
+  const endpoint = getEndpoint();
 
   return window
     .fetch(`${endpoint}/resourcelist?${queryString.stringify(params)}`, {
@@ -221,7 +220,7 @@ export function updateDocument(
     pk:
       documentId && documentId.partitionKey && !documentId.partitionKey.systemKey ? documentId.partitionKeyProperty : ""
   };
-  const endpoint = getEndpoint(databaseAccount);
+  const endpoint = getEndpoint();
 
   return window
     .fetch(`${endpoint}?${queryString.stringify(params)}`, {
@@ -260,7 +259,7 @@ export function deleteDocument(databaseId: string, collection: Collection, docum
     pk:
       documentId && documentId.partitionKey && !documentId.partitionKey.systemKey ? documentId.partitionKeyProperty : ""
   };
-  const endpoint = getEndpoint(databaseAccount);
+  const endpoint = getEndpoint();
 
   return window
     .fetch(`${endpoint}?${queryString.stringify(params)}`, {
@@ -303,7 +302,7 @@ export function createMongoCollectionWithProxy(
     autoPilotThroughput: params.autoPilotMaxThroughput?.toString()
   };
 
-  const endpoint = getEndpoint(databaseAccount);
+  const endpoint = getEndpoint();
 
   return window
     .fetch(
@@ -327,12 +326,9 @@ export function createMongoCollectionWithProxy(
     });
 }
 
-export function getEndpoint(databaseAccount: DataModels.DatabaseAccount): string {
-  const serverId = window.dataExplorer.serverId();
+export function getEndpoint(): string {
   const extensionEndpoint = window.dataExplorer.extensionEndpoint();
-  let url = configContext.MONGO_BACKEND_ENDPOINT
-    ? configContext.MONGO_BACKEND_ENDPOINT + "/api/mongo/explorer"
-    : EnvironmentUtility.getMongoBackendEndpoint(serverId, databaseAccount.location, extensionEndpoint);
+  let url = (configContext.MONGO_BACKEND_ENDPOINT || extensionEndpoint) + "/api/mongo/explorer";
 
   if (window.authType === AuthType.EncryptedToken) {
     url = url.replace("api/mongo", "api/guest/mongo");

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -6,7 +6,6 @@ import { AuthType } from "../../AuthType";
 import { ConsoleDataType } from "../../Explorer/Menus/NotificationConsole/NotificationConsoleComponent";
 import * as Constants from "../../Common/Constants";
 import * as Entities from "./Entities";
-import EnvironmentUtility from "../../Common/EnvironmentUtility";
 import * as HeadersUtility from "../../Common/HeadersUtility";
 import * as Logger from "../../Common/Logger";
 import * as NotificationConsoleUtils from "../../Utils/NotificationConsoleUtils";
@@ -308,7 +307,7 @@ export class CassandraAPIDataClient extends TableDataClient {
       authType === AuthType.EncryptedToken
         ? Constants.CassandraBackend.guestQueryApi
         : Constants.CassandraBackend.queryApi;
-    $.ajax(`${EnvironmentUtility.getCassandraBackendEndpoint(collection.container)}${apiEndpoint}`, {
+    $.ajax(`${collection.container.extensionEndpoint()}${apiEndpoint}`, {
       type: "POST",
       data: {
         accountName: collection && collection.container.databaseAccount && collection.container.databaseAccount().name,
@@ -559,7 +558,7 @@ export class CassandraAPIDataClient extends TableDataClient {
       authType === AuthType.EncryptedToken
         ? Constants.CassandraBackend.guestKeysApi
         : Constants.CassandraBackend.keysApi;
-    let endpoint = `${EnvironmentUtility.getCassandraBackendEndpoint(collection.container)}${apiEndpoint}`;
+    let endpoint = `${collection.container.extensionEndpoint()}${apiEndpoint}`;
     const deferred = Q.defer<CassandraTableKeys>();
     $.ajax(endpoint, {
       type: "POST",
@@ -614,7 +613,7 @@ export class CassandraAPIDataClient extends TableDataClient {
       authType === AuthType.EncryptedToken
         ? Constants.CassandraBackend.guestSchemaApi
         : Constants.CassandraBackend.schemaApi;
-    let endpoint = `${EnvironmentUtility.getCassandraBackendEndpoint(collection.container)}${apiEndpoint}`;
+    let endpoint = `${collection.container.extensionEndpoint()}${apiEndpoint}`;
     const deferred = Q.defer<CassandraTableKey[]>();
     $.ajax(endpoint, {
       type: "POST",
@@ -668,7 +667,7 @@ export class CassandraAPIDataClient extends TableDataClient {
       authType === AuthType.EncryptedToken
         ? Constants.CassandraBackend.guestCreateOrDeleteApi
         : Constants.CassandraBackend.createOrDeleteApi;
-    $.ajax(`${EnvironmentUtility.getCassandraBackendEndpoint(explorer)}${apiEndpoint}`, {
+    $.ajax(`${explorer.extensionEndpoint()}${apiEndpoint}`, {
       type: "POST",
       data: {
         accountName: explorer.databaseAccount() && explorer.databaseAccount().name,

--- a/src/Explorer/Tabs/MongoShellTab.ts
+++ b/src/Explorer/Tabs/MongoShellTab.ts
@@ -2,7 +2,6 @@ import * as Constants from "../../Common/Constants";
 import * as ko from "knockout";
 import * as ViewModels from "../../Contracts/ViewModels";
 import AuthHeadersUtil from "../../Platform/Hosted/Authorization";
-import EnvironmentUtility from "../../Common/EnvironmentUtility";
 import { isInvalidParentFrameOrigin } from "../../Utils/MessageValidation";
 import Q from "q";
 import TabsBase from "./TabsBase";
@@ -109,11 +108,7 @@ export default class MongoShellTab extends TabsBase {
       ) + Constants.MongoDBAccounts.defaultPort.toString();
     const databaseId = this.collection.databaseId;
     const collectionId = this.collection.id();
-    const apiEndpoint = EnvironmentUtility.getMongoBackendEndpoint(
-      this._container.serverId(),
-      userContext.databaseAccount.location,
-      this._container.extensionEndpoint()
-    ).replace("/api/mongo/explorer", "");
+    const apiEndpoint = this._container.extensionEndpoint();
     const encryptedAuthToken: string = userContext.accessToken;
 
     shellIframe.contentWindow.postMessage(


### PR DESCRIPTION
The portal passes down the extension endpoint in the iframe message but in some cases, we were relying on older code to pick the endpoint from constants. This code was not aware of webpack variable injection and did not work on localhost. This PR unifies all extension endpoint references to pull from the value passed down via the portal.