### PR TITLE
Use SDK for reading database offer for Tables API

### DIFF
--- a/src/Common/dataAccess/readDatabaseOffer.ts
+++ b/src/Common/dataAccess/readDatabaseOffer.ts
@@ -16,7 +16,11 @@ export const readDatabaseOffer = async (
 ): Promise<DataModels.OfferWithHeaders> => {
   let offerId = params.offerId;
   if (!offerId) {
-    if (window.authType === AuthType.AAD && !userContext.useSDKOperations && userContext.defaultExperience !== DefaultAccountExperienceType.Table) {
+    if (
+      window.authType === AuthType.AAD &&
+      !userContext.useSDKOperations &&
+      userContext.defaultExperience !== DefaultAccountExperienceType.Table
+    ) {
       try {
         offerId = await getDatabaseOfferIdWithARM(params.databaseId);
       } catch (error) {

--- a/src/Common/dataAccess/readDatabaseOffer.ts
+++ b/src/Common/dataAccess/readDatabaseOffer.ts
@@ -16,7 +16,7 @@ export const readDatabaseOffer = async (
 ): Promise<DataModels.OfferWithHeaders> => {
   let offerId = params.offerId;
   if (!offerId) {
-    if (window.authType === AuthType.AAD && !userContext.useSDKOperations) {
+    if (window.authType === AuthType.AAD && !userContext.useSDKOperations && userContext.defaultExperience !== DefaultAccountExperienceType.Table) {
       try {
         offerId = await getDatabaseOfferIdWithARM(params.databaseId);
       } catch (error) {


### PR DESCRIPTION
Since RP doesn't have an API for reading database throughput for Tables API, we should switch to using SDK. Note that it should still work fine going through the RP code path, just cleaner and safer to use SDK for Tables.