### PR TITLE
Fix create database for serverless accounts

### DIFF
--- a/src/Common/dataAccess/readDatabaseOffer.ts
+++ b/src/Common/dataAccess/readDatabaseOffer.ts
@@ -30,7 +30,7 @@ export const readDatabaseOffer = async (
         return undefined;
       }
     } else {
-      offerId = await getDatabaseOfferIdWithSDK(params.databaseResourceId, params.isServerless);
+      offerId = await getDatabaseOfferIdWithSDK(params.databaseResourceId);
       if (!offerId) {
         return undefined;
       }
@@ -80,8 +80,8 @@ const getDatabaseOfferIdWithARM = async (databaseId: string): Promise<string> =>
   return rpResponse?.name;
 };
 
-const getDatabaseOfferIdWithSDK = async (databaseResourceId: string, isServerless: boolean): Promise<string> => {
-  const offers = await readOffers(isServerless);
+const getDatabaseOfferIdWithSDK = async (databaseResourceId: string): Promise<string> => {
+  const offers = await readOffers();
   const offer = offers.find(offer => offer.resource === databaseResourceId);
   return offer?.id;
 };

--- a/src/Common/dataAccess/readOffers.ts
+++ b/src/Common/dataAccess/readOffers.ts
@@ -6,11 +6,7 @@ import { client } from "../CosmosClient";
 import { sendCachedDataMessage } from "../MessageHandler";
 import { userContext } from "../../UserContext";
 
-export const readOffers = async (isServerless?: boolean): Promise<Offer[]> => {
-  if (isServerless) {
-    return []; // Reading offers is not supported for serverless accounts
-  }
-
+export const readOffers = async (): Promise<Offer[]> => {
   try {
     if (configContext.platform === Platform.Portal) {
       return sendCachedDataMessage<Offer[]>(MessageTypes.AllOffers, [

--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -292,7 +292,6 @@ export interface CreateCollectionParams {
 export interface ReadDatabaseOfferParams {
   databaseId: string;
   databaseResourceId?: string;
-  isServerless?: boolean;
   offerId?: string;
 }
 

--- a/src/Explorer/Panes/AddCollectionPane.ts
+++ b/src/Explorer/Panes/AddCollectionPane.ts
@@ -666,7 +666,7 @@ export default class AddCollectionPane extends ContextualPaneBase {
     const subscriptionType: ViewModels.SubscriptionType =
       this.container.subscriptionType && this.container.subscriptionType();
 
-    if (subscriptionType === ViewModels.SubscriptionType.EA) {
+    if (subscriptionType === ViewModels.SubscriptionType.EA || this.container.isServerlessEnabled()) {
       return false;
     }
 

--- a/src/Explorer/Panes/AddDatabasePane.ts
+++ b/src/Explorer/Panes/AddDatabasePane.ts
@@ -337,7 +337,7 @@ export default class AddDatabasePane extends ContextualPaneBase {
     const subscriptionType: ViewModels.SubscriptionType =
       this.container.subscriptionType && this.container.subscriptionType();
 
-    if (subscriptionType === ViewModels.SubscriptionType.EA) {
+    if (subscriptionType === ViewModels.SubscriptionType.EA || this.container.isServerlessEnabled()) {
       return false;
     }
 

--- a/src/Explorer/Tree/Database.ts
+++ b/src/Explorer/Tree/Database.ts
@@ -200,11 +200,10 @@ export default class Database implements ViewModels.Database {
   }
 
   public async loadOffer(): Promise<void> {
-    if (!this.offer()) {
+    if (!this.container.isServerlessEnabled() && !this.offer()) {
       const params: DataModels.ReadDatabaseOfferParams = {
         databaseId: this.id(),
-        databaseResourceId: this.self,
-        isServerless: this.container.isServerlessEnabled()
+        databaseResourceId: this.self
       };
       this.offer(await readDatabaseOffer(params));
     }


### PR DESCRIPTION
By default, the `AddCollectionPane` and `AddDatabasePane` set shared throughput to true. This causes the create database call to fail for serverless accounts because shared throughput is not supported.

The fix is to set shared throughput to false by default if the database account is serverless.

Similarly, the read database offer call would fail if the account is serverless so we shouldn't make the call if it's serverless.