### PR TITLE
Don't generate source maps for vendor files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "sourceMap": false,
+    "sourceMap": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -206,7 +206,6 @@ module.exports = function(env = {}, argv = {}) {
       filename: "[name].[chunkhash:6].js",
       path: path.resolve(__dirname, "dist")
     },
-    devtool: false,
     plugins,
     module: {
       rules

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -109,6 +109,7 @@ module.exports = function(env = {}, argv = {}) {
     mode === "development"
       ? new webpack.EvalSourceMapDevToolPlugin({})
       : new webpack.SourceMapDevToolPlugin({
+          // test: [".js", ".mjs", ".css", ".ts", ".tsx"],
           filename: "[name].js.map",
           exclude: [/vendor/]
         });
@@ -174,6 +175,7 @@ module.exports = function(env = {}, argv = {}) {
       patterns: [{ from: "DataExplorer.nuspec" }, { from: "web.config" }, { from: "quickstart/*.zip" }]
     }),
     new EnvironmentPlugin(envVars),
+    new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
     sourceMapPlugin
   ];
 
@@ -216,6 +218,7 @@ module.exports = function(env = {}, argv = {}) {
       minimize: mode === "production" ? true : false,
       minimizer: [
         new TerserPlugin({
+          sourceMap: true,
           cache: ".cache/terser",
           terserOptions: {
             // These options increase our initial bundle size by ~5% but the builds are significantly faster and won't run out of memory


### PR DESCRIPTION
This change excludes all vendor chunks from generating source maps. In practice we rarely need these for debugging. On my machine it decreases the total build time from 8min to 2min and the dist size from 200mb to 50mb