### PR TITLE
Do not fail when trying to find DE window with cross origin

### DIFF
--- a/src/Common/MessageHandler.ts
+++ b/src/Common/MessageHandler.ts
@@ -49,16 +49,15 @@ export function sendCachedDataMessage<TResponseDataModel>(
 
 export function sendMessage(data: any): void {
   if (canSendMessage()) {
-    const dataExplorerWindow = getDataExplorerWindow(window);
-    if (dataExplorerWindow) {
-      dataExplorerWindow.parent.postMessage(
-        {
-          signature: "pcIframe",
-          data: data
-        },
-        dataExplorerWindow.document.referrer
-      );
-    }
+    // We try to find data explorer window first, then fallback to current window
+    const portalChildWindow = getDataExplorerWindow(window) || window;
+    portalChildWindow.parent.postMessage(
+      {
+        signature: "pcIframe",
+        data: data
+      },
+      portalChildWindow.document.referrer
+    );
   }
 }
 

--- a/src/Utils/WindowUtils.ts
+++ b/src/Utils/WindowUtils.ts
@@ -2,15 +2,21 @@ export const getDataExplorerWindow = (currentWindow: Window): Window | undefined
   // Start with the current window and traverse up the parent hierarchy to find a window
   // with `dataExplorerPlatform` property
   let dataExplorerWindow: Window | undefined = currentWindow;
-  // TODO: Need to `any` here since the window imports Explorer which can't be in strict mode yet
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  while (dataExplorerWindow && (dataExplorerWindow as any).dataExplorerPlatform === undefined) {
-    // If a window does not have a parent, its parent property is a reference to itself.
-    if (dataExplorerWindow.parent === dataExplorerWindow) {
-      dataExplorerWindow = undefined;
-    } else {
-      dataExplorerWindow = dataExplorerWindow.parent;
+
+  try {
+    // TODO: Need to `any` here since the window imports Explorer which can't be in strict mode yet
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    while (dataExplorerWindow && (dataExplorerWindow as any).dataExplorerPlatform == undefined) {
+      // If a window does not have a parent, its parent property is a reference to itself.
+      if (dataExplorerWindow.parent == dataExplorerWindow) {
+        dataExplorerWindow = undefined;
+      } else {
+        dataExplorerWindow = dataExplorerWindow.parent;
+      }
     }
+  } catch (error) {
+    // This can happen if we come across parent from a different origin
+    dataExplorerWindow = undefined;
   }
 
   return dataExplorerWindow;

--- a/src/Utils/WindowUtils.ts
+++ b/src/Utils/WindowUtils.ts
@@ -6,9 +6,9 @@ export const getDataExplorerWindow = (currentWindow: Window): Window | undefined
   try {
     // TODO: Need to `any` here since the window imports Explorer which can't be in strict mode yet
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    while (dataExplorerWindow && (dataExplorerWindow as any).dataExplorerPlatform == undefined) {
+    while (dataExplorerWindow && (dataExplorerWindow as any).dataExplorerPlatform === undefined) {
       // If a window does not have a parent, its parent property is a reference to itself.
-      if (dataExplorerWindow.parent == dataExplorerWindow) {
+      if (dataExplorerWindow.parent === dataExplorerWindow) {
         dataExplorerWindow = undefined;
       } else {
         dataExplorerWindow = dataExplorerWindow.parent;


### PR DESCRIPTION
Heatmap is hosted in an iframe directly by portal window. This causes `getDataExplorerWindow` to jump to portal window directly and throwing exception because of different origin. The fix here is to catch the exception and fallback to current window if no data explorer window is found.

![image](https://user-images.githubusercontent.com/693092/94315793-142d8380-ff38-11ea-91d8-7a523d322c3b.png)

Verified that heatmap no longer throws above exception locally.
