### PR TITLE
Fix Cassandra Endpoint URLs by adding trailing slash in construction

### DIFF
--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -307,7 +307,7 @@ export class CassandraAPIDataClient extends TableDataClient {
       authType === AuthType.EncryptedToken
         ? Constants.CassandraBackend.guestQueryApi
         : Constants.CassandraBackend.queryApi;
-    $.ajax(`${collection.container.extensionEndpoint()}${apiEndpoint}`, {
+    $.ajax(`${collection.container.extensionEndpoint()}/${apiEndpoint}`, {
       type: "POST",
       data: {
         accountName: collection && collection.container.databaseAccount && collection.container.databaseAccount().name,
@@ -558,7 +558,7 @@ export class CassandraAPIDataClient extends TableDataClient {
       authType === AuthType.EncryptedToken
         ? Constants.CassandraBackend.guestKeysApi
         : Constants.CassandraBackend.keysApi;
-    let endpoint = `${collection.container.extensionEndpoint()}${apiEndpoint}`;
+    let endpoint = `${collection.container.extensionEndpoint()}/${apiEndpoint}`;
     const deferred = Q.defer<CassandraTableKeys>();
     $.ajax(endpoint, {
       type: "POST",
@@ -613,7 +613,7 @@ export class CassandraAPIDataClient extends TableDataClient {
       authType === AuthType.EncryptedToken
         ? Constants.CassandraBackend.guestSchemaApi
         : Constants.CassandraBackend.schemaApi;
-    let endpoint = `${collection.container.extensionEndpoint()}${apiEndpoint}`;
+    let endpoint = `${collection.container.extensionEndpoint()}/${apiEndpoint}`;
     const deferred = Q.defer<CassandraTableKey[]>();
     $.ajax(endpoint, {
       type: "POST",
@@ -667,7 +667,7 @@ export class CassandraAPIDataClient extends TableDataClient {
       authType === AuthType.EncryptedToken
         ? Constants.CassandraBackend.guestCreateOrDeleteApi
         : Constants.CassandraBackend.createOrDeleteApi;
-    $.ajax(`${explorer.extensionEndpoint()}${apiEndpoint}`, {
+    $.ajax(`${explorer.extensionEndpoint()}/${apiEndpoint}`, {
       type: "POST",
       data: {
         accountName: explorer.databaseAccount() && explorer.databaseAccount().name,


### PR DESCRIPTION
Cassandra endpoints are broken since the in their original backend object they had trailing slashes while all other types did not. This keeps all endpoints consistent in not having a trailing slash and instead adds it when the `apiEndpoint` const is declared as the other endpoints do (like mongo)

See: #224 