### PR TITLE
Remove option to delete/create root table database

### DIFF
--- a/src/Common/dataAccess/createDatabase.ts
+++ b/src/Common/dataAccess/createDatabase.ts
@@ -34,11 +34,10 @@ export async function createDatabase(params: DataModels.CreateDatabaseParams): P
   let database: DataModels.Database;
   const clearMessage = logConsoleProgress(`Creating a new database ${params.databaseId}`);
   try {
-    if (
-      window.authType === AuthType.AAD &&
-      !userContext.useSDKOperations &&
-      userContext.defaultExperience !== DefaultAccountExperienceType.Table
-    ) {
+    if (userContext.defaultExperience === DefaultAccountExperienceType.Table) {
+      throw new Error("Creating database resources is not allowed for tables accounts");
+    }
+    if (window.authType === AuthType.AAD && !userContext.useSDKOperations) {
       database = await createDatabaseWithARM(params);
     } else {
       database = await createDatabaseWithSDK(params);

--- a/src/Common/dataAccess/deleteDatabase.ts
+++ b/src/Common/dataAccess/deleteDatabase.ts
@@ -15,11 +15,10 @@ export async function deleteDatabase(databaseId: string): Promise<void> {
   const clearMessage = logConsoleProgress(`Deleting database ${databaseId}`);
 
   try {
-    if (
-      window.authType === AuthType.AAD &&
-      userContext.defaultExperience !== DefaultAccountExperienceType.Table &&
-      !userContext.useSDKOperations
-    ) {
+    if (userContext.defaultExperience !== DefaultAccountExperienceType.Table) {
+      throw new Error("Deleting database resources is not allowed for tables accounts");
+    }
+    if (window.authType === AuthType.AAD && !userContext.useSDKOperations) {
       await deleteDatabaseWithARM(databaseId);
     } else {
       await client()

--- a/src/Common/dataAccess/deleteDatabase.ts
+++ b/src/Common/dataAccess/deleteDatabase.ts
@@ -15,7 +15,7 @@ export async function deleteDatabase(databaseId: string): Promise<void> {
   const clearMessage = logConsoleProgress(`Deleting database ${databaseId}`);
 
   try {
-    if (userContext.defaultExperience !== DefaultAccountExperienceType.Table) {
+    if (userContext.defaultExperience === DefaultAccountExperienceType.Table) {
       throw new Error("Deleting database resources is not allowed for tables accounts");
     }
     if (window.authType === AuthType.AAD && !userContext.useSDKOperations) {

--- a/src/Explorer/ContextMenuButtonFactory.ts
+++ b/src/Explorer/ContextMenuButtonFactory.ts
@@ -16,6 +16,8 @@ import Explorer from "./Explorer";
 import UserDefinedFunction from "./Tree/UserDefinedFunction";
 import StoredProcedure from "./Tree/StoredProcedure";
 import Trigger from "./Tree/Trigger";
+import { userContext } from "../UserContext";
+import { DefaultAccountExperienceType } from "../DefaultAccountExperienceType";
 
 export interface CollectionContextMenuButtonParams {
   databaseId: string;
@@ -29,23 +31,24 @@ export interface DatabaseContextMenuButtonParams {
  * New resource tree (in ReactJS)
  */
 export class ResourceTreeContextMenuButtonFactory {
-  public static createDatabaseContextMenu(
-    container: Explorer,
-    selectedDatabase: ViewModels.Database
-  ): TreeNodeMenuItem[] {
-    const newCollectionMenuItem: TreeNodeMenuItem = {
-      iconSrc: AddCollectionIcon,
-      onClick: () => container.onNewCollectionClicked(),
-      label: container.addCollectionText()
-    };
+  public static createDatabaseContextMenu(container: Explorer): TreeNodeMenuItem[] {
+    const items: TreeNodeMenuItem[] = [
+      {
+        iconSrc: AddCollectionIcon,
+        onClick: () => container.onNewCollectionClicked(),
+        label: container.addCollectionText()
+      }
+    ];
 
-    const deleteDatabaseMenuItem = {
-      iconSrc: DeleteDatabaseIcon,
-      onClick: () => container.deleteDatabaseConfirmationPane.open(),
-      label: container.deleteDatabaseText(),
-      styleClass: "deleteDatabaseMenuItem"
-    };
-    return [newCollectionMenuItem, deleteDatabaseMenuItem];
+    if (userContext.defaultExperience !== DefaultAccountExperienceType.Table) {
+      items.push({
+        iconSrc: DeleteDatabaseIcon,
+        onClick: () => container.deleteDatabaseConfirmationPane.open(),
+        label: container.deleteDatabaseText(),
+        styleClass: "deleteDatabaseMenuItem"
+      });
+    }
+    return items;
   }
 
   public static createCollectionContextMenuButton(

--- a/src/Explorer/Tree/ResourceTreeAdapter.tsx
+++ b/src/Explorer/Tree/ResourceTreeAdapter.tsx
@@ -169,7 +169,7 @@ export class ResourceTreeAdapter implements ReactAdapter {
         className: "databaseHeader",
         children: [],
         isSelected: () => this.isDataNodeSelected(database.rid, "Database", undefined),
-        contextMenu: ResourceTreeContextMenuButtonFactory.createDatabaseContextMenu(this.container, database),
+        contextMenu: ResourceTreeContextMenuButtonFactory.createDatabaseContextMenu(this.container),
         onClick: async isExpanded => {
           // Rewritten version of expandCollapseDatabase():
           if (isExpanded) {


### PR DESCRIPTION
Removes delete database option from resource tree menu for Tables accounts. Also throws for create/delete in underlying API calls

![image](https://user-images.githubusercontent.com/471400/94482485-f6158c80-019e-11eb-8ae6-a3931150bf4b.png)
