### PR TITLE
Fix Parent Origin Regex

### DIFF
--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -31,10 +31,11 @@ interface ConfigContext {
 let configContext: Readonly<ConfigContext> = {
   platform: Platform.Portal,
   allowedParentFrameOrigins: [
-    `^https:\\/\\/cosmos.azure.(com|cn|us)$`,
-    `^https:\\/\\/[\\.\\w]*portal.azure.(com|cn|us)$`,
-    `^https:\\/\\/[\\.\\w]*ext.azure.(com|cn|us)$`,
-    `^https:\\/\\/[\\.\\w]*microsoftazure.de$`
+    `^https:\\/\\/cosmos\\.azure\\.(com|cn|us)$`,
+    `^https:\\/\\/[\\.\\w]*portal\\.azure\\.(com|cn|us)$`,
+    `^https:\\/\\/[\\.\\w]*ext\\.azure\\.(com|cn|us)$`,
+    `^https:\\/\\/[\\.\\w]*\\.ext\\.microsoftazure\\.de$`,
+    `^https://cosmos-db-dataexplorer-germanycentral.azurewebsites.de$`
   ],
   // Webpack injects this at build time
   gitSha: process.env.GIT_SHA,

--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -32,9 +32,9 @@ let configContext: Readonly<ConfigContext> = {
   platform: Platform.Portal,
   allowedParentFrameOrigins: [
     `^https:\\/\\/cosmos.azure.(com|cn|us)$`,
-    `^https:\\/\\/[\\.\\w]+.portal.azure.(com|cn|us)$`,
-    `^https:\\/\\/[\\.\\w]+.ext.azure.(com|cn|us)$`,
-    `^https:\\/\\/[\\.\\w]+microsoftazure.de$`
+    `^https:\\/\\/[\\.\\w]*portal.azure.(com|cn|us)$`,
+    `^https:\\/\\/[\\.\\w]*ext.azure.(com|cn|us)$`,
+    `^https:\\/\\/[\\.\\w]*microsoftazure.de$`
   ],
   // Webpack injects this at build time
   gitSha: process.env.GIT_SHA,

--- a/src/Utils/MessageValidation.test.ts
+++ b/src/Utils/MessageValidation.test.ts
@@ -5,14 +5,12 @@ test.each`
   ${"https://cosmos.azure.com"}                                    | ${false}
   ${"https://cosmos.azure.us"}                                     | ${false}
   ${"https://cosmos.azure.cn"}                                     | ${false}
-  ${"https://cosmos.microsoftazure.de"}                            | ${false}
   ${"https://portal.azure.com"}                                    | ${false}
   ${"https://portal.azure.us"}                                     | ${false}
   ${"https://portal.azure.cn"}                                     | ${false}
   ${"https://subdomain.portal.azure.com"}                          | ${false}
   ${"https://subdomain.portal.azure.us"}                           | ${false}
   ${"https://subdomain.portal.azure.cn"}                           | ${false}
-  ${"https://subdomain.microsoftazure.de"}                         | ${false}
   ${"https://main.documentdb.ext.azure.com"}                       | ${false}
   ${"https://main.documentdb.ext.azure.us"}                        | ${false}
   ${"https://main.documentdb.ext.azure.cn"}                        | ${false}
@@ -20,6 +18,8 @@ test.each`
   ${"https://random.domain"}                                       | ${true}
   ${"https://malicious.cloudapp.azure.com"}                        | ${true}
   ${"https://malicious.germanycentral.cloudapp.microsoftazure.de"} | ${true}
+  ${"https://maliciousazure.com"}                                  | ${true}
+  ${"https://maliciousportalsazure.com"}                           | ${true}
 `("returns $expected when called with $domain", ({ domain, expected }) => {
   expect(isInvalidParentFrameOrigin({ origin: domain } as MessageEvent)).toBe(expected);
 });

--- a/src/Utils/MessageValidation.test.ts
+++ b/src/Utils/MessageValidation.test.ts
@@ -1,24 +1,25 @@
 import { isInvalidParentFrameOrigin } from "./MessageValidation";
 
 test.each`
-  domain                                             | expected
-  ${"https://cosmos.azure.com"}                      | ${false}
-  ${"https://cosmos.azure.us"}                       | ${false}
-  ${"https://cosmos.azure.cn"}                       | ${false}
-  ${"https://cosmos.microsoftazure.de"}              | ${false}
-  ${"https://portal.azure.com"}                      | ${false}
-  ${"https://portal.azure.us"}                       | ${false}
-  ${"https://portal.azure.cn"}                       | ${false}
-  ${"https://subdomain.portal.azure.com"}            | ${false}
-  ${"https://subdomain.portal.azure.us"}             | ${false}
-  ${"https://subdomain.portal.azure.cn"}             | ${false}
-  ${"https://subdomain.microsoftazure.de"}           | ${false}
-  ${"https://main.documentdb.ext.azure.com"}         | ${false}
-  ${"https://main.documentdb.ext.azure.us"}          | ${false}
-  ${"https://main.documentdb.ext.azure.cn"}          | ${false}
-  ${"https://main.documentdb.ext.microsoftazure.de"} | ${false}
-  ${"https://random.domain"}                         | ${true}
-  ${"https://malicious.cloudapp.azure.com"}          | ${true}
+  domain                                                           | expected
+  ${"https://cosmos.azure.com"}                                    | ${false}
+  ${"https://cosmos.azure.us"}                                     | ${false}
+  ${"https://cosmos.azure.cn"}                                     | ${false}
+  ${"https://cosmos.microsoftazure.de"}                            | ${false}
+  ${"https://portal.azure.com"}                                    | ${false}
+  ${"https://portal.azure.us"}                                     | ${false}
+  ${"https://portal.azure.cn"}                                     | ${false}
+  ${"https://subdomain.portal.azure.com"}                          | ${false}
+  ${"https://subdomain.portal.azure.us"}                           | ${false}
+  ${"https://subdomain.portal.azure.cn"}                           | ${false}
+  ${"https://subdomain.microsoftazure.de"}                         | ${false}
+  ${"https://main.documentdb.ext.azure.com"}                       | ${false}
+  ${"https://main.documentdb.ext.azure.us"}                        | ${false}
+  ${"https://main.documentdb.ext.azure.cn"}                        | ${false}
+  ${"https://main.documentdb.ext.microsoftazure.de"}               | ${false}
+  ${"https://random.domain"}                                       | ${true}
+  ${"https://malicious.cloudapp.azure.com"}                        | ${true}
+  ${"https://malicious.germanycentral.cloudapp.microsoftazure.de"} | ${true}
 `("returns $expected when called with $domain", ({ domain, expected }) => {
   expect(isInvalidParentFrameOrigin({ origin: domain } as MessageEvent)).toBe(expected);
 });

--- a/src/Utils/MessageValidation.test.ts
+++ b/src/Utils/MessageValidation.test.ts
@@ -6,6 +6,9 @@ test.each`
   ${"https://cosmos.azure.us"}                       | ${false}
   ${"https://cosmos.azure.cn"}                       | ${false}
   ${"https://cosmos.microsoftazure.de"}              | ${false}
+  ${"https://portal.azure.com"}                      | ${false}
+  ${"https://portal.azure.us"}                       | ${false}
+  ${"https://portal.azure.cn"}                       | ${false}
   ${"https://subdomain.portal.azure.com"}            | ${false}
   ${"https://subdomain.portal.azure.us"}             | ${false}
   ${"https://subdomain.portal.azure.cn"}             | ${false}

--- a/src/Utils/MessageValidation.ts
+++ b/src/Utils/MessageValidation.ts
@@ -17,6 +17,6 @@ function isValidOrigin(allowedOrigins: string[], event: MessageEvent): boolean {
       return true;
     }
   }
-  console.error(`Invalid parent frame origin decected: ${eventOrigin}`);
+  console.error(`Invalid parent frame origin detected: ${eventOrigin}`);
   return false;
 }

--- a/src/Utils/MessageValidation.ts
+++ b/src/Utils/MessageValidation.ts
@@ -17,5 +17,6 @@ function isValidOrigin(allowedOrigins: string[], event: MessageEvent): boolean {
       return true;
     }
   }
+  console.error(`Invalid parent frame origin decected: ${eventOrigin}`);
   return false;
 }


### PR DESCRIPTION
My original change to the new set of Regex's did not account for the bare production domains. So `ms.portal.azure.com` worked but not `portal.azure.com`