### PR TITLE
Use 2020-03-01 API version for ARM calls

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -50,7 +50,7 @@ export class ArmApiVersions {
   public static readonly arcadiaLivy: string = "2019-11-01-preview";
   public static readonly arm: string = "2015-11-01";
   public static readonly armFeatures: string = "2014-08-01-preview";
-  public static readonly publicVersion = "2020-04-01";
+  public static readonly publicVersion = "2020-03-01";
 }
 
 export class ArmResourceTypes {

--- a/src/Utils/arm/generatedClients/2020-04-01/cassandraResources.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/cassandraResources.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Lists the Cassandra keyspaces under an existing Azure Cosmos DB database account. */
 export async function listCassandraKeyspaces(

--- a/src/Utils/arm/generatedClients/2020-04-01/collection.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/collection.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Retrieves the metrics determined by the given filter for the given database account and collection. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/2020-04-01/collectionPartition.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/collectionPartition.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Retrieves the metrics determined by the given filter for the given collection, split by partition. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/2020-04-01/collectionPartitionRegion.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/collectionPartitionRegion.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Retrieves the metrics determined by the given filter for the given collection and region, split by partition. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/2020-04-01/collectionRegion.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/collectionRegion.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Retrieves the metrics determined by the given filter for the given database account, collection and region. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/2020-04-01/database.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/database.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Retrieves the metrics determined by the given filter for the given database account and database. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/2020-04-01/databaseAccountRegion.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/databaseAccountRegion.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Retrieves the metrics determined by the given filter for the given database account and region. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/2020-04-01/databaseAccounts.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/databaseAccounts.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Retrieves the properties of an existing Azure Cosmos DB database account. */
 export async function get(

--- a/src/Utils/arm/generatedClients/2020-04-01/gremlinResources.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/gremlinResources.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Lists the Gremlin databases under an existing Azure Cosmos DB database account. */
 export async function listGremlinDatabases(

--- a/src/Utils/arm/generatedClients/2020-04-01/mongoDBResources.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/mongoDBResources.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Lists the MongoDB databases under an existing Azure Cosmos DB database account. */
 export async function listMongoDBDatabases(

--- a/src/Utils/arm/generatedClients/2020-04-01/operations.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/operations.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Lists all of the available Cosmos DB Resource Provider operations. */
 export async function list(): Promise<Types.OperationListResult> {

--- a/src/Utils/arm/generatedClients/2020-04-01/partitionKeyRangeId.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/partitionKeyRangeId.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Retrieves the metrics determined by the given filter for the given partition key range id. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/2020-04-01/partitionKeyRangeIdRegion.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/partitionKeyRangeIdRegion.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Retrieves the metrics determined by the given filter for the given partition key range id and region. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/2020-04-01/percentile.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/percentile.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Retrieves the metrics determined by the given filter for the given database account. This url is only for PBS and Replication Latency data */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/2020-04-01/percentileSourceTarget.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/percentileSourceTarget.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Retrieves the metrics determined by the given filter for the given account, source and target region. This url is only for PBS and Replication Latency data */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/2020-04-01/percentileTarget.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/percentileTarget.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Retrieves the metrics determined by the given filter for the given account target region. This url is only for PBS and Replication Latency data */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/2020-04-01/sqlResources.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/sqlResources.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Lists the SQL databases under an existing Azure Cosmos DB database account. */
 export async function listSqlDatabases(

--- a/src/Utils/arm/generatedClients/2020-04-01/tableResources.ts
+++ b/src/Utils/arm/generatedClients/2020-04-01/tableResources.ts
@@ -7,7 +7,7 @@
 import { armRequest } from "../../request";
 import * as Types from "./types";
 import { configContext } from "../../../../ConfigContext";
-const apiVersion = "2020-04-01";
+const apiVersion = "2020-03-01";
 
 /* Lists the Tables under an existing Azure Cosmos DB database account. */
 export async function listTables(


### PR DESCRIPTION
We need to support some environments that do not yet have 2020-04-01 ARM API version. However the requests are backwards compatible where possible and the breaking changes are not used in this repo. So this is a bit hacky, but should work fine until we can use 2020-04-01 everywhere.