### PR TITLE
Allow setting of ARM API version via query param

### DIFF
--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -25,6 +25,7 @@ interface ConfigContext {
   GITHUB_CLIENT_ID: string;
   GITHUB_CLIENT_SECRET?: string; // No need to inject secret for prod. Juno already knows it.
   hostedExplorerURL: string;
+  armAPIVersion?: string;
 }
 
 // Default configuration
@@ -93,6 +94,10 @@ export async function initializeConfiguration(): Promise<ConfigContext> {
     }
     // Allow override of platform value with URL query parameter
     const params = new URLSearchParams(window.location.search);
+    if (params.has("armAPIVersion")) {
+      const armAPIVersion = params.get("armAPIVersion");
+      updateConfigContext({ armAPIVersion });
+    }
     if (params.has("platform")) {
       const platform = params.get("platform");
       switch (platform) {

--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -95,7 +95,7 @@ export async function initializeConfiguration(): Promise<ConfigContext> {
     // Allow override of platform value with URL query parameter
     const params = new URLSearchParams(window.location.search);
     if (params.has("armAPIVersion")) {
-      const armAPIVersion = params.get("armAPIVersion");
+      const armAPIVersion = params.get("armAPIVersion") || "";
       updateConfigContext({ armAPIVersion });
     }
     if (params.has("platform")) {

--- a/src/Utils/arm/request.ts
+++ b/src/Utils/arm/request.ts
@@ -6,6 +6,7 @@ Instead, generate ARM clients that consume this function with stricter typing.
 */
 
 import promiseRetry, { AbortError } from "p-retry";
+import { configContext } from "../../ConfigContext";
 import { userContext } from "../../UserContext";
 
 interface ErrorResponse {
@@ -43,7 +44,8 @@ interface Options {
 // TODO: This is very similar to what is happening in ResourceProviderClient.ts. Should probably merge them.
 export async function armRequest<T>({ host, path, apiVersion, method, body: requestBody }: Options): Promise<T> {
   const url = new URL(path, host);
-  url.searchParams.append("api-version", apiVersion);
+  console.log(configContext);
+  url.searchParams.append("api-version", configContext.armAPIVersion || apiVersion);
   const response = await window.fetch(url.href, {
     method,
     headers: {

--- a/src/Utils/arm/request.ts
+++ b/src/Utils/arm/request.ts
@@ -44,7 +44,6 @@ interface Options {
 // TODO: This is very similar to what is happening in ResourceProviderClient.ts. Should probably merge them.
 export async function armRequest<T>({ host, path, apiVersion, method, body: requestBody }: Options): Promise<T> {
   const url = new URL(path, host);
-  console.log(configContext);
   url.searchParams.append("api-version", configContext.armAPIVersion || apiVersion);
   const response = await window.fetch(url.href, {
     method,


### PR DESCRIPTION
Allows overriding the ARM API version via query param: https://cosmos.azure.com/explorer.html?armAPIVersion=2020-03-01