### PR TITLE
[Azure][Screen Reader-CosmosDB – Data Explorer]  Alt is not correctly defined for the console image on the data explorer page,

### DIFF
--- a/src/Explorer/Menus/NotificationConsole/NotificationConsoleComponent.tsx
+++ b/src/Explorer/Menus/NotificationConsole/NotificationConsoleComponent.tsx
@@ -134,10 +134,11 @@ export class NotificationConsoleComponent extends React.Component<
             className="expandCollapseButton"
             role="button"
             tabIndex={0}
-            aria-label={this.state.isExpanded ? "collapse console" : "expand console"}
-            aria-expanded={this.state.isExpanded}
+            aria-label={"console button" + (this.state.isExpanded ? " collapsed" : " expanded")}
+            aria-expanded={!this.state.isExpanded}
+            aria-haspopup={true}
           >
-            <img src={this.state.isExpanded ? ChevronDownIcon : ChevronUpIcon} alt="" />
+            <img src={this.state.isExpanded ? ChevronDownIcon : ChevronUpIcon} alt={this.state.isExpanded ? "ChevronDownIcon" : "ChevronUpIcon"} />
           </div>
         </div>
         <AnimateHeight


### PR DESCRIPTION
story description:
Repro-Steps:
1. Open URL: https://ms.portal.azure.com/
2. Login via valid credentials
3. Navigate to "Azure Cosmos DB" from left pane and select it.
4. Navigate to any of the Azure Cosmos DB which is already created and select it.
5. Navigate to "Data Explorer" from the left and select it.
6. Navigate through all the controls under Data Explorer blade.
7. Navigate with the Narrator and reach console image at the button of the page.

Expected Result:
On the data explorer page, alt should be properly defined for the console image i.e alt=console. So, that the Screen Reader user does able gets the proper information of the image.