### PR TITLE
Add checks for serverless account

### DIFF
--- a/src/Explorer/Tabs/SettingsTab.ts
+++ b/src/Explorer/Tabs/SettingsTab.ts
@@ -517,6 +517,10 @@ export default class SettingsTab extends TabsBase implements ViewModels.WaitsFor
         return false;
       }
 
+      if (this.container.isServerlessEnabled()) {
+        return false;
+      }
+
       const numPartitions = this.collection.quotaInfo().numPartitions;
       return !!this.collection.partitionKeyProperty || numPartitions > 1;
     });
@@ -526,7 +530,7 @@ export default class SettingsTab extends TabsBase implements ViewModels.WaitsFor
     );
 
     this.minRUs = ko.computed<number>(() => {
-      if (this.isTryCosmosDBSubscription()) {
+      if (this.isTryCosmosDBSubscription() || this.container.isServerlessEnabled()) {
         return SharedConstants.CollectionCreation.DefaultCollectionRUs400;
       }
 
@@ -573,7 +577,7 @@ export default class SettingsTab extends TabsBase implements ViewModels.WaitsFor
 
     this.maxRUs = ko.computed<number>(() => {
       const isTryCosmosDBSubscription = this.isTryCosmosDBSubscription();
-      if (isTryCosmosDBSubscription) {
+      if (isTryCosmosDBSubscription || this.container.isServerlessEnabled()) {
         return Constants.TryCosmosExperience.maxRU;
       }
 
@@ -749,7 +753,7 @@ export default class SettingsTab extends TabsBase implements ViewModels.WaitsFor
         if (
           this.rupm() === Constants.RUPMStates.on &&
           this.throughput() >
-            SharedConstants.CollectionCreation.MaxRUPMPerPartition * this.collection.quotaInfo().numPartitions
+            SharedConstants.CollectionCreation.MaxRUPMPerPartition * this.collection.quotaInfo()?.numPartitions
         ) {
           return false;
         }


### PR DESCRIPTION
The Settings tab is broken for serverless account because we do not have null checks for `collection.quotaInfo()`. Due to my recent change that lazy loads the collection offer, we no longer read quota info if the account is serverless, thus `collection.quotaInfo()` returns undefined. There are several places in SettingsTab where we call `this.collection.quotaInfo().numPartitions` which would throw an error.

The fix is to either add a null check or add a special case for serverless account.