### PR TITLE
[Azure][Screen Reader-CosmosDB – Data Explorer] Alt is not correctly defined for the console image on the data explorer page

### DIFF
--- a/src/Explorer/Menus/NotificationConsole/NotificationConsoleComponent.tsx
+++ b/src/Explorer/Menus/NotificationConsole/NotificationConsoleComponent.tsx
@@ -136,7 +136,6 @@ export class NotificationConsoleComponent extends React.Component<
             tabIndex={0}
             aria-label={"console button" + (this.state.isExpanded ? " collapsed" : " expanded")}
             aria-expanded={!this.state.isExpanded}
-            aria-haspopup={true}
           >
             <img
               src={this.state.isExpanded ? ChevronDownIcon : ChevronUpIcon}

--- a/src/Explorer/Menus/NotificationConsole/NotificationConsoleComponent.tsx
+++ b/src/Explorer/Menus/NotificationConsole/NotificationConsoleComponent.tsx
@@ -134,10 +134,14 @@ export class NotificationConsoleComponent extends React.Component<
             className="expandCollapseButton"
             role="button"
             tabIndex={0}
-            aria-label={this.state.isExpanded ? "collapse console" : "expand console"}
-            aria-expanded={this.state.isExpanded}
+            aria-label={"console button" + (this.state.isExpanded ? " collapsed" : " expanded")}
+            aria-expanded={!this.state.isExpanded}
+            aria-haspopup={true}
           >
-            <img src={this.state.isExpanded ? ChevronDownIcon : ChevronUpIcon} alt="" />
+            <img
+              src={this.state.isExpanded ? ChevronDownIcon : ChevronUpIcon}
+              alt={this.state.isExpanded ? "ChevronDownIcon" : "ChevronUpIcon"}
+            />
           </div>
         </div>
         <AnimateHeight

--- a/src/Explorer/Menus/NotificationConsole/__snapshots__/NotificationConsoleComponent.test.tsx.snap
+++ b/src/Explorer/Menus/NotificationConsole/__snapshots__/NotificationConsoleComponent.test.tsx.snap
@@ -68,14 +68,14 @@ exports[`NotificationConsoleComponent renders the console (expanded) 1`] = `
       </span>
     </div>
     <div
-      aria-expanded={true}
-      aria-label="collapse console"
+      aria-expanded={false}
+      aria-label="console button collapsed"
       className="expandCollapseButton"
       role="button"
       tabIndex={0}
     >
       <img
-        alt=""
+        alt="ChevronDownIcon"
         src=""
       />
     </div>


### PR DESCRIPTION
story description:
Repro-Steps:

Open URL: https://ms.portal.azure.com/
Login via valid credentials
Navigate to "Azure Cosmos DB" from left pane and select it.
Navigate to any of the Azure Cosmos DB which is already created and select it.
Navigate to "Data Explorer" from the left and select it.
Navigate through all the controls under Data Explorer blade.
Navigate with the Narrator and reach console image at the button of the page.
Expected Result:
On the data explorer page, alt should be properly defined for the console image i.e alt=console. So, that the Screen Reader user does able gets the proper information of the image.