### PR TITLE
Use Github PAT for automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -24,6 +24,6 @@ jobs:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.11.0"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.AUTOMERGE_GITHUB_PAT }}"
           MERGE_METHOD: "squash"
           MERGE_COMMIT_MESSAGE: "pull-request-title"


### PR DESCRIPTION
A limitation of Github actions is that [a workflow cannot trigger another workflow if using the built in github token](https://github.com/pascalgn/automerge-action#limitations). I have set up a PAT on my account that should allow us to workaround this. 