### PR TITLE
Fix database offers not loaded when add collection pane is opened

### DIFF
--- a/src/Explorer/Explorer.ts
+++ b/src/Explorer/Explorer.ts
@@ -3130,8 +3130,10 @@ export default class Explorer {
   }
 
   public async loadDatabaseOffers(): Promise<void> {
-    this.databases()?.forEach(async (database: ViewModels.Database) => {
-      await database.loadOffer();
-    });
+    await Promise.all(
+      this.databases()?.map(async (database: ViewModels.Database) => {
+        await database.loadOffer();
+      })
+    );
   }
 }


### PR DESCRIPTION
Using `await` inside a `forEach` loop does not work as expected. It actually just throws away all the promises instead of waiting for the promise to finish before moving onto the next one.

The correct way to do this is to use `map` instead of `forEach` and use `Promise.all` to wait for all promises to finish. This allows the database offers to be loaded in parallel.