### PR TITLE
Add correct content-type header to terminals calls

### DIFF
--- a/src/Terminal/index.ts
+++ b/src/Terminal/index.ts
@@ -7,7 +7,7 @@ import { JupyterLabAppFactory } from "./JupyterLabAppFactory";
 import { Action } from "../Shared/Telemetry/TelemetryConstants";
 import * as TelemetryProcessor from "../Shared/Telemetry/TelemetryProcessor";
 import { updateUserContext } from "../UserContext";
-import { TerminalQueryParams } from "../Common/Constants";
+import { HttpHeaders, TerminalQueryParams } from "../Common/Constants";
 
 const getUrlVars = (): { [key: string]: string } => {
   const vars: { [key: string]: string } = {};
@@ -20,16 +20,20 @@ const getUrlVars = (): { [key: string]: string } => {
 
 const createServerSettings = (urlVars: { [key: string]: string }): ServerConnection.ISettings => {
   let body: BodyInit;
+  let headers: HeadersInit;
   if (urlVars.hasOwnProperty(TerminalQueryParams.TerminalEndpoint)) {
     body = JSON.stringify({
       endpoint: urlVars[TerminalQueryParams.TerminalEndpoint]
     });
+    headers = {
+      [HttpHeaders.contentType]: "application/json"
+    };
   }
 
   const server = urlVars[TerminalQueryParams.Server];
   let options: Partial<ServerConnection.ISettings> = {
     baseUrl: server,
-    init: { body },
+    init: { body, headers },
     fetch: window.parent.fetch
   };
   if (urlVars.hasOwnProperty(TerminalQueryParams.Token)) {
@@ -37,7 +41,7 @@ const createServerSettings = (urlVars: { [key: string]: string }): ServerConnect
       baseUrl: server,
       token: urlVars[TerminalQueryParams.Token],
       appendToken: true,
-      init: { body },
+      init: { body, headers },
       fetch: window.parent.fetch
     };
   }


### PR DESCRIPTION
Recent upgrade to jupyterlab broke opening Mongo Shell and Cassandra Shell because now we need to explicitly pass the correct content-type header.