### PR TITLE
Fix horizontal scrollbar in notebook cell input issue

### DIFF
--- a/src/Explorer/Notebook/NotebookRenderer/base.css
+++ b/src/Explorer/Notebook/NotebookRenderer/base.css
@@ -49,7 +49,7 @@
 
 .nteract-cell-input .nteract-cell-source {
   flex: 1 1 auto;
-  overflow: hidden;
+  overflow: visible;
 }
 
 /** Adaptation for the R kernel's inline lists **/

--- a/src/Explorer/Notebook/NotebookRenderer/base.css
+++ b/src/Explorer/Notebook/NotebookRenderer/base.css
@@ -49,7 +49,7 @@
 
 .nteract-cell-input .nteract-cell-source {
   flex: 1 1 auto;
-  overflow: auto;
+  overflow: hidden;
 }
 
 /** Adaptation for the R kernel's inline lists **/


### PR DESCRIPTION
The [switch to monaco editor](https://github.com/Azure/cosmos-explorer/pull/239) has introduced this issue.
When running Data Explorer outside of portal, I often see an extra horizontal scrollbar in the cell input. This seems to be caused by the monaco editor widget not properly recalculating its width wrt to the container (nteract cell input): it must be off by a pixel or so, as shown by the scrollbar draggable element covering the entire width of the bar itself. No content is occluded.

This change removes the scrollbar in both directions as they don't seem useful: 
- in the y axis, the cell height expands with the content
- in the x axis, the words wraps. Images a scaled to fit.

The change is also in line with the default settings in nteract (which we override).

![image](https://user-images.githubusercontent.com/21954022/95318971-8fc3f480-0897-11eb-997b-ded01b2526d8.png)
