### PR TITLE
Fix double-scrollbar bug

### DIFF
--- a/less/documentDB.less
+++ b/less/documentDB.less
@@ -2082,7 +2082,8 @@ a:link {
 .resourceTreeAndTabs {
     display: flex;
     flex: 1 1 auto;
-    overflow: auto;
+    overflow-x: auto;
+    overflow-y: hidden;
     height: 100%;
 }
 


### PR DESCRIPTION
Allow horizontal scrollbar when zooming in, but not vertical.

![image](https://user-images.githubusercontent.com/21954022/95427127-5a76df80-0947-11eb-97cb-e9c00e382364.png)
