### PR TITLE
Added telelmetry for settings v2 and v1

### DIFF
--- a/src/Explorer/Controls/Settings/SettingsComponent.tsx
+++ b/src/Explorer/Controls/Settings/SettingsComponent.tsx
@@ -264,7 +264,7 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
     this.props.settingsTab.isExecutionError(false);
 
     this.props.settingsTab.isExecuting(true);
-    const startKey: number = traceStart(Action.UpdateSettingsV2, {
+    const startKey: number = traceStart(Action.SettingsV2Updated, {
       databaseAccountName: this.container.databaseAccount()?.name,
       defaultExperience: this.container.defaultExperience(),
       dataExplorerArea: Constants.Areas.Tab,
@@ -405,7 +405,7 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
             this.setState({ isScaleSaveable: false, isScaleDiscardable: false });
           } catch (error) {
             traceFailure(
-              Action.UpdateSettingsV2,
+              Action.SettingsV2Updated,
               {
                 databaseAccountName: this.container.databaseAccount().name,
                 databaseName: this.collection && this.collection.databaseId,
@@ -454,7 +454,7 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
       this.setBaseline();
       this.setState({ wasAutopilotOriginallySet: this.state.isAutoPilotSelected });
       traceSuccess(
-        Action.UpdateSettingsV2,
+        Action.SettingsV2Updated,
         {
           databaseAccountName: this.container.databaseAccount()?.name,
           defaultExperience: this.container.defaultExperience(),
@@ -468,7 +468,7 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
       this.props.settingsTab.isExecutionError(true);
       console.error(reason);
       traceFailure(
-        Action.UpdateSettingsV2,
+        Action.SettingsV2Updated,
         {
           databaseAccountName: this.container.databaseAccount()?.name,
           defaultExperience: this.container.defaultExperience(),
@@ -482,7 +482,7 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
   };
 
   public onRevertClick = (): void => {
-    trace(Action.DiscardSettingsV2, ActionModifiers.Mark, {
+    trace(Action.SettingsV2Discarded, ActionModifiers.Mark, {
       message: "Settings Discarded"
     });
 

--- a/src/Explorer/Tabs/SettingsTab.ts
+++ b/src/Explorer/Tabs/SettingsTab.ts
@@ -13,7 +13,7 @@ import Q from "q";
 import SaveIcon from "../../../images/save-cosmos.svg";
 import TabsBase from "./TabsBase";
 import * as TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
-import { Action } from "../../Shared/Telemetry/TelemetryConstants";
+import { Action, ActionModifiers } from "../../Shared/Telemetry/TelemetryConstants";
 import { PlatformType } from "../../PlatformType";
 import { RequestOptions } from "@azure/cosmos/dist-esm";
 import Explorer from "../Explorer";
@@ -1233,6 +1233,9 @@ export default class SettingsTab extends TabsBase implements ViewModels.WaitsFor
   };
 
   public onRevertClick = (): Q.Promise<any> => {
+    TelemetryProcessor.trace(Action.DiscardSettings, ActionModifiers.Mark, {
+      message: "Settings Discarded"
+    });
     this.throughput.setBaseline(this.throughput.getEditableOriginalValue());
     this.timeToLive.setBaseline(this.timeToLive.getEditableOriginalValue());
     this.timeToLiveSeconds.setBaseline(this.timeToLiveSeconds.getEditableOriginalValue());

--- a/src/Explorer/Tabs/SettingsTabV2.tsx
+++ b/src/Explorer/Tabs/SettingsTabV2.tsx
@@ -9,6 +9,7 @@ export default class SettingsTabV2 extends TabsBase {
 
   constructor(options: ViewModels.TabOptions) {
     super(options);
+    this.tabId = "SettingsV2-" + this.tabId
     const props: SettingsComponentProps = {
       settingsTab: this
     };

--- a/src/Explorer/Tabs/SettingsTabV2.tsx
+++ b/src/Explorer/Tabs/SettingsTabV2.tsx
@@ -9,7 +9,7 @@ export default class SettingsTabV2 extends TabsBase {
 
   constructor(options: ViewModels.TabOptions) {
     super(options);
-    this.tabId = "SettingsV2-" + this.tabId
+    this.tabId = "SettingsV2-" + this.tabId;
     const props: SettingsComponentProps = {
       settingsTab: this
     };

--- a/src/Explorer/Tabs/TabsBase.ts
+++ b/src/Explorer/Tabs/TabsBase.ts
@@ -88,7 +88,8 @@ export default class TabsBase extends WaitsForTemplateViewModel {
       databaseAccountName: this.getContainer().databaseAccount().name,
       defaultExperience: this.getContainer().defaultExperience(),
       dataExplorerArea: Constants.Areas.Tab,
-      tabTitle: this.tabTitle()
+      tabTitle: this.tabTitle(),
+      tabId: this.tabId
     });
   }
 
@@ -145,7 +146,8 @@ export default class TabsBase extends WaitsForTemplateViewModel {
       databaseAccountName: this.getContainer().databaseAccount().name,
       defaultExperience: this.getContainer().defaultExperience(),
       dataExplorerArea: Constants.Areas.Tab,
-      tabTitle: this.tabTitle()
+      tabTitle: this.tabTitle(),
+      tabId: this.tabId
     });
     return Q();
   }

--- a/src/Shared/Telemetry/TelemetryConstants.ts
+++ b/src/Shared/Telemetry/TelemetryConstants.ts
@@ -86,7 +86,10 @@ export enum Action {
   CreateMongoCollectionWithWildcardIndex,
   ClickCommandBarButton,
   RefreshResourceTreeMyNotebooks,
-  ClickResourceTreeNodeContextMenuItem
+  ClickResourceTreeNodeContextMenuItem,
+  DiscardSettings,
+  UpdateSettingsV2,
+  DiscardSettingsV2
 }
 
 export const ActionModifiers = {

--- a/src/Shared/Telemetry/TelemetryConstants.ts
+++ b/src/Shared/Telemetry/TelemetryConstants.ts
@@ -88,8 +88,8 @@ export enum Action {
   RefreshResourceTreeMyNotebooks,
   ClickResourceTreeNodeContextMenuItem,
   DiscardSettings,
-  UpdateSettingsV2,
-  DiscardSettingsV2
+  SettingsV2Updated,
+  SettingsV2Discarded
 }
 
 export const ActionModifiers = {


### PR DESCRIPTION
- Modified tab activate and close logging to contain tabId
- Overrode this tabId in SettingsV2 to make the tabId contain "SettingsV2"
- Changed type of telemetry action for updatecollection and update offer success and failure to "UpdateSettingsV2" in SettingsComponent
- Added new Action types "DiscardSettings" and "DiscardSettingsV2" for telemetry actions fired when discard button is clicked on setttings v2 and settings v2 respectively