### PR TITLE
Fix shared throughput for tables

### DIFF
--- a/src/Common/dataAccess/readDatabaseOffer.ts
+++ b/src/Common/dataAccess/readDatabaseOffer.ts
@@ -17,14 +17,12 @@ import { userContext } from "../../UserContext";
 export const readDatabaseOffer = async (
   params: DataModels.ReadDatabaseOfferParams
 ): Promise<DataModels.OfferWithHeaders> => {
-  if (userContext.defaultExperience === DefaultAccountExperienceType.Table) {
-    throw new Error("Reading database offer is not allowed for tables accounts");
-  }
-
   const clearMessage = logConsoleProgress(`Querying offer for database ${params.databaseId}`);
   let offerId = params.offerId;
   if (!offerId) {
-    offerId = await (window.authType === AuthType.AAD && !userContext.useSDKOperations
+    offerId = await (window.authType === AuthType.AAD &&
+    !userContext.useSDKOperations &&
+    userContext.defaultExperience !== DefaultAccountExperienceType.Table
       ? getDatabaseOfferIdWithARM(params.databaseId)
       : getDatabaseOfferIdWithSDK(params.databaseResourceId));
     if (!offerId) {

--- a/src/Common/dataAccess/updateOffer.ts
+++ b/src/Common/dataAccess/updateOffer.ts
@@ -60,9 +60,14 @@ export const updateOffer = async (params: UpdateOfferParams): Promise<Offer> => 
 
   try {
     if (window.authType === AuthType.AAD && !userContext.useSDKOperations) {
-      updatedOffer = await (params.collectionId
-        ? updateCollectionOfferWithARM(params)
-        : updateDatabaseOfferWithARM(params));
+      if (params.collectionId) {
+        updatedOffer = await updateCollectionOfferWithARM(params);
+      } else if (userContext.defaultExperience === DefaultAccountExperienceType.Table) {
+        // update table's database offer with SDK since RP doesn't support it
+        updatedOffer = await updateOfferWithSDK(params);
+      } else {
+        updatedOffer = await updateDatabaseOfferWithARM(params);
+      }
     } else {
       updatedOffer = await updateOfferWithSDK(params);
     }

--- a/src/Explorer/Tree/Database.ts
+++ b/src/Explorer/Tree/Database.ts
@@ -201,11 +201,7 @@ export default class Database implements ViewModels.Database {
   }
 
   public async loadOffer(): Promise<void> {
-    if (
-      !this.container.isServerlessEnabled() &&
-      this.container.defaultExperience() !== DefaultAccountExperienceType.Table &&
-      !this.offer()
-    ) {
+    if (!this.container.isServerlessEnabled() && !this.offer()) {
       const params: DataModels.ReadDatabaseOfferParams = {
         databaseId: this.id(),
         databaseResourceId: this.self


### PR DESCRIPTION
RP does not support reading or updating database level throughput for Tables API so I'm switching back to using SDK calls for these operations.