### PR TITLE
Use RP to read databases for all API

### DIFF
--- a/src/Common/dataAccess/readDatabases.ts
+++ b/src/Common/dataAccess/readDatabases.ts
@@ -12,16 +12,14 @@ import { sendNotificationForError } from "./sendNotificationForError";
 import { userContext } from "../../UserContext";
 
 export async function readDatabases(): Promise<DataModels.Database[]> {
+  if (userContext.defaultExperience === DefaultAccountExperienceType.Table) {
+    return [{ id: "TablesDB" } as DataModels.Database];
+  }
+
   let databases: DataModels.Database[];
   const clearMessage = logConsoleProgress(`Querying databases`);
   try {
-    if (
-      window.authType === AuthType.AAD &&
-      !userContext.useSDKOperations &&
-      userContext.defaultExperience !== DefaultAccountExperienceType.MongoDB &&
-      userContext.defaultExperience !== DefaultAccountExperienceType.Table &&
-      userContext.defaultExperience !== DefaultAccountExperienceType.Cassandra
-    ) {
+    if (window.authType === AuthType.AAD && !userContext.useSDKOperations) {
       databases = await readDatabasesWithARM();
     } else {
       const sdkResponse = await client()


### PR DESCRIPTION
Since I've cleaned up all the places that use `_rid` and `_self` of a database in my previous commit (https://github.com/Azure/cosmos-explorer/commit/d525afa14272ea3c7c90df2c20949aba2f145daa), we are safe to use RP to read databases for all APIs except Tables.

For Tables API, since RP doesn't support any database level operations, I have to hardcode the read database response. The only property we need in the Tables database is the id which is the string that we display in the resource tree.