### PR TITLE
[ID: 833708][Screen Reader - CosmosDB – New KeySpace] Visual label(K…

### DIFF
--- a/src/Explorer/Controls/ThroughputInput/ThroughputInputComponent.html
+++ b/src/Explorer/Controls/ThroughputInput/ThroughputInputComponent.html
@@ -45,7 +45,7 @@
 
     <input
       class="throughputModeRadio nonFirstRadio"
-      aria-label="Provisioned Throughput mode"
+      aria-label="Manual mode"
       type="radio"
       role="radio"
       tabindex="0"

--- a/src/Explorer/Controls/ThroughputInput/ThroughputInputComponentAutoscaleV3.html
+++ b/src/Explorer/Controls/ThroughputInput/ThroughputInputComponentAutoscaleV3.html
@@ -44,7 +44,7 @@
 
     <input
       class="throughputModeRadio nonFirstRadio"
-      aria-label="Provisioned Throughput mode"
+      aria-label="Manual mode"
       type="radio"
       role="radio"
       tabindex="0"

--- a/src/Explorer/Panes/AddDatabasePane.html
+++ b/src/Explorer/Panes/AddDatabasePane.html
@@ -75,7 +75,7 @@
           <input id="database-id" type="text" aria-required="true" autocomplete="off" pattern="[^/?#\\]*[^/?# \\]"
               title="May not end with space nor contain characters '\' '/' '#' '?'"
               size="40" class="collid" data-bind="textInput: databaseId, hasFocus: firstFieldHasFocus, attr: { placeholder: databaseIdPlaceHolder }"
-              aria-label="Database id" autofocus>
+              aria-label="Keyspace id" autofocus>
 
           <!-- Database provisioned throughput - Start -->
           <!-- ko if: canConfigureThroughput -->

--- a/src/Explorer/Panes/AddDatabasePane.html
+++ b/src/Explorer/Panes/AddDatabasePane.html
@@ -74,8 +74,8 @@
 
           <input id="database-id" type="text" aria-required="true" autocomplete="off" pattern="[^/?#\\]*[^/?# \\]"
               title="May not end with space nor contain characters '\' '/' '#' '?'"
-              size="40" class="collid" data-bind="textInput: databaseId, hasFocus: firstFieldHasFocus, attr: { placeholder: databaseIdPlaceHolder }"
-              aria-label="Keyspace id" autofocus>
+              size="40" class="collid" data-bind="textInput: databaseId, hasFocus: firstFieldHasFocus, attr: { 'aria-label': databaseIdLabel, 'placeholder': databaseIdPlaceHolder }"
+              autofocus>
 
           <!-- Database provisioned throughput - Start -->
           <!-- ko if: canConfigureThroughput -->


### PR DESCRIPTION
Expected Result:
Visual label(Keyspace id) and aria-label(Database id) should be same for Keyspace id edit field under New KeySpace blade.

current Result: changed