### PR TITLE
Fix notebook code complete selected dropdown item background color

### DIFF
--- a/src/Explorer/Notebook/NotebookRenderer/NotebookRenderer.less
+++ b/src/Explorer/Notebook/NotebookRenderer/NotebookRenderer.less
@@ -106,3 +106,7 @@
 .expanded::before {
     content: '';
 }
+
+.monaco-editor .monaco-list .main {
+    background-color: transparent;
+}


### PR DESCRIPTION
In Notebook code complete dropdown, moving and up/down active item does not update background color.
This is because the item background color has a `.main` class which is accidentally one of the `.main` rules in Data Explorer less file which should be more specific.

Rather than modifying our `.main {}` rule, which could break something, the easiest is to clear the background with a specific rule.