### PR TITLE
Allow users to switch between manual and autoscale for fixed collections

### DIFF
--- a/src/Explorer/Controls/Settings/SettingsSubComponents/ScaleComponent.tsx
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/ScaleComponent.tsx
@@ -98,11 +98,11 @@ export class ScaleComponent extends React.Component<ScaleComponentProps> {
   };
 
   public canThroughputExceedMaximumValue = (): boolean => {
-    const isPublicAzurePortal: boolean =
-      configContext.platform === Platform.Portal && !this.props.container.isRunningOnNationalCloud();
-    const hasPartitionKey = !!this.props.collection.partitionKey;
-
-    return isPublicAzurePortal && hasPartitionKey;
+    return (
+      !this.props.isFixedContainer &&
+      configContext.platform === Platform.Portal &&
+      !this.props.container.isRunningOnNationalCloud()
+    );
   };
 
   public getInitialNotificationElement = (): JSX.Element => {

--- a/src/Explorer/Controls/Settings/SettingsSubComponents/ThroughputInputComponents/ThroughputInputAutoPilotV3Component.tsx
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/ThroughputInputComponents/ThroughputInputAutoPilotV3Component.tsx
@@ -142,7 +142,7 @@ export class ThroughputInputAutoPilotV3Component extends React.Component<
 
     this.step = this.props.step ?? ThroughputInputAutoPilotV3Component.defaultStep;
     this.throughputInputMaxValue = this.props.canExceedMaximumValue ? Int32.Max : this.props.maximum;
-    this.autoPilotInputMaxValue = Int32.Max;
+    this.autoPilotInputMaxValue = this.props.isFixed ? this.props.maximum : Int32.Max;
   }
 
   public hasProvisioningTypeChanged = (): boolean =>
@@ -284,6 +284,7 @@ export class ThroughputInputAutoPilotV3Component extends React.Component<
           onChange={this.onSpendAckChecked}
         />
       )}
+      {this.props.isFixed && <p>When using a collection with fixed storage capacity, you can set up to 10,000 RU/s.</p>}
     </>
   );
 
@@ -323,14 +324,14 @@ export class ThroughputInputAutoPilotV3Component extends React.Component<
         />
       )}
 
-      {this.props.isFixed && <p>Choose unlimited storage capacity for more than 10,000 RU/s.</p>}
+      {this.props.isFixed && <p>When using a collection with fixed storage capacity, you can set up to 10,000 RU/s.</p>}
     </Stack>
   );
 
   public render(): JSX.Element {
     return (
       <Stack {...checkBoxAndInputStackProps}>
-        {!this.props.isFixed && this.renderThroughputModeChoices()}
+        {this.renderThroughputModeChoices()}
 
         {this.props.isAutoPilotSelected ? this.renderAutoPilotInput() : this.renderThroughputInput()}
       </Stack>

--- a/src/Explorer/Controls/Settings/SettingsUtils.test.tsx
+++ b/src/Explorer/Controls/Settings/SettingsUtils.test.tsx
@@ -91,7 +91,7 @@ describe("SettingsUtils", () => {
   it("getSanitizedInputValue", () => {
     const max = 100;
     expect(getSanitizedInputValue("", max)).toEqual(0);
-    expect(getSanitizedInputValue("999", max)).toEqual(99);
+    expect(getSanitizedInputValue("999", max)).toEqual(100);
     expect(getSanitizedInputValue("10", max)).toEqual(10);
   });
 });

--- a/src/Explorer/Controls/Settings/SettingsUtils.tsx
+++ b/src/Explorer/Controls/Settings/SettingsUtils.tsx
@@ -131,13 +131,12 @@ export const parseConflictResolutionProcedure = (procedureFromBackEnd: string): 
 };
 
 export const getSanitizedInputValue = (newValueString: string, max: number): number => {
-  let newValue = parseInt(newValueString);
+  const newValue = parseInt(newValueString);
   if (isNaN(newValue)) {
-    newValue = zeroValue;
-  } else if (newValue > max) {
-    newValue = Math.floor(newValue / 10);
+    return zeroValue;
   }
-  return newValue;
+  // make sure new value does not exceed the maximum throughput
+  return Math.min(newValue, max);
 };
 
 export const isDirty = (current: isDirtyTypes, baseline: isDirtyTypes): boolean => {

--- a/src/Explorer/Controls/ThroughputInput/ThroughputInputComponentAutoscaleV3.html
+++ b/src/Explorer/Controls/ThroughputInput/ThroughputInputComponentAutoscaleV3.html
@@ -119,6 +119,10 @@
       <span data-bind="text: spendAckText, attr: { for: spendAckId }"></span>
     </p>
     <!-- /ko -->
+
+    <!-- ko if: isFixed -->
+    <p>Choose unlimited storage capacity for more than 10,000 RU/s.</p>
+    <!-- /ko -->
   </div>
 
   <div data-bind="visible: !isAutoPilotSelected()">

--- a/src/Explorer/Tabs/SettingsTab.ts
+++ b/src/Explorer/Tabs/SettingsTab.ts
@@ -492,11 +492,11 @@ export default class SettingsTab extends TabsBase implements ViewModels.WaitsFor
     });
 
     this.canThroughputExceedMaximumValue = ko.pureComputed<boolean>(() => {
-      const isPublicAzurePortal: boolean =
-        configContext.platform === Platform.Portal && !this.container.isRunningOnNationalCloud();
-      const hasPartitionKey = !!this.collection.partitionKey;
-
-      return isPublicAzurePortal && hasPartitionKey;
+      return (
+        this._isFixedContainer() &&
+        configContext.platform === Platform.Portal &&
+        !this.container.isRunningOnNationalCloud()
+      );
     });
 
     this.canRequestSupport = ko.pureComputed(() => {


### PR DESCRIPTION
- removed the `isFixed` check in both new and old settings tab so that the options to switch between manual and autoscale shows up for fixed collections
- updated the message below the text box to inform the users that the max RU for fixed collections is 10000
- updated validation rule so that the max RU cannot exceed 10000 for fixed collections for both autoscale and manual