### PR TITLE
Add Tab Name to Telemetry

### DIFF
--- a/src/Explorer/Tabs/TabsBase.ts
+++ b/src/Explorer/Tabs/TabsBase.ts
@@ -85,6 +85,7 @@ export default class TabsBase extends WaitsForTemplateViewModel {
     explorer.tabsManager.closeTab(this.tabId, explorer);
 
     TelemetryProcessor.trace(Action.Tab, ActionModifiers.Close, {
+      tabName: this.constructor.name,
       databaseAccountName: this.getContainer().databaseAccount().name,
       defaultExperience: this.getContainer().defaultExperience(),
       dataExplorerArea: Constants.Areas.Tab,
@@ -143,6 +144,7 @@ export default class TabsBase extends WaitsForTemplateViewModel {
     this.updateNavbarWithTabsButtons();
 
     TelemetryProcessor.trace(Action.Tab, ActionModifiers.Open, {
+      tabName: this.constructor.name,
       databaseAccountName: this.getContainer().databaseAccount().name,
       defaultExperience: this.getContainer().defaultExperience(),
       dataExplorerArea: Constants.Areas.Tab,


### PR DESCRIPTION
Can't tell from current telemetry the name of the tab that was opened/closed