### PR TITLE
Fix create and delete database

### DIFF
--- a/src/Explorer/Panes/AddDatabasePane.ts
+++ b/src/Explorer/Panes/AddDatabasePane.ts
@@ -296,11 +296,15 @@ export default class AddDatabasePane extends ContextualPaneBase {
     this.isExecuting(true);
 
     const createDatabaseParams: DataModels.CreateDatabaseParams = {
-      autoPilotMaxThroughput: this.maxAutoPilotThroughputSet(),
       databaseId: addDatabasePaneStartMessage.database.id,
-      databaseLevelThroughput: addDatabasePaneStartMessage.database.shared,
-      offerThroughput: addDatabasePaneStartMessage.offerThroughput
+      databaseLevelThroughput: addDatabasePaneStartMessage.database.shared
     };
+
+    if (this.isAutoPilotSelected()) {
+      createDatabaseParams.autoPilotMaxThroughput = this.maxAutoPilotThroughputSet();
+    } else {
+      createDatabaseParams.offerThroughput = addDatabasePaneStartMessage.offerThroughput;
+    }
 
     createDatabase(createDatabaseParams).then(
       (database: DataModels.Database) => {

--- a/src/Utils/arm/request.ts
+++ b/src/Utils/arm/request.ts
@@ -93,6 +93,10 @@ async function getOperationStatus(operationStatusUrl: string) {
     throw new AbortError(error);
   }
 
+  if (response.status === 204) {
+    return;
+  }
+
   const body = await response.json();
   const status = body.status;
   if (!status && response.status === 200) {


### PR DESCRIPTION
1. Create database issue:
	- Databases created via create database panel always have auto pilot selected, even if manual throughput is selected.
	- This is because the panel sets the auto pilot throughput value even if manual throughput is selected. When we send the create database request, we check for autoscale throughput setting first, so we always end up creating a database with auto pilot enabled.
	- The fix is to only set the `autoPilotMaxThroughput` of the `CreateDatabaseParams` if autos pilot is selected in the panel.
2. Delete database issue:
	- The `Location` header of the delete request returns `204` instead of `200` when the operation completes.
	- The fix is to add an additional check for `204` status code when polling for operation status.