### PR TITLE
Added loadAutopilotOfferWithRetry

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -437,3 +437,8 @@ export class TerminalQueryParams {
   public static readonly SubscriptionId = "subscriptionId";
   public static readonly TerminalEndpoint = "terminalEndpoint";
 }
+
+export class LoadOfferRetry {
+  public static readonly MaxRetries = 5;
+  public static readonly RetryAfterMilliSeconds = 5000;
+}

--- a/src/Contracts/ViewModels.ts
+++ b/src/Contracts/ViewModels.ts
@@ -162,6 +162,7 @@ export interface Collection extends CollectionBase {
   loadStoredProcedures(): Promise<any>;
   loadTriggers(): Promise<any>;
   loadOffer(): Promise<void>;
+  loadAutopilotOfferWithRetry(): Promise<DataModels.Offer>;
 
   createStoredProcedureNode(data: StoredProcedureDefinition & Resource): StoredProcedure;
   createUserDefinedFunctionNode(data: UserDefinedFunctionDefinition & Resource): UserDefinedFunction;

--- a/src/Explorer/Controls/Settings/SettingsComponent.tsx
+++ b/src/Explorer/Controls/Settings/SettingsComponent.tsx
@@ -532,11 +532,12 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
           }
           const updatedOffer: DataModels.Offer = await updateOffer(updateOfferParams);
           this.collection.offer(updatedOffer);
-          this.setState({ isScaleSaveable: false, isScaleDiscardable: false });
+
           if (this.state.isAutoPilotSelected) {
+            const autoPilotOffer = await this.collection.loadAutopilotOfferWithRetry();
             this.setState({
-              autoPilotThroughput: updatedOffer.content.offerAutopilotSettings.maxThroughput,
-              autoPilotThroughputBaseline: updatedOffer.content.offerAutopilotSettings.maxThroughput
+              autoPilotThroughput: autoPilotOffer.content.offerAutopilotSettings.maxThroughput,
+              autoPilotThroughputBaseline: autoPilotOffer.content.offerAutopilotSettings.maxThroughput
             });
           } else {
             this.setState({
@@ -544,6 +545,8 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
               throughputBaseline: updatedOffer.content.offerThroughput
             });
           }
+
+          this.setState({ isScaleSaveable: false, isScaleDiscardable: false });
         }
       }
       this.container.isRefreshingExplorer(false);

--- a/src/Explorer/Tree/Collection.ts
+++ b/src/Explorer/Tree/Collection.ts
@@ -1343,7 +1343,7 @@ export default class Collection implements ViewModels.Collection {
       retryCount++;
     }
     throw new Error(
-      "Max Retries for loading offer are completed. Offer does not have an offerAutopilotSettings field."
+      "Max retries for loading offer are completed. Offer does not have an Autopilot settings field."
     );
   }
 


### PR DESCRIPTION
A spurious bug that seems to appear when updating offer from manual -> autopilot is that the updated offer does not immediately reflect in the Offer Object received after running updateOffer(0.
So an 'offerAutopilotSettings' field is not present in the returned offer. This surfaces as a  **Cannot   read property 'maxThroughput' of undefined** error when the update for offer is done in the Scale subtab.

This PR adds a retry mechanism to loadOffer when this field is not present, and surfaces a more verbose message when the retries have been exhausted.


A spurious bug that seems to appear when updating offer from manual -> autopilot is that the updated offer does not immediately reflect in the Offer Object received after running updateOffer(0.
So an 'offerAutopilotSettings' field is not present in the returned offer. This surfaces as a  **Cannot   read property 'maxThroughput' of undefined** error when the update for offer is done in the Scale subtab.

This PR adds a retry mechanism to loadOffer when this field is not present, and surfaces a more verbose message when the retries have been exhausted.


