### PR TITLE
[526416][Visual Requirement-Data Explorer (iframe)]On the Data Explorer page, luminosity contrast ratio of the borderline button is less than 3.:1.

### DIFF
--- a/src/Explorer/SplashScreen/SplashScreenComponent.less
+++ b/src/Explorer/SplashScreen/SplashScreenComponent.less
@@ -47,7 +47,7 @@
         padding: 32px 16px;
         display: flex;
         background-color: @BaseLight;
-        border: 1px solid #E5E5E5;
+        border: 1px solid #949494;
         box-sizing: border-box;
         box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
         border-radius: 4px;


### PR DESCRIPTION
Repro Steps:
1. Open URL: https://ms.portal.azure.com/
2. Login via valid credentials
3. Navigate to "Azure Cosmos DB" from left pane and select it.
4. Navigate to any of the Azure Cosmos DB which is already created and select it.
5. Navigate to "Data Explorer" from the left and select it.
6. Navigate through all the controls under Data Explorer blade.
7. Open CCA tool and check luminosity contrast ratio of borderline control i.e Start with sample button.
8. Verify, if the luminosity ratio of the borderline control is greater than 3:1 or less than 3:1.


Actual Result:
Luminosity contrast ratio of the borderline control is less than 3:1 i.e 1.3:1.

Expected result:
Luminosity contrast ratio of the borderline control should be 3:1 or greater than 3:1.

Current solution make color #949494 to contrast #FFFFFF, The ratio is 3.03
https://msdata.visualstudio.com/CosmosDB/_workitems/edit/526416