### PR TITLE
Only call getCollectionDataUsageSize for AAD users

### DIFF
--- a/src/Common/dataAccess/getCollectionDataUsageSize.ts
+++ b/src/Common/dataAccess/getCollectionDataUsageSize.ts
@@ -1,3 +1,4 @@
+import { AuthType } from "../../AuthType";
 import { armRequest } from "../../Utils/arm/request";
 import { configContext } from "../../ConfigContext";
 import { handleError } from "../ErrorHandlingUtils";
@@ -40,6 +41,10 @@ interface MetricsResponse {
 }
 
 export const getCollectionUsageSizeInKB = async (databaseName: string, containerName: string): Promise<number> => {
+  if (window.authType !== AuthType.AAD) {
+    return undefined;
+  }
+
   const subscriptionId = userContext.subscriptionId;
   const resourceGroup = userContext.resourceGroup;
   const accountName = userContext.databaseAccount.name;


### PR DESCRIPTION
`getCollectionDataUsageSize` uses the Azure Monitor RP call which doesn't work for non-AAD users. Currently the collection data usage size is only used for the MinRU survey that we display in the settings tab. Discussed with @southpolesteve: we will hide the survey for non-AAD users for now.