### PR TITLE
Fix missing scrollbar in left pane when too many collections/notebooks

### DIFF
--- a/less/tree.less
+++ b/less/tree.less
@@ -4,6 +4,9 @@
 .resourceTree {
     height: 100%;
     flex: 0 0 auto;
+    .main {
+        height: 100%;
+    }
 }
 
 .resourceTreeScroll {


### PR DESCRIPTION
Constrain left pane container to height: 100% so that scrollbar show up when content wants to overflow.
The `main` classname seems too generic, but I left it alone (so I don't break anything), since this part will eventually be ported to React.