### PR TITLE
Warn on SubQuery

### DIFF
--- a/src/Explorer/Tabs/QueryTab.html
+++ b/src/Explorer/Tabs/QueryTab.html
@@ -11,6 +11,15 @@
       Start by writing a Mongo query, for example: <strong>{'id':'foo'}</strong> or <strong>{ }</strong> to get all the
       documents.
     </div>
+    <div class="warningErrorContainer" aria-live="assertive" data-bind="visible: maybeSubQuery">
+      <div class="warningErrorContent">
+          <span><img class="paneErrorIcon" src="/error_red.svg" alt="Error"></span>
+          <span class="warningErrorDetailsLinkContainer">
+              We have detecetd you may be using a subquery. Non-correlated subqueries are not supported. 
+              <a href="https://docs.microsoft.com/en-us/azure/cosmos-db/sql-query-subquery">Please see Cosmos sub query documentation for further information</a>
+          </span>
+      </div>
+  </div>
     <div class="queryEditorWithSplitter" data-bind="attr: { id: queryEditorId }">
       <editor
         class="queryEditor"

--- a/src/Explorer/Tabs/QueryTab.html
+++ b/src/Explorer/Tabs/QueryTab.html
@@ -13,13 +13,15 @@
     </div>
     <div class="warningErrorContainer" aria-live="assertive" data-bind="visible: maybeSubQuery">
       <div class="warningErrorContent">
-          <span><img class="paneErrorIcon" src="/error_red.svg" alt="Error"></span>
-          <span class="warningErrorDetailsLinkContainer">
-              We have detecetd you may be using a subquery. Non-correlated subqueries are not supported. 
-              <a href="https://docs.microsoft.com/en-us/azure/cosmos-db/sql-query-subquery">Please see Cosmos sub query documentation for further information</a>
-          </span>
+        <span><img class="paneErrorIcon" src="/error_red.svg" alt="Error"/></span>
+        <span class="warningErrorDetailsLinkContainer">
+          We have detecetd you may be using a subquery. Non-correlated subqueries are not supported.
+          <a href="https://docs.microsoft.com/en-us/azure/cosmos-db/sql-query-subquery"
+            >Please see Cosmos sub query documentation for further information</a
+          >
+        </span>
       </div>
-  </div>
+    </div>
     <div class="queryEditorWithSplitter" data-bind="attr: { id: queryEditorId }">
       <editor
         class="queryEditor"

--- a/src/Explorer/Tabs/QueryTab.html
+++ b/src/Explorer/Tabs/QueryTab.html
@@ -13,7 +13,7 @@
     </div>
     <div class="warningErrorContainer" aria-live="assertive" data-bind="visible: maybeSubQuery">
       <div class="warningErrorContent">
-        <span><img class="paneErrorIcon" src="/Info.svg" alt="Error"/></span>
+        <span><img class="paneErrorIcon" src="/info_color.svg" alt="Error"/></span>
         <span class="warningErrorDetailsLinkContainer">
           We have detected you may be using a subquery. Non-correlated subqueries are not currently supported.
           <a href="https://docs.microsoft.com/en-us/azure/cosmos-db/sql-query-subquery"

--- a/src/Explorer/Tabs/QueryTab.html
+++ b/src/Explorer/Tabs/QueryTab.html
@@ -13,9 +13,9 @@
     </div>
     <div class="warningErrorContainer" aria-live="assertive" data-bind="visible: maybeSubQuery">
       <div class="warningErrorContent">
-        <span><img class="paneErrorIcon" src="/error_red.svg" alt="Error"/></span>
+        <span><img class="paneErrorIcon" src="/Info.svg" alt="Error"/></span>
         <span class="warningErrorDetailsLinkContainer">
-          We have detecetd you may be using a subquery. Non-correlated subqueries are not supported.
+          We have detected you may be using a subquery. Non-correlated subqueries are not currently supported.
           <a href="https://docs.microsoft.com/en-us/azure/cosmos-db/sql-query-subquery"
             >Please see Cosmos sub query documentation for further information</a
           >

--- a/src/Explorer/Tabs/QueryTab.ts
+++ b/src/Explorer/Tabs/QueryTab.ts
@@ -121,7 +121,6 @@ export default class QueryTab extends TabsBase implements ViewModels.WaitsForTem
 
     this.maybeSubQuery = ko.computed<boolean>(function() {
       const sql = this.sqlQueryEditorContent();
-      console.log(sql, /.*\(.*SELECT.*\)/i.test(sql));
       return sql && /.*\(.*SELECT.*\)/i.test(sql);
     }, this);
 

--- a/src/Explorer/Tabs/QueryTab.ts
+++ b/src/Explorer/Tabs/QueryTab.ts
@@ -121,8 +121,8 @@ export default class QueryTab extends TabsBase implements ViewModels.WaitsForTem
 
     this.maybeSubQuery = ko.computed<boolean>(function() {
       const sql = this.sqlQueryEditorContent();
-      console.log(sql, /.*\(.*SELECT.*\)/.test(sql));
-      return sql && /.*\(.*SELECT.*\)/.test(sql);
+      console.log(sql, /.*\(.*SELECT.*\)/i.test(sql));
+      return sql && /.*\(.*SELECT.*\)/i.test(sql);
     }, this);
 
     this.saveQueryButton = {

--- a/src/Explorer/Tabs/QueryTab.ts
+++ b/src/Explorer/Tabs/QueryTab.ts
@@ -1,5 +1,4 @@
 import * as ko from "knockout";
-import Q from "q";
 import * as Constants from "../../Common/Constants";
 import * as DataModels from "../../Contracts/DataModels";
 import * as ViewModels from "../../Contracts/ViewModels";
@@ -7,7 +6,6 @@ import { Action } from "../../Shared/Telemetry/TelemetryConstants";
 import TabsBase from "./TabsBase";
 import { HashMap } from "../../Common/HashMap";
 import * as HeadersUtility from "../../Common/HeadersUtility";
-import * as Logger from "../../Common/Logger";
 import { Splitter, SplitterBounds, SplitterDirection } from "../../Common/Splitter";
 import * as TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
 import ExecuteQueryIcon from "../../../images/ExecuteQuery.svg";
@@ -31,6 +29,7 @@ export default class QueryTab extends TabsBase implements ViewModels.WaitsForTem
   public fetchNextPageButton: ViewModels.Button;
   public saveQueryButton: ViewModels.Button;
   public initialEditorContent: ko.Observable<string>;
+  public maybeSubQuery: ko.Computed<boolean>;
   public sqlQueryEditorContent: ko.Observable<string>;
   public selectedContent: ko.Observable<string>;
   public sqlStatementToExecute: ko.Observable<string>;
@@ -119,6 +118,12 @@ export default class QueryTab extends TabsBase implements ViewModels.WaitsForTem
       const container = this.collection && this.collection.container;
       return (container && (container.isPreferredApiDocumentDB() || container.isPreferredApiGraph())) || false;
     });
+
+    this.maybeSubQuery = ko.computed<boolean>(function() {
+      const sql = this.sqlQueryEditorContent();
+      console.log(sql, /.*\(.*SELECT.*\)/.test(sql));
+      return sql && /.*\(.*SELECT.*\)/.test(sql);
+    }, this);
 
     this.saveQueryButton = {
       enabled: this._isSaveQueriesEnabled,


### PR DESCRIPTION
Cosmos does not support non-correlated subqueries https://docs.microsoft.com/en-us/azure/cosmos-db/sql-query-subquery But unfortunately there is no way for a user to know this as the query still executes and returns results. Query team is working on supporting this, but as a stop gap we can use a simple regex to try and direct users to the sub query docs.

![image](https://user-images.githubusercontent.com/471400/104048320-a6d0f600-51a8-11eb-9528-befbef955179.png)
