### PR TITLE
A11y fixes - Add a skip link and remove duplicate ids 

### DIFF
--- a/less/hostedexplorer.less
+++ b/less/hostedexplorer.less
@@ -13,6 +13,11 @@
 @NavMediumSpace: 10px;
 @NavLargeSpace: 15px;
 
+.skip-link {
+    position: fixed;
+    top: -200px;
+}
+
 html {
     font-family: wf_segoe-ui_normal, "Segoe UI", "Segoe WP", Tahoma, Arial, sans-serif;
     padding: 0px;

--- a/src/Explorer/Panes/AddCollectionPane.html
+++ b/src/Explorer/Panes/AddCollectionPane.html
@@ -257,7 +257,7 @@
                               range of values and is likely to have evenly distributed access patterns.</span>
                       </span>
                   </p>
-                  <input type="text" id="partitionKeyValue" data-test="addCollection-partitionKeyValue" aria-required="true" size="40"
+                  <input type="text" id="addCollection-partitionKeyValue" data-test="addCollection-partitionKeyValue" aria-required="true" size="40"
                       class="textfontclr collid" data-bind="textInput: partitionKey,
                                                 attr: {
                                                     placeholder: partitionKeyPlaceholder,

--- a/src/hostedExplorer.html
+++ b/src/hostedExplorer.html
@@ -7,6 +7,7 @@
   </head>
 
   <body>
+    <a class="skip-link" href="#data-explorer-content">Skip to content</a>
     <header>
       <div class="items" role="menubar">
         <div class="cosmosDBTitle">
@@ -48,16 +49,18 @@
 
     <switch-directory-pane params="{data: switchDirectoryPane}"></switch-directory-pane>
 
-    <!-- TODO generate version number dynamically -->
-    <iframe
-      id="explorerMenu"
-      name="explorer"
-      class="iframe"
-      title="explorer"
-      src="explorer.html?v=1.0.1&platform=Hosted"
-      data-bind="visible: navigationSelection() === 'explorer'"
-    >
-    </iframe>
+    <div id="data-explorer-content">
+      <!-- TODO generate version number dynamically -->
+      <iframe
+        id="explorerMenu"
+        name="explorer"
+        class="iframe"
+        title="explorer"
+        src="explorer.html?v=1.0.1&platform=Hosted"
+        data-bind="visible: navigationSelection() === 'explorer'"
+      >
+      </iframe>
+    </div>
 
     <div data-bind="react: firewallWarningComponentAdapter"></div>
     <div data-bind="react: dialogComponentAdapter"></div>


### PR DESCRIPTION
A11y fixes - Add a skip link and remove duplicate ids 

- Add a skip link to allow people who navigate sequentially through content more direct access to the primary content of the Data Explorer
- Rename id of partition key field in Add Collection Pane to ensure no elements contain duplicate attributes.