### PR TITLE
Properly construct the query to delete Cassandra row

### DIFF
--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -312,9 +312,10 @@ export class CassandraAPIDataClient extends TableDataClient {
         const clearMessage = NotificationConsoleUtils.logConsoleProgress(`Deleting row ${currEntityToDelete.RowKey._}`);
         const partitionKeyValue = currEntityToDelete[partitionKeyProperty];
         const currQuery =
-          query + this.isStringType(partitionKeyValue.$)
+          query +
+          (this.isStringType(partitionKeyValue.$)
             ? `${partitionKeyProperty} = '${partitionKeyValue._}'`
-            : `${partitionKeyProperty} = ${partitionKeyValue._}`;
+            : `${partitionKeyProperty} = ${partitionKeyValue._}`);
 
         try {
           await this.queryDocuments(collection, currQuery);


### PR DESCRIPTION
The query for deleting a Cassandra table row is not constructed properly. Need to add a pair of brackets to fix the order of concatenating the query string.