### PR TITLE
Delete Cassandra tables/keyspaces via ARM

### DIFF
--- a/src/Explorer/Panes/DeleteCollectionConfirmationPane.ts
+++ b/src/Explorer/Panes/DeleteCollectionConfirmationPane.ts
@@ -50,18 +50,7 @@ export default class DeleteCollectionConfirmationPane extends ContextualPaneBase
       dataExplorerArea: Constants.Areas.ContextualPane,
       paneTitle: this.title(),
     });
-    let promise: Promise<any>;
-    if (this.container.isPreferredApiCassandra()) {
-      promise = ((<CassandraAPIDataClient>this.container.tableDataClient).deleteTableOrKeyspace(
-        this.container.databaseAccount().properties.cassandraEndpoint,
-        this.container.databaseAccount().id,
-        `DROP TABLE ${selectedCollection.databaseId}.${selectedCollection.id()};`,
-        this.container
-      ) as unknown) as Promise<any>;
-    } else {
-      promise = deleteCollection(selectedCollection.databaseId, selectedCollection.id());
-    }
-    return promise.then(
+    return deleteCollection(selectedCollection.databaseId, selectedCollection.id()).then(
       () => {
         this.isExecuting(false);
         this.close();

--- a/src/Explorer/Panes/DeleteCollectionConfirmationPane.ts
+++ b/src/Explorer/Panes/DeleteCollectionConfirmationPane.ts
@@ -1,9 +1,7 @@
 import * as ko from "knockout";
-import Q from "q";
 import * as ViewModels from "../../Contracts/ViewModels";
 import * as Constants from "../../Common/Constants";
 import { Action, ActionModifiers } from "../../Shared/Telemetry/TelemetryConstants";
-import { CassandraAPIDataClient } from "../Tables/TableDataClient";
 import { ConsoleDataType } from "../Menus/NotificationConsole/NotificationConsoleComponent";
 import { ContextualPaneBase } from "./ContextualPaneBase";
 import { DefaultExperienceUtility } from "../../Shared/DefaultExperienceUtility";

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -416,41 +416,6 @@ export class CassandraAPIDataClient extends TableDataClient {
     return deferred.promise;
   }
 
-  public deleteTableOrKeyspace(
-    cassandraEndpoint: string,
-    resourceId: string,
-    deleteQuery: string,
-    explorer: Explorer
-  ): Q.Promise<any> {
-    const deferred = Q.defer<any>();
-    const notificationId = NotificationConsoleUtils.logConsoleMessage(
-      ConsoleDataType.InProgress,
-      `Deleting resource with query ${deleteQuery}`
-    );
-    this.createOrDeleteQuery(cassandraEndpoint, resourceId, deleteQuery, explorer)
-      .then(
-        () => {
-          NotificationConsoleUtils.logConsoleMessage(
-            ConsoleDataType.Info,
-            `Successfully deleted resource with query ${deleteQuery}`
-          );
-          deferred.resolve();
-        },
-        (error) => {
-          handleError(
-            error,
-            "DeleteKeyspaceOrTableCassandra",
-            `Error while deleting resource with query ${deleteQuery}`
-          );
-          deferred.reject(error);
-        }
-      )
-      .finally(() => {
-        NotificationConsoleUtils.clearInProgressMessageWithId(notificationId);
-      });
-    return deferred.promise;
-  }
-
   public getTableKeys(collection: ViewModels.Collection): Q.Promise<CassandraTableKeys> {
     if (!!collection.cassandraKeys) {
       return Q.resolve(collection.cassandraKeys);


### PR DESCRIPTION
Missed this during our mass ARM migration. Cassandra deletes were still going through proxy instead of ARM.