### PR TITLE
Fix start with samples in Gremlin API

### DIFF
--- a/sampleData/gremlinSampleData.json
+++ b/sampleData/gremlinSampleData.json
@@ -3,6 +3,7 @@
   "offerThroughput": 400,
   "databaseLevelThroughput": false,
   "collectionId": "Persons",
+  "createNewDatabase": true,
   "partitionKey": { "kind": "Hash", "paths": ["/name"] },
   "data": [
     "g.addV('person').property(id, '1').property('name', 'Eva').property('age', 44)",


### PR DESCRIPTION
The `gremlinSampleData.json` is missing the `createNewDatabase` flag which allows the `SamplesDB` database to be created before creating the sample container.