### PR TITLE
Fix serverless create issue

### DIFF
--- a/src/Explorer/Panes/AddCollectionPane.ts
+++ b/src/Explorer/Panes/AddCollectionPane.ts
@@ -680,8 +680,10 @@ export default class AddCollectionPane extends ContextualPaneBase {
     this.formWarnings("");
     this.databaseCreateNewShared(this.getSharedThroughputDefault());
     this.shouldCreateMongoWildcardIndex(this.container.isMongoIndexingEnabled());
-    this.isAutoPilotSelected(this.container.isAutoscaleDefaultEnabled());
-    this.isSharedAutoPilotSelected(this.container.isAutoscaleDefaultEnabled());
+    if (!this.container.isServerlessEnabled()) {
+      this.isAutoPilotSelected(this.container.isAutoscaleDefaultEnabled());
+      this.isSharedAutoPilotSelected(this.container.isAutoscaleDefaultEnabled());
+    }
     if (this.isPreferredApiTable() && !databaseId) {
       databaseId = SharedConstants.CollectionCreation.TablesAPIDefaultDatabase;
     }

--- a/src/Explorer/Panes/CassandraAddCollectionPane.ts
+++ b/src/Explorer/Panes/CassandraAddCollectionPane.ts
@@ -289,7 +289,9 @@ export default class CassandraAddCollectionPane extends ContextualPaneBase {
 
   public open() {
     super.open();
-    this.isAutoPilotSelected(this.container.isAutoscaleDefaultEnabled());
+    if (!this.container.isServerlessEnabled()) {
+      this.isAutoPilotSelected(this.container.isAutoscaleDefaultEnabled());
+    }
     const addCollectionPaneOpenMessage = {
       databaseAccountName: this.container.databaseAccount().name,
       defaultExperience: this.container.defaultExperience(),


### PR DESCRIPTION
The `isAutoPilotSelected` flag needs to be true when creating a collection on a serverless account.