### PR TITLE
Removed published, favourites tabs for hosted gallery

### DIFF
--- a/src/Explorer/Controls/NotebookGallery/GalleryViewerComponent.tsx
+++ b/src/Explorer/Controls/NotebookGallery/GalleryViewerComponent.tsx
@@ -33,7 +33,6 @@ import { InfoComponent } from "./InfoComponent/InfoComponent";
 import { handleError } from "../../../Common/ErrorHandlingUtils";
 import { trace } from "../../../Shared/Telemetry/TelemetryProcessor";
 import { Action, ActionModifiers } from "../../../Shared/Telemetry/TelemetryConstants";
-import { configContext, Platform } from "../../../ConfigContext";
 
 export interface GalleryViewerComponentProps {
   container?: Explorer;
@@ -162,7 +161,7 @@ export class GalleryViewerComponent extends React.Component<GalleryViewerCompone
       )
     );
 
-    if (configContext.platform !== Platform.Hosted) {
+    if (this.props.container) {
       tabs.push(this.createFavoritesTab(GalleryTab.Favorites, this.state.favoriteNotebooks));
       tabs.push(this.createPublishedNotebooksTab(GalleryTab.Published, this.state.publishedNotebooks));
     }

--- a/src/Explorer/Controls/NotebookGallery/GalleryViewerComponent.tsx
+++ b/src/Explorer/Controls/NotebookGallery/GalleryViewerComponent.tsx
@@ -33,6 +33,7 @@ import { InfoComponent } from "./InfoComponent/InfoComponent";
 import { handleError } from "../../../Common/ErrorHandlingUtils";
 import { trace } from "../../../Shared/Telemetry/TelemetryProcessor";
 import { Action, ActionModifiers } from "../../../Shared/Telemetry/TelemetryConstants";
+import { configContext, Platform } from "../../../ConfigContext";
 
 export interface GalleryViewerComponentProps {
   container?: Explorer;
@@ -161,8 +162,10 @@ export class GalleryViewerComponent extends React.Component<GalleryViewerCompone
       )
     );
 
-    tabs.push(this.createFavoritesTab(GalleryTab.Favorites, this.state.favoriteNotebooks));
-    tabs.push(this.createPublishedNotebooksTab(GalleryTab.Published, this.state.publishedNotebooks));
+    if (configContext.platform !== Platform.Hosted) {
+      tabs.push(this.createFavoritesTab(GalleryTab.Favorites, this.state.favoriteNotebooks));
+      tabs.push(this.createPublishedNotebooksTab(GalleryTab.Published, this.state.publishedNotebooks));
+    }
 
     const pivotProps: IPivotProps = {
       onLinkClick: this.onPivotChange,

--- a/src/Explorer/Controls/NotebookGallery/__snapshots__/GalleryViewerComponent.test.tsx.snap
+++ b/src/Explorer/Controls/NotebookGallery/__snapshots__/GalleryViewerComponent.test.tsx.snap
@@ -180,34 +180,6 @@ exports[`GalleryViewerComponent renders 1`] = `
         </Stack>
       </div>
     </PivotItem>
-    <PivotItem
-      headerText="My favorites"
-      itemKey="Favorites"
-      key="Favorites"
-      style={
-        Object {
-          "marginTop": 20,
-        }
-      }
-    >
-      <StyledSpinnerBase
-        size={3}
-      />
-    </PivotItem>
-    <PivotItem
-      headerText="My published work"
-      itemKey="Published"
-      key="Published"
-      style={
-        Object {
-          "marginTop": 20,
-        }
-      }
-    >
-      <StyledSpinnerBase
-        size={3}
-      />
-    </PivotItem>
   </StyledPivotBase>
 </div>
 `;


### PR DESCRIPTION
This PR removes published and favourites tabs when users sees the gallery through the cosmos.azure.com/gallery.html landing page and is not logged in. In such a case, the container passed to GalleryViewerComponent is undefind, and it used as a check.

Portal experience:
<img width="569" alt="portal - all tabs" src="https://user-images.githubusercontent.com/13487215/109493724-c1ee1280-7a41-11eb-96b4-51567f6a2254.PNG">


Stand alone Gallery experience:
<img width="408" alt="public gallery-no tabs" src="https://user-images.githubusercontent.com/13487215/109493745-c9adb700-7a41-11eb-8c10-7878d08edc2f.PNG">

