### PR TITLE
Retry E2E tests twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           npm start &
           node utils/cleanupDBs.js
           npm run wait-for-server
-          npm run test:e2e
+          npm run test:e2e || npm run test:e2e
         shell: bash
         env:
           NODE_TLS_REJECT_UNAUTHORIZED: 0


### PR DESCRIPTION
This is a bit of a hack, but it will retry E2E tests a second time if they fail. These tests have been flaky lately but almost always pass on the second time they are run.