### PR TITLE
Notebook viewer bug fix

### DIFF
--- a/src/NotebookViewer/NotebookViewer.tsx
+++ b/src/NotebookViewer/NotebookViewer.tsx
@@ -11,6 +11,7 @@ import { IGalleryItem, JunoClient } from "../Juno/JunoClient";
 import * as GalleryUtils from "../Utils/GalleryUtils";
 import { GalleryHeaderComponent } from "../Explorer/Controls/Header/GalleryHeaderComponent";
 import { FileSystemUtil } from "../Explorer/Notebook/FileSystemUtil";
+import { GalleryTab } from "../Explorer/Controls/NotebookGallery/GalleryViewerComponent";
 
 const onInit = async () => {
   initializeIcons();
@@ -21,7 +22,10 @@ const onInit = async () => {
   let onBackClick: () => void;
   if (galleryViewerProps.selectedTab !== undefined) {
     backNavigationText = GalleryUtils.getTabTitle(galleryViewerProps.selectedTab);
-    onBackClick = () => (window.location.href = `${configContext.hostedExplorerURL}gallery.html`);
+    onBackClick = () =>
+      (window.location.href = `${configContext.hostedExplorerURL}gallery.html?tab=${
+        GalleryTab[galleryViewerProps.selectedTab]
+      }`);
   }
   const hideInputs = notebookViewerProps.hideInputs;
 


### PR DESCRIPTION
When the notebook viewer gets a tab name in the url, it does not propagate it to the Gallery link which is opened when the back arrow is clicked. This PR fixes that error. This is needed now since public gallery is going to be available as well.

![notebook viewer fix](https://user-images.githubusercontent.com/13487215/109713980-b8a29a00-7b56-11eb-833a-77906e6ce8cc.gif)
