### PR TITLE
Fix subscription leak

### DIFF
--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -41,17 +41,27 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
   private static readonly failoverUrl = "https://docs.microsoft.com/azure/cosmos-db/high-availability";
 
   private readonly container: Explorer;
+  private subscriptions: Array<{ dispose: () => void }>;
 
   constructor(props: SplashScreenProps) {
     super(props);
     this.container = props.explorer;
-    this.container.tabsManager.openedTabs.subscribe(() => this.setState({}));
-    this.container.selectedNode.subscribe(() => this.setState({}));
-    this.container.isNotebookEnabled.subscribe(() => this.setState({}));
   }
 
   public shouldComponentUpdate() {
     return this.container.tabsManager.openedTabs.length === 0;
+  }
+
+  public componentWillUnmount() {
+    while (this.subscriptions.length) this.subscriptions.pop().dispose();
+  }
+
+  public componentDidMount() {
+    this.subscriptions.push(
+      this.container.tabsManager.openedTabs.subscribe(() => this.setState({})),
+      this.container.selectedNode.subscribe(() => this.setState({})),
+      this.container.isNotebookEnabled.subscribe(() => this.setState({}))
+    );
   }
 
   private clearMostRecent = (): void => {

--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -46,6 +46,7 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
   constructor(props: SplashScreenProps) {
     super(props);
     this.container = props.explorer;
+    this.subscriptions = [];
   }
 
   public shouldComponentUpdate() {

--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -53,7 +53,9 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
   }
 
   public componentWillUnmount() {
-    while (this.subscriptions.length) this.subscriptions.pop().dispose();
+    while (this.subscriptions.length) {
+      this.subscriptions.pop().dispose();
+    }
   }
 
   public componentDidMount() {


### PR DESCRIPTION
> [2:52 AM] @languy
>     
> @notlaforge I'm looking at SplashScreen as a template to migrate ResourceTree. I noticed that it subscribes to some ko's in the constructor: https://github.com/Azure/cosmos-explorer/blob/7188e8d8c26b9fde55e8e138875db8205f81a536/src/Explorer/SplashScreen/SplashScreen.tsx#L48 I suggest we do the subscribing in componentDidMount() and unsubscribe in componentWillUnmount()in order to properly cleanup and only subscribe when the component is being used. Thoughts? 
> 