### PR TITLE
Run Emulator test only on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           path: dist/
   endtoendemulator:
     name: "End To End Emulator Tests"
-    needs: [lint, format, compile, unittest]
+    if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Removes the emulator test as check during PRs. Why?
- Its a slow and flaky test
- The emulator is released **very** rarely and never from a branch
- Emulator is always manually tested before release
- Almost all of the emulator specific init logic has been removed
- If it runs on master and fails, it is a good signal but will not block peoples work or deploys

Give these reasons I think its a fair trade off to only run this test on a master or release branch
