### PR TITLE
Fix Mongo AAD bug where collections are not loading

### DIFF
--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -78,18 +78,22 @@ async function configureHosted(explorerParams: ExplorerParams): Promise<Explorer
 }
 
 async function configureHostedWithAAD(config: AAD, explorerParams: ExplorerParams): Promise<Explorer> {
+  // TODO: Refactor. updateUserContext needs to be called twice because listKeys below depends on userContext.authorizationToken
+  updateUserContext({
+    authType: AuthType.AAD,
+    authorizationToken: `Bearer ${config.authorizationToken}`,
+  });
   const account = config.databaseAccount;
   const accountResourceId = account.id;
   const subscriptionId = accountResourceId && accountResourceId.split("subscriptions/")[1].split("/")[0];
   const resourceGroup = accountResourceId && accountResourceId.split("resourceGroups/")[1].split("/")[0];
+  const keys = await listKeys(subscriptionId, resourceGroup, account.name);
   updateUserContext({
     subscriptionId,
     resourceGroup,
-    authType: AuthType.AAD,
-    authorizationToken: `Bearer ${config.authorizationToken}`,
     databaseAccount: config.databaseAccount,
+    masterKey: keys.primaryMasterKey,
   });
-  const keys = await listKeys(subscriptionId, resourceGroup, account.name);
   const explorer = new Explorer(explorerParams);
   explorer.configure({
     databaseAccount: account,


### PR DESCRIPTION
The refactor of #541 introduced a bug where userContext does not contain the AAD token before calling `listKeys` in the same method. As a result, the CosmosClient did not have access to the master key and was failing for certain operations against the Mongo Proxy. This PR fixes it, but brings up some long term concerns:

1. Should all our AAD function depend on userContext being populated? Should we make it accept the token as an optional parameter for cases like this?
2. Not having a fully populated userContext object is a recipe for bugs. We should ensure all userContext updates happen as soon as possible in the application*or* maybe look into moving userContext to a proper react context provider.