### PR TITLE
Make ready message backwards compatible

### DIFF
--- a/src/Common/MessageHandler.ts
+++ b/src/Common/MessageHandler.ts
@@ -69,12 +69,12 @@ export function sendReadyMessage(): void {
       {
         signature: "pcIframe",
         kind: "ready",
+        data: "ready",
       },
       portalChildWindow.document.referrer
     );
   }
 }
-
 
 export function canSendMessage(): boolean {
   return window.parent !== window;

--- a/src/Controls/Heatmap/Heatmap.ts
+++ b/src/Controls/Heatmap/Heatmap.ts
@@ -14,7 +14,7 @@ import {
   HeatmapData,
   LayoutSettings,
   PartitionTimeStampToData,
-  PortalTheme
+  PortalTheme,
 } from "./HeatmapDatatypes";
 
 export class Heatmap {

--- a/src/Explorer/Tabs/MongoShellTab.ts
+++ b/src/Explorer/Tabs/MongoShellTab.ts
@@ -100,7 +100,7 @@ export default class MongoShellTab extends TabsBase {
       documentEndpoint.substr(
         Constants.MongoDBAccounts.protocol.length + 3,
         documentEndpoint.length -
-        (Constants.MongoDBAccounts.protocol.length + 2 + Constants.MongoDBAccounts.defaultPort.length)
+          (Constants.MongoDBAccounts.protocol.length + 2 + Constants.MongoDBAccounts.defaultPort.length)
       ) + Constants.MongoDBAccounts.defaultPort.toString();
     const databaseId = this.collection.databaseId;
     const collectionId = this.collection.id();

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -15,14 +15,14 @@ import {
   ConnectionString,
   EncryptedToken,
   HostedExplorerChildFrame,
-  ResourceToken
+  ResourceToken,
 } from "../HostedExplorerChildFrame";
 import { emulatorAccount } from "../Platform/Emulator/emulatorAccount";
 import { extractFeatures } from "../Platform/Hosted/extractFeatures";
 import { parseResourceTokenConnectionString } from "../Platform/Hosted/Helpers/ResourceTokenUtils";
 import {
   getDatabaseAccountKindFromExperience,
-  getDatabaseAccountPropertiesFromMetadata
+  getDatabaseAccountPropertiesFromMetadata,
 } from "../Platform/Hosted/HostedUtils";
 import { DefaultExperienceUtility } from "../Shared/DefaultExperienceUtility";
 import { PortalEnv, updateUserContext } from "../UserContext";


### PR DESCRIPTION
This change makes the ready message compatible with Ibiza SDK IFrame v1 control, currently used by the portal. The previous change made the ready message compatible with IFrame v2, but breaks current portal users.