### PR TITLE
Use window instead of window.parent in extractFeatures function

### DIFF
--- a/src/Platform/Hosted/extractFeatures.ts
+++ b/src/Platform/Hosted/extractFeatures.ts
@@ -24,7 +24,7 @@ export type Features = {
 };
 
 export function extractFeatures(params?: URLSearchParams): Features {
-  params = params || new URLSearchParams(window.parent.location.search);
+  params = params || new URLSearchParams(window.location.search);
   const downcased = new URLSearchParams();
   params.forEach((value, key) => downcased.append(key.toLocaleLowerCase(), value));
   const get = (key: string) => downcased.get("feature." + key.toLocaleLowerCase()) ?? undefined;


### PR DESCRIPTION
Since we are now calling `extractFeatures` in `UserContext` which is in the outer iframe layer instead of `explorer` which is in the inner iframe, we should use `window.location.search` instead of `window.parent.location.search`.