### PR TITLE
Fix table api query projections

### DIFF
--- a/src/Explorer/Tables/QueryBuilder/QueryBuilderViewModel.ts
+++ b/src/Explorer/Tables/QueryBuilder/QueryBuilderViewModel.ts
@@ -1,17 +1,17 @@
 import * as ko from "knockout";
-import * as CustomTimestampHelper from "./CustomTimestampHelper";
-import { getQuotedCqlIdentifier } from "../CqlUtilities";
-import QueryClauseViewModel from "./QueryClauseViewModel";
-import ClauseGroup from "./ClauseGroup";
-import ClauseGroupViewModel from "./ClauseGroupViewModel";
-import QueryViewModel from "./QueryViewModel";
+import { KeyCodes } from "../../../Common/Constants";
 import * as Constants from "../Constants";
-import TableEntityListViewModel from "../DataTable/TableEntityListViewModel";
-import * as DateTimeUtilities from "./DateTimeUtilities";
+import { getQuotedCqlIdentifier } from "../CqlUtilities";
 import * as DataTableUtilities from "../DataTable/DataTableUtilities";
+import TableEntityListViewModel from "../DataTable/TableEntityListViewModel";
 import * as TableEntityProcessor from "../TableEntityProcessor";
 import * as Utilities from "../Utilities";
-import { KeyCodes } from "../../../Common/Constants";
+import ClauseGroup from "./ClauseGroup";
+import ClauseGroupViewModel from "./ClauseGroupViewModel";
+import * as CustomTimestampHelper from "./CustomTimestampHelper";
+import * as DateTimeUtilities from "./DateTimeUtilities";
+import QueryClauseViewModel from "./QueryClauseViewModel";
+import QueryViewModel from "./QueryViewModel";
 
 export default class QueryBuilderViewModel {
   /* Labels */
@@ -182,7 +182,7 @@ export default class QueryBuilderViewModel {
             value = `["${TableEntityProcessor.keyProperties.PartitionKey}"]`;
             filterString = filterString.concat(filterString === "SELECT" ? " c" : ", c");
           } else if (value === Constants.EntityKeyNames.RowKey) {
-            value = `["${TableEntityProcessor.keyProperties.Id2}"]`;
+            value = `["${TableEntityProcessor.keyProperties.Id}"]`;
             filterString = filterString.concat(filterString === "SELECT" ? " c" : ", c");
           } else {
             if (value === Constants.EntityKeyNames.Timestamp) {

--- a/src/Explorer/Tables/TableEntityProcessor.ts
+++ b/src/Explorer/Tables/TableEntityProcessor.ts
@@ -1,6 +1,6 @@
 import * as ViewModels from "../../Contracts/ViewModels";
-import * as Entities from "./Entities";
 import * as Constants from "./Constants";
+import * as Entities from "./Entities";
 import * as DateTimeUtilities from "./QueryBuilder/DateTimeUtilities";
 
 // For use exclusively with Tables API.
@@ -36,7 +36,7 @@ export function convertDocumentsToEntities(documents: any[]): Entities.ITableEnt
   let results: Entities.ITableEntityForTablesAPI[] = [];
   documents &&
     documents.forEach((document) => {
-      if (!document.hasOwnProperty(keyProperties.PartitionKey) || !document.hasOwnProperty(keyProperties.Id2)) {
+      if (!document.hasOwnProperty(keyProperties.PartitionKey) || !document.hasOwnProperty(keyProperties.Id)) {
         //Document does not match the current required format for Tables, so we ignore it
         return; // The rest of the key properties should be guaranteed as DocumentDB properties
       }


### PR DESCRIPTION
When building queries with projections, the resulting query does not include the "id" property as part of the projection. The "id" property is used by the results grid to display as the RowKey so the result is queries wih projections do not show the RowKey.

This change fixes this by including "id" as part of the projections.