### PR TITLE
Added className to SelfServeBaseClass

### DIFF
--- a/src/SelfServe/SelfServe.tsx
+++ b/src/SelfServe/SelfServe.tsx
@@ -38,20 +38,26 @@ const loadTranslations = async (className: string): Promise<void> => {
 };
 
 const getDescriptor = async (selfServeType: SelfServeType): Promise<SelfServeDescriptor> => {
+  let descriptor: SelfServeDescriptor;
   switch (selfServeType) {
     case SelfServeType.example: {
       const SelfServeExample = await import(/* webpackChunkName: "SelfServeExample" */ "./Example/SelfServeExample");
-      await loadTranslations("SelfServeExample");
-      return new SelfServeExample.default().toSelfServeDescriptor();
+      const selfServeExample = new SelfServeExample.default();
+      await loadTranslations(selfServeExample.getClassName());
+      descriptor = selfServeExample.toSelfServeDescriptor();
+      break;
     }
     case SelfServeType.sqlx: {
       const SqlX = await import(/* webpackChunkName: "SqlX" */ "./SqlX/SqlX");
-      await loadTranslations("SqlX");
-      return new SqlX.default().toSelfServeDescriptor();
+      const sqlX = new SqlX.default();
+      await loadTranslations(sqlX.getClassName());
+      descriptor = sqlX.toSelfServeDescriptor();
+      break;
     }
     default:
       return undefined;
   }
+  return descriptor;
 };
 
 const renderComponent = (selfServeDescriptor: SelfServeDescriptor): JSX.Element => {

--- a/src/SelfServe/SelfServe.tsx
+++ b/src/SelfServe/SelfServe.tsx
@@ -42,13 +42,13 @@ const getDescriptor = async (selfServeType: SelfServeType): Promise<SelfServeDes
     case SelfServeType.example: {
       const SelfServeExample = await import(/* webpackChunkName: "SelfServeExample" */ "./Example/SelfServeExample");
       const selfServeExample = new SelfServeExample.default();
-      await loadTranslations(selfServeExample.getClassName());
+      await loadTranslations(selfServeExample.constructor.name);
       return selfServeExample.toSelfServeDescriptor();
     }
     case SelfServeType.sqlx: {
       const SqlX = await import(/* webpackChunkName: "SqlX" */ "./SqlX/SqlX");
       const sqlX = new SqlX.default();
-      await loadTranslations(sqlX.getClassName());
+      await loadTranslations(sqlX.constructor.name);
       return sqlX.toSelfServeDescriptor();
     }
     default:

--- a/src/SelfServe/SelfServe.tsx
+++ b/src/SelfServe/SelfServe.tsx
@@ -38,26 +38,22 @@ const loadTranslations = async (className: string): Promise<void> => {
 };
 
 const getDescriptor = async (selfServeType: SelfServeType): Promise<SelfServeDescriptor> => {
-  let descriptor: SelfServeDescriptor;
   switch (selfServeType) {
     case SelfServeType.example: {
       const SelfServeExample = await import(/* webpackChunkName: "SelfServeExample" */ "./Example/SelfServeExample");
       const selfServeExample = new SelfServeExample.default();
       await loadTranslations(selfServeExample.getClassName());
-      descriptor = selfServeExample.toSelfServeDescriptor();
-      break;
+      return selfServeExample.toSelfServeDescriptor();
     }
     case SelfServeType.sqlx: {
       const SqlX = await import(/* webpackChunkName: "SqlX" */ "./SqlX/SqlX");
       const sqlX = new SqlX.default();
       await loadTranslations(sqlX.getClassName());
-      descriptor = sqlX.toSelfServeDescriptor();
-      break;
+      return sqlX.toSelfServeDescriptor();
     }
     default:
       return undefined;
   }
-  return descriptor;
 };
 
 const renderComponent = (selfServeDescriptor: SelfServeDescriptor): JSX.Element => {

--- a/src/SelfServe/SelfServeTypes.ts
+++ b/src/SelfServe/SelfServeTypes.ts
@@ -68,36 +68,28 @@ export abstract class SelfServeBaseClass {
     baselineValues: ReadonlyMap<string, SmartUiInput>
   ) => Promise<OnSaveResult>;
   public abstract onRefresh: () => Promise<RefreshResult>;
-  private className: string;
-
-  constructor() {
-    this.className = this.constructor.name;
-  }
-
-  public getClassName(): string {
-    return this.className;
-  }
 
   public toSelfServeDescriptor(): SelfServeDescriptor {
-    const selfServeDescriptor = Reflect.getMetadata(this.className, this) as SelfServeDescriptor;
+    const className = this.constructor.name;
+    const selfServeDescriptor = Reflect.getMetadata(className, this) as SelfServeDescriptor;
 
     if (!this.initialize) {
-      throw new Error(`initialize() was not declared for the class '${this.className}'`);
+      throw new Error(`initialize() was not declared for the class '${className}'`);
     }
     if (!this.onSave) {
-      throw new Error(`onSave() was not declared for the class '${this.className}'`);
+      throw new Error(`onSave() was not declared for the class '${className}'`);
     }
     if (!this.onRefresh) {
-      throw new Error(`onRefresh() was not declared for the class '${this.className}'`);
+      throw new Error(`onRefresh() was not declared for the class '${className}'`);
     }
     if (!selfServeDescriptor?.root) {
-      throw new Error(`@IsDisplayable decorator was not declared for the class '${this.className}'`);
+      throw new Error(`@IsDisplayable decorator was not declared for the class '${className}'`);
     }
 
     selfServeDescriptor.initialize = this.initialize;
     selfServeDescriptor.onSave = this.onSave;
     selfServeDescriptor.onRefresh = this.onRefresh;
-    selfServeDescriptor.root.id = this.className;
+    selfServeDescriptor.root.id = className;
 
     return selfServeDescriptor;
   }

--- a/src/SelfServe/SelfServeTypes.ts
+++ b/src/SelfServe/SelfServeTypes.ts
@@ -68,27 +68,37 @@ export abstract class SelfServeBaseClass {
     baselineValues: ReadonlyMap<string, SmartUiInput>
   ) => Promise<OnSaveResult>;
   public abstract onRefresh: () => Promise<RefreshResult>;
+  private className: string;
+
+  constructor() {
+    this.className = this.constructor.name;
+  }
+
+  public getClassName(): string {
+    return this.className;
+  }
 
   public toSelfServeDescriptor(): SelfServeDescriptor {
-    const className = this.constructor.name;
-    const selfServeDescriptor = Reflect.getMetadata(className, this) as SelfServeDescriptor;
+    const selfServeDescriptor = Reflect.getMetadata(this.className, this) as SelfServeDescriptor;
 
     if (!this.initialize) {
-      throw new Error(`initialize() was not declared for the class '${className}'`);
+      throw new Error(`initialize() was not declared for the class '${this.className}'`);
     }
     if (!this.onSave) {
-      throw new Error(`onSave() was not declared for the class '${className}'`);
+      throw new Error(`onSave() was not declared for the class '${this.className}'`);
     }
     if (!this.onRefresh) {
-      throw new Error(`onRefresh() was not declared for the class '${className}'`);
+      throw new Error(`onRefresh() was not declared for the class '${this.className}'`);
     }
     if (!selfServeDescriptor?.root) {
-      throw new Error(`@IsDisplayable decorator was not declared for the class '${className}'`);
+      throw new Error(`@IsDisplayable decorator was not declared for the class '${this.className}'`);
     }
 
     selfServeDescriptor.initialize = this.initialize;
     selfServeDescriptor.onSave = this.onSave;
     selfServeDescriptor.onRefresh = this.onRefresh;
+    selfServeDescriptor.root.id = this.className;
+
     return selfServeDescriptor;
   }
 }

--- a/src/SelfServe/SelfServeUtils.test.tsx
+++ b/src/SelfServe/SelfServeUtils.test.tsx
@@ -35,6 +35,8 @@ describe("SelfServeUtils", () => {
       public onSave = jest.fn();
       public onRefresh = jest.fn();
     }
+    const testClassObject = new Test();
+    expect(testClassObject.getClassName()).toEqual("Test");
     expect(() => new Test().toSelfServeDescriptor()).toThrow(
       "@IsDisplayable decorator was not declared for the class 'Test'"
     );
@@ -150,7 +152,7 @@ describe("SelfServeUtils", () => {
     ]);
     const expectedDescriptor = {
       root: {
-        id: "TestClass",
+        id: undefined as string,
         children: [
           {
             id: "dbThroughput",
@@ -270,7 +272,7 @@ describe("SelfServeUtils", () => {
         "invalidRegions",
       ],
     };
-    const descriptor = mapToSmartUiDescriptor("TestClass", context);
+    const descriptor = mapToSmartUiDescriptor(context);
     expect(descriptor).toEqual(expectedDescriptor);
   });
 });

--- a/src/SelfServe/SelfServeUtils.test.tsx
+++ b/src/SelfServe/SelfServeUtils.test.tsx
@@ -36,7 +36,6 @@ describe("SelfServeUtils", () => {
       public onRefresh = jest.fn();
     }
     const testClassObject = new Test();
-    expect(testClassObject.getClassName()).toEqual("Test");
     expect(() => new Test().toSelfServeDescriptor()).toThrow(
       "@IsDisplayable decorator was not declared for the class 'Test'"
     );
@@ -152,7 +151,6 @@ describe("SelfServeUtils", () => {
     ]);
     const expectedDescriptor = {
       root: {
-        id: undefined as string,
         children: [
           {
             id: "dbThroughput",

--- a/src/SelfServe/SelfServeUtils.test.tsx
+++ b/src/SelfServe/SelfServeUtils.test.tsx
@@ -35,7 +35,6 @@ describe("SelfServeUtils", () => {
       public onSave = jest.fn();
       public onRefresh = jest.fn();
     }
-    const testClassObject = new Test();
     expect(() => new Test().toSelfServeDescriptor()).toThrow(
       "@IsDisplayable decorator was not declared for the class 'Test'"
     );

--- a/src/SelfServe/SelfServeUtils.tsx
+++ b/src/SelfServe/SelfServeUtils.tsx
@@ -112,21 +112,18 @@ export const updateContextWithDecorator = <T extends keyof DecoratorProperties, 
 
 export const buildSmartUiDescriptor = (className: string, target: unknown): void => {
   const context = Reflect.getMetadata(className, target) as Map<string, DecoratorProperties>;
-  const smartUiDescriptor = mapToSmartUiDescriptor(className, context);
+  const smartUiDescriptor = mapToSmartUiDescriptor(context);
   Reflect.defineMetadata(className, smartUiDescriptor, target);
 };
 
-export const mapToSmartUiDescriptor = (
-  className: string,
-  context: Map<string, DecoratorProperties>
-): SelfServeDescriptor => {
+export const mapToSmartUiDescriptor = (context: Map<string, DecoratorProperties>): SelfServeDescriptor => {
   const inputNames: string[] = [];
   const root = context.get("root");
   context.delete("root");
 
   const smartUiDescriptor: SelfServeDescriptor = {
     root: {
-      id: className,
+      id: undefined,
       info: undefined,
       children: [],
     },

--- a/src/SelfServe/SqlX/SqlX.tsx
+++ b/src/SelfServe/SqlX/SqlX.tsx
@@ -177,7 +177,7 @@ export default class SqlX extends SelfServeBaseClass {
     currentValues: Map<string, SmartUiInput>,
     baselineValues: Map<string, SmartUiInput>
   ): Promise<OnSaveResult> => {
-    selfServeTrace({ selfServeClassName: "SqlX" });
+    selfServeTrace({ selfServeClassName: this.getClassName() });
 
     const dedicatedGatewayCurrentlyEnabled = currentValues.get("enableDedicatedGateway")?.value as boolean;
     const dedicatedGatewayOriginallyEnabled = baselineValues.get("enableDedicatedGateway")?.value as boolean;

--- a/src/SelfServe/SqlX/SqlX.tsx
+++ b/src/SelfServe/SqlX/SqlX.tsx
@@ -177,7 +177,7 @@ export default class SqlX extends SelfServeBaseClass {
     currentValues: Map<string, SmartUiInput>,
     baselineValues: Map<string, SmartUiInput>
   ): Promise<OnSaveResult> => {
-    selfServeTrace({ selfServeClassName: this.getClassName() });
+    selfServeTrace({ selfServeClassName: this.constructor.name });
 
     const dedicatedGatewayCurrentlyEnabled = currentValues.get("enableDedicatedGateway")?.value as boolean;
     const dedicatedGatewayOriginallyEnabled = baselineValues.get("enableDedicatedGateway")?.value as boolean;


### PR DESCRIPTION
This PR
- There was mismatch in prod when the classname was set before the object instantiation earlier. now we use constructor.name throughout
- Removed setting className for selfServeDescriptor in SelfServeUtil
- Modified tests