### PR TITLE
Webpack changes for selfserve

### DIFF
--- a/src/SelfServe/SqlX/SqlX.tsx
+++ b/src/SelfServe/SqlX/SqlX.tsx
@@ -177,7 +177,7 @@ export default class SqlX extends SelfServeBaseClass {
     currentValues: Map<string, SmartUiInput>,
     baselineValues: Map<string, SmartUiInput>
   ): Promise<OnSaveResult> => {
-    selfServeTrace({ selfServeClassName: this.constructor.name });
+    selfServeTrace({ selfServeClassName: SqlX.name });
 
     const dedicatedGatewayCurrentlyEnabled = currentValues.get("enableDedicatedGateway")?.value as boolean;
     const dedicatedGatewayOriginallyEnabled = baselineValues.get("enableDedicatedGateway")?.value as boolean;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -220,7 +220,10 @@ module.exports = function (env = {}, argv = {}) {
           terserOptions: {
             // These options increase our initial bundle size by ~5% but the builds are significantly faster and won't run out of memory
             compress: false,
-            mangle: true,
+            mangle: {
+              keep_fnames: true,
+              keep_classnames: true,
+            },
           },
         }),
       ],


### PR DESCRIPTION
This PR adds a webpack change to ensure class and function names are not mangled. This is needed for selfserve, since we use the class name to build the intermediate data structure and to pick up translations.