### PR TITLE
Fix telemetry from child windows of Data Explorer

### DIFF
--- a/src/Common/MessageHandler.ts
+++ b/src/Common/MessageHandler.ts
@@ -48,14 +48,14 @@ export function sendCachedDataMessage<TResponseDataModel>(
 }
 
 export function sendMessage(data: any): void {
-  sendMessageImpl({
+  _sendMessage({
     signature: "pcIframe",
     data: data,
   });
 }
 
 export function sendReadyMessage(): void {
-  sendMessageImpl({
+  _sendMessage({
     signature: "pcIframe",
     kind: "ready",
     data: "ready",
@@ -76,7 +76,7 @@ export function runGarbageCollector() {
   });
 }
 
-const sendMessageImpl = (message: any): void => {
+const _sendMessage = (message: any): void => {
   if (canSendMessage()) {
     // Portal window can receive messages from only child windows
     const portalChildWindow = getDataExplorerWindow(window) || window;

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -266,7 +266,7 @@ async function configurePortal(explorerParams: ExplorerParams): Promise<Explorer
           if (openAction) {
             handleOpenAction(openAction, explorer.databases(), explorer);
           }
-        } else if (shouldForwardMessage(message)) {
+        } else if (shouldForwardMessage(message, event.origin)) {
           sendMessage(message);
         }
       },
@@ -277,8 +277,9 @@ async function configurePortal(explorerParams: ExplorerParams): Promise<Explorer
   });
 }
 
-function shouldForwardMessage(message: PortalMessage) {
-  return message.type === MessageTypes.TelemetryInfo;
+function shouldForwardMessage(message: PortalMessage, messageOrigin: string) {
+  // Only allow forwarding messages from the same origin
+  return messageOrigin === window.document.location.origin && message.type === MessageTypes.TelemetryInfo;
 }
 
 function shouldProcessMessage(event: MessageEvent): boolean {

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -3,7 +3,7 @@ import { applyExplorerBindings } from "../applyExplorerBindings";
 import { AuthType } from "../AuthType";
 import { AccountKind, DefaultAccountExperience } from "../Common/Constants";
 import { normalizeArmEndpoint } from "../Common/EnvironmentUtility";
-import { sendReadyMessage } from "../Common/MessageHandler";
+import { sendMessage, sendReadyMessage } from "../Common/MessageHandler";
 import { configContext, Platform, updateConfigContext } from "../ConfigContext";
 import { ActionType, DataExplorerAction } from "../Contracts/ActionContracts";
 import { MessageTypes } from "../Contracts/ExplorerContracts";
@@ -266,6 +266,8 @@ async function configurePortal(explorerParams: ExplorerParams): Promise<Explorer
           if (openAction) {
             handleOpenAction(openAction, explorer.databases(), explorer);
           }
+        } else if (shouldForwardMessage(message)) {
+          sendMessage(message);
         }
       },
       false
@@ -273,6 +275,10 @@ async function configurePortal(explorerParams: ExplorerParams): Promise<Explorer
 
     sendReadyMessage();
   });
+}
+
+function shouldForwardMessage(message: PortalMessage) {
+  return message.type === MessageTypes.TelemetryInfo;
 }
 
 function shouldProcessMessage(event: MessageEvent): boolean {


### PR DESCRIPTION
With the new iFrame component in Ibiza SDK the portal window only accepts messages coming from the windows that it created. This broke our Kusto telemetry logging from the Terminal windows because terminal windows are created by Data Explorer.

To fix this we now send messages from Terminal window to Portal window via Data Explorer.

Verified that this fix works by inspecting /extensiontelemetry payload.