### PR TITLE
Fix for Mongo shard key loaded via ARM

### DIFF
--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -121,6 +121,10 @@ export interface ISchemaRequest {
 }
 
 export interface Collection extends Resource {
+  // Only in Mongo collections loaded via ARM
+  shardKey?: {
+    [key: string]: "Hash";
+  };
   defaultTtl?: number;
   indexingPolicy?: IndexingPolicy;
   partitionKey?: PartitionKey;

--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -123,7 +123,7 @@ export interface ISchemaRequest {
 export interface Collection extends Resource {
   // Only in Mongo collections loaded via ARM
   shardKey?: {
-    [key: string]: "Hash";
+    [key: string]: string;
   };
   defaultTtl?: number;
   indexingPolicy?: IndexingPolicy;

--- a/src/Explorer/Tabs/MongoDocumentsTab.ts
+++ b/src/Explorer/Tabs/MongoDocumentsTab.ts
@@ -1,14 +1,9 @@
-import * as Constants from "../../Common/Constants";
-import * as DataModels from "../../Contracts/DataModels";
+import { extractPartitionKey, PartitionKeyDefinition } from "@azure/cosmos";
 import * as ko from "knockout";
-import * as ViewModels from "../../Contracts/ViewModels";
-import DocumentId from "../Tree/DocumentId";
-import DocumentsTab from "./DocumentsTab";
-import MongoUtility from "../../Common/MongoUtility";
-import ObjectId from "../Tree/ObjectId";
 import Q from "q";
-import * as TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
-import { Action } from "../../Shared/Telemetry/TelemetryConstants";
+import * as Constants from "../../Common/Constants";
+import { getErrorMessage, getErrorStack } from "../../Common/ErrorHandlingUtils";
+import * as Logger from "../../Common/Logger";
 import {
   createDocument,
   deleteDocument,
@@ -16,10 +11,14 @@ import {
   readDocument,
   updateDocument,
 } from "../../Common/MongoProxyClient";
-import { extractPartitionKey } from "@azure/cosmos";
-import * as Logger from "../../Common/Logger";
-import { PartitionKeyDefinition } from "@azure/cosmos";
-import { getErrorMessage, getErrorStack } from "../../Common/ErrorHandlingUtils";
+import MongoUtility from "../../Common/MongoUtility";
+import * as DataModels from "../../Contracts/DataModels";
+import * as ViewModels from "../../Contracts/ViewModels";
+import { Action } from "../../Shared/Telemetry/TelemetryConstants";
+import * as TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
+import DocumentId from "../Tree/DocumentId";
+import ObjectId from "../Tree/ObjectId";
+import DocumentsTab from "./DocumentsTab";
 
 export default class MongoDocumentsTab extends DocumentsTab {
   public collection: ViewModels.Collection;

--- a/src/Explorer/Tree/Collection.ts
+++ b/src/Explorer/Tree/Collection.ts
@@ -513,9 +513,7 @@ export default class Collection implements ViewModels.Collection {
         tabKind: ViewModels.CollectionTabKind.Documents,
         title: "Documents",
         tabPath: "",
-
         collection: this,
-
         node: this,
         hashLocation: `${Constants.HashRoutePrefixes.collectionsWithIds(this.databaseId, this.id())}/mongoDocuments`,
         isActive: ko.observable(false),


### PR DESCRIPTION
ICM: https://portal.microsofticm.com/imp/v3/incidents/details/236412873/home
This fixes a bug introduced by https://github.com/Azure/cosmos-explorer/pull/636

Mongo collections were previously loaded via the SQL SDK which returned a `parititonKey` property. ARM returns a `shardKey` property in a different format. This PR still loads the collections via ARM but it adds a `partitionKey` property to the response calculated from `shardKey`. This is a bit of a hack, but lots of downstream code expects `Collection.partitionKey` to exist.

I have manually tests CRUD for the following cases:
- No shard key
- Simple shard key: `foo`
- Complex shard key: `foo.bar.baz`

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/657?feature.someFeatureFlagYouMightNeed=true)