### PR TITLE
Fix Markdown Editor not displaying when double-clicking on Markdown cell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7169,14 +7169,6 @@
       "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
-      },
-      "dependencies": {
-        "file-uri-to-path": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-          "optional": true
-        }
       }
     },
     "bintrees": {
@@ -7850,9 +7842,9 @@
           }
         },
         "fsevents": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
-          "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
           "dev": true,
           "optional": true
         },
@@ -11004,6 +10996,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
       "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "3.6.1",

--- a/src/Explorer/Notebook/NotebookRenderer/markdown-cell.tsx
+++ b/src/Explorer/Notebook/NotebookRenderer/markdown-cell.tsx
@@ -7,12 +7,13 @@ import { ImmutableCell } from "@nteract/commutable/src";
 import { actions, AppState, ContentRef, selectors } from "@nteract/core";
 import { MarkdownPreviewer } from "@nteract/markdown";
 import { defineConfigOption } from "@nteract/mythic-configuration";
-import { Source } from "@nteract/presentational-components";
+import { Source as BareSource } from "@nteract/presentational-components";
 import Editor, { EditorSlots } from "@nteract/stateful-components/lib/inputs/editor";
 import React from "react";
 import { ReactMarkdownProps } from "react-markdown";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
+import styled from "styled-components";
 
 const { selector: markdownConfig } = defineConfigOption({
   key: "markdownOptions",
@@ -46,6 +47,12 @@ interface DispatchProps {
   unfocusEditor: () => void;
 }
 
+// Add missing style to make the editor show https://github.com/nteract/nteract/commit/7fa580011578350e56deac81359f6294fdfcad20#diff-07829a1908e4bf98d4420f868a1c6f890b95d77297b9805c9590d2dba11e80ce
+export const Source = styled(BareSource)`
+  width: 100%;
+  width: -webkit-fill-available;
+  width: -moz-available;
+`;
 export class PureMarkdownCell extends React.Component<ComponentProps & DispatchProps & StateProps> {
   render() {
     const { contentRef, id, cell, children } = this.props;


### PR DESCRIPTION
By manually importing `markdown-cell.tsx` from `@nteract/stateful-components` (in #658), we introduced a new dependency to `@nteract/presentational-components@3.4.9`. The rest of the code relies on `@nteract/presentational-components@3.4.8`.
The difference between the two versions is [a now missing `width: 100%`](https://github.com/nteract/nteract/commit/7fa580011578350e56deac81359f6294fdfcad20#diff-07829a1908e4bf98d4420f868a1c6f890b95d77297b9805c9590d2dba11e80ce) for the markdown editor.

This fix reinstates the style to properly show the editor.