### PR TITLE
Fix Stored Procedures for Non-Partitioned Collections

### DIFF
--- a/src/Explorer/Panes/ExecuteSprocParamsPanel/__snapshots__/index.test.tsx.snap
+++ b/src/Explorer/Panes/ExecuteSprocParamsPanel/__snapshots__/index.test.tsx.snap
@@ -1149,7 +1149,6 @@ exports[`Excute Sproc Param Pane should render Default properly 1`] = `
                 isAddRemoveVisible={false}
                 onParamKeyChange={[Function]}
                 onParamValueChange={[Function]}
-                paramValue=""
                 selectedKey="string"
               >
                 <StyledLabelBase>
@@ -2684,7 +2683,6 @@ exports[`Excute Sproc Param Pane should render Default properly 1`] = `
                       key=".0:$.1"
                       label="Value"
                       onChange={[Function]}
-                      value=""
                     >
                       <TextFieldBase
                         autoFocus={true}
@@ -2969,7 +2967,6 @@ exports[`Excute Sproc Param Pane should render Default properly 1`] = `
                           }
                         }
                         validateOnLoad={true}
-                        value=""
                       >
                         <div
                           className="ms-TextField root-70"

--- a/src/Explorer/Panes/ExecuteSprocParamsPanel/index.tsx
+++ b/src/Explorer/Panes/ExecuteSprocParamsPanel/index.tsx
@@ -30,7 +30,7 @@ export const ExecuteSprocParamsPanel: FunctionComponent<ExecuteSprocParamsPanePr
 }: ExecuteSprocParamsPaneProps): JSX.Element => {
   const [isLoading, { setTrue: setLoadingTrue, setFalse: setLoadingFalse }] = useBoolean(false);
   const [paramKeyValues, setParamKeyValues] = useState<UnwrappedExecuteSprocParam[]>([{ key: "string", text: "" }]);
-  const [partitionValue, setPartitionValue] = useState<string>("");
+  const [partitionValue, setPartitionValue] = useState<string>(); // Defaulting to undefined here is important. It is not the same partition key as ""
   const [selectedKey, setSelectedKey] = React.useState<IDropdownOption>({ key: "string", text: "" });
   const [formError, setFormError] = useState<string>("");
   const [formErrorsDetails, setFormErrorsDetails] = useState<string>("");


### PR DESCRIPTION
Changing the default here from `undefined` to  `""` ended up breaking non-partitioned stored procedure execution 

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/685?feature.someFeatureFlagYouMightNeed=true)