### PR TITLE
Parse Custom sproc parameters

### DIFF
--- a/src/Explorer/Panes/ExecuteSprocParamsPanel/index.tsx
+++ b/src/Explorer/Panes/ExecuteSprocParamsPanel/index.tsx
@@ -87,7 +87,7 @@ export const ExecuteSprocParamsPanel: FunctionComponent<ExecuteSprocParamsPanePr
         }
         return sprocParam.text;
       });
-    storedProcedure.execute(sprocParams, partitionValue);
+    storedProcedure.execute(sprocParams, partitionKey === "custom" ? JSON.parse(partitionValue) : partitionValue);
     setLoadingFalse();
     closePanel();
   };

--- a/src/Explorer/Panes/ExecuteSprocParamsPanel/index.tsx
+++ b/src/Explorer/Panes/ExecuteSprocParamsPanel/index.tsx
@@ -79,7 +79,14 @@ export const ExecuteSprocParamsPanel: FunctionComponent<ExecuteSprocParamsPanePr
       return;
     }
     setLoadingTrue();
-    const sprocParams = wrappedSprocParams && wrappedSprocParams.map((sprocParam) => sprocParam.text);
+    const sprocParams =
+      wrappedSprocParams &&
+      wrappedSprocParams.map((sprocParam) => {
+        if (sprocParam.key === "custom") {
+          return JSON.parse(sprocParam.text);
+        }
+        return sprocParam.text;
+      });
     storedProcedure.execute(sprocParams, partitionValue);
     setLoadingFalse();
     closePanel();


### PR DESCRIPTION
This was missed in the React migration. Custom parameters and partition keys need to be run through `JSON.parse`

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/693)
