### PR TITLE
Add collection panel improvements

### DIFF
--- a/src/Explorer/Controls/CollapsiblePanel/CollapsibleSectionComponent.tsx
+++ b/src/Explorer/Controls/CollapsiblePanel/CollapsibleSectionComponent.tsx
@@ -5,6 +5,7 @@ import { accordionStackTokens } from "../Settings/SettingsRenderUtils";
 export interface CollapsibleSectionProps {
   title: string;
   isExpandedByDefault: boolean;
+  onClick?: () => void;
 }
 
 export interface CollapsibleSectionState {
@@ -21,6 +22,7 @@ export class CollapsibleSectionComponent extends React.Component<CollapsibleSect
 
   private toggleCollapsed = (): void => {
     this.setState({ isExpanded: !this.state.isExpanded });
+    this.props.onClick();
   };
 
   public render(): JSX.Element {

--- a/src/Explorer/Controls/ThroughputInput/ThroughputInput.tsx
+++ b/src/Explorer/Controls/ThroughputInput/ThroughputInput.tsx
@@ -74,7 +74,7 @@ export class ThroughputInput extends React.Component<ThroughputInputProps, Throu
         {this.state.isAutoscaleSelected && (
           <Stack className="throughputInputSpacing">
             <Text variant="small">
-              Provision maximum RU/s required by this resource. Estimate your required RU/s with&nbsp;
+              Estimate your required RU/s with&nbsp;
               <Link target="_blank" href="https://cosmos.azure.com/capacitycalculator/">
                 capacity calculator
               </Link>
@@ -271,10 +271,20 @@ const CostEstimateText: React.FunctionComponent<CostEstimateTextProps> = (props:
     ? PricingUtils.getAutoscalePricePerRu(serverId, multiplier) * multiplier
     : PricingUtils.getPricePerRu(serverId) * multiplier;
 
+  const iconWithEstimatedCostDisclaimer: JSX.Element = (
+    <TooltipHost
+      directionalHint={DirectionalHint.bottomLeftEdge}
+      content={PricingUtils.estimatedCostDisclaimer}
+      styles={{ root: { verticalAlign: "bottom" } }}
+    >
+      <Icon iconName="InfoSolid" className="panelInfoIcon" />
+    </TooltipHost>
+  );
+
   if (isAutoscale) {
     return (
       <Text variant="small">
-        Estimated monthly cost ({currency}):{" "}
+        Estimated monthly cost ({currency}){iconWithEstimatedCostDisclaimer}:{" "}
         <b>
           {currencySign + PricingUtils.calculateEstimateNumber(monthlyPrice / 10)} -{" "}
           {currencySign + PricingUtils.calculateEstimateNumber(monthlyPrice)}{" "}
@@ -287,7 +297,7 @@ const CostEstimateText: React.FunctionComponent<CostEstimateTextProps> = (props:
 
   return (
     <Text variant="small">
-      Cost ({currency}):{" "}
+      Estimated cost ({currency}){iconWithEstimatedCostDisclaimer}:{" "}
       <b>
         {currencySign + PricingUtils.calculateEstimateNumber(hourlyPrice)} hourly /{" "}
         {currencySign + PricingUtils.calculateEstimateNumber(dailyPrice)} daily /{" "}
@@ -295,8 +305,6 @@ const CostEstimateText: React.FunctionComponent<CostEstimateTextProps> = (props:
       </b>
       ({numberOfRegions + (numberOfRegions === 1 ? " region" : " regions")}, {requestUnits}RU/s,{" "}
       {currencySign + pricePerRu}/RU)
-      <br />
-      <em>{PricingUtils.estimatedCostDisclaimer}</em>
     </Text>
   );
 };

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -2087,11 +2087,11 @@ export default class Explorer {
   public onNewCollectionClicked(): void {
     if (userContext.apiType === "Cassandra") {
       this.cassandraAddCollectionPane.open();
-    } else if (userContext.features.enableReactPane) {
-      this.openAddCollectionPanel();
-    } else {
+    } else if (userContext.features.enableKOPanel) {
       this.addCollectionPane.open(this.selectedDatabaseId());
       document.getElementById("linkAddCollection").focus();
+    } else {
+      this.openAddCollectionPanel();
     }
   }
 

--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -505,7 +505,11 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
           )}
 
           {userContext.apiType !== "Tables" && (
-            <CollapsibleSectionComponent title="Advanced" isExpandedByDefault={false}>
+            <CollapsibleSectionComponent
+              title="Advanced"
+              isExpandedByDefault={false}
+              onClick={() => TelemetryProcessor.traceOpen(Action.OpenAddCollectionPaneAdvancedSection)}
+            >
               <Stack className="panelGroupSpacing">
                 {this.props.explorer.isEnableMongoCapabilityPresent() && (
                   <Stack>

--- a/src/Platform/Hosted/extractFeatures.ts
+++ b/src/Platform/Hosted/extractFeatures.ts
@@ -27,7 +27,8 @@ export type Features = {
 export function extractFeatures(given = new URLSearchParams(window.location.search)): Features {
   const downcased = new URLSearchParams();
   const set = (value: string, key: string) => downcased.set(key.toLowerCase(), value);
-  const get = (key: string, defaultValue?: string) => downcased.get("feature." + key) ?? defaultValue;
+  const get = (key: string, defaultValue?: string) =>
+    downcased.get("feature." + key) ?? downcased.get(key) ?? defaultValue;
 
   try {
     new URLSearchParams(window.parent.location.search).forEach(set);

--- a/src/Platform/Hosted/extractFeatures.ts
+++ b/src/Platform/Hosted/extractFeatures.ts
@@ -27,8 +27,7 @@ export type Features = {
 export function extractFeatures(given = new URLSearchParams(window.location.search)): Features {
   const downcased = new URLSearchParams();
   const set = (value: string, key: string) => downcased.set(key.toLowerCase(), value);
-  const get = (key: string, defaultValue?: string) =>
-    downcased.get("feature." + key) ?? downcased.get(key) ?? defaultValue;
+  const get = (key: string, defaultValue?: string) => downcased.get("feature." + key) ?? defaultValue;
 
   try {
     new URLSearchParams(window.parent.location.search).forEach(set);

--- a/src/Shared/Telemetry/TelemetryConstants.ts
+++ b/src/Shared/Telemetry/TelemetryConstants.ts
@@ -115,6 +115,7 @@ export enum Action {
   NotebooksGalleryFavoritesCount,
   NotebooksGalleryPublishedCount,
   SelfServe,
+  OpenAddCollectionPaneAdvancedSection,
 }
 
 export const ActionModifiers = {


### PR DESCRIPTION
- moved cost estimate disclaimer text inside info icon tooltip
- changed `Database id` and `Collection id` to `Database name` and `Collection name` for mongo
- revert large partition key check box so that hashV1 is used by default
- hide advanced section for Tables API since there's nothing to show
- enable the new add collection panel by default and fallback to the old one using `useKOpanel` feature flag

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/705)
