### PR TITLE
Enable the "Enable notebooks" button

### DIFF
--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -285,8 +285,8 @@ export default class Explorer {
           async () => {
             this.isNotebookEnabled(
               userContext.authType !== AuthType.ResourceToken &&
-                ((await this._containsDefaultNotebookWorkspace(this.databaseAccount())) ||
-                  userContext.features.enableNotebooks)
+              ((await this._containsDefaultNotebookWorkspace(this.databaseAccount())) ||
+                userContext.features.enableNotebooks)
             );
 
             TelemetryProcessor.trace(Action.NotebookEnabled, ActionModifiers.Mark, {
@@ -308,7 +308,7 @@ export default class Explorer {
                 this.isSparkEnabledForAccount() &&
                 this.arcadiaWorkspaces() &&
                 this.arcadiaWorkspaces().length > 0) ||
-                userContext.features.enableSpark
+              userContext.features.enableSpark
             );
             if (this.isSparkEnabled()) {
               trackEvent(
@@ -1729,7 +1729,11 @@ export default class Explorer {
     }
 
     const databaseAccount = this.databaseAccount();
-    const databaseAccountLocation = databaseAccount && databaseAccount.location.toLowerCase();
+    const databaseAccountLocations = databaseAccount && [
+      databaseAccount?.location.toLowerCase(),
+      ...databaseAccount?.properties?.readLocations?.map(location => location?.locationName?.toLowerCase()),
+      ...databaseAccount?.properties?.writeLocations?.map(location => location?.locationName?.toLowerCase())
+    ];
     const disallowedLocationsUri = `${configContext.BACKEND_ENDPOINT}/api/disallowedLocations`;
     const authorizationHeader = getAuthorizationHeader();
     try {
@@ -1754,9 +1758,15 @@ export default class Explorer {
         this.isNotebooksEnabledForAccount(true);
         return;
       }
-      const isAccountInAllowedLocation = !disallowedLocations.some(
-        (disallowedLocation) => disallowedLocation === databaseAccountLocation
-      );
+      const isAccountInAllowedLocation = databaseAccountLocations?.some(
+        (accountLocation) => {
+          if (!accountLocation) {
+            return false;
+          }
+
+          return !disallowedLocations.some(disallowedLocation => disallowedLocation === accountLocation); // not a disallowed location
+        }
+      ) || false;
       this.isNotebooksEnabledForAccount(isAccountInAllowedLocation);
     } catch (error) {
       Logger.logError(getErrorMessage(error), "Explorer/isNotebooksEnabledForAccount");

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -1729,7 +1729,6 @@ export default class Explorer {
     }
 
     const databaseAccount = this.databaseAccount();
-    const databaseAccountLocation = databaseAccount && databaseAccount?.location.toLowerCase();
     const firstWriteLocation = databaseAccount?.properties?.writeLocations[0].locationName.toLowerCase();
     const disallowedLocationsUri = `${configContext.BACKEND_ENDPOINT}/api/disallowedLocations`;
     const authorizationHeader = getAuthorizationHeader();
@@ -1756,11 +1755,8 @@ export default class Explorer {
         return;
       }
 
-      // databaseAccountLocation or firstWriteLocation are not disallowed
-      const isAccountInAllowedLocation =
-        disallowedLocations.indexOf(databaseAccountLocation) === -1 ||
-        disallowedLocations.indexOf(firstWriteLocation) === -1;
-
+      // firstWriteLocation should not be disallowed
+      const isAccountInAllowedLocation = disallowedLocations.indexOf(firstWriteLocation) === -1;
       this.isNotebooksEnabledForAccount(isAccountInAllowedLocation);
     } catch (error) {
       Logger.logError(getErrorMessage(error), "Explorer/isNotebooksEnabledForAccount");

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -1729,7 +1729,9 @@ export default class Explorer {
     }
 
     const databaseAccount = this.databaseAccount();
-    const firstWriteLocation = databaseAccount?.properties?.writeLocations[0].locationName.toLowerCase();
+    const firstWriteLocation =
+      databaseAccount?.properties?.writeLocations &&
+      databaseAccount?.properties?.writeLocations[0]?.locationName.toLowerCase();
     const disallowedLocationsUri = `${configContext.BACKEND_ENDPOINT}/api/disallowedLocations`;
     const authorizationHeader = getAuthorizationHeader();
     try {
@@ -1756,7 +1758,7 @@ export default class Explorer {
       }
 
       // firstWriteLocation should not be disallowed
-      const isAccountInAllowedLocation = disallowedLocations.indexOf(firstWriteLocation) === -1;
+      const isAccountInAllowedLocation = firstWriteLocation && disallowedLocations.indexOf(firstWriteLocation) === -1;
       this.isNotebooksEnabledForAccount(isAccountInAllowedLocation);
     } catch (error) {
       Logger.logError(getErrorMessage(error), "Explorer/isNotebooksEnabledForAccount");

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -285,8 +285,8 @@ export default class Explorer {
           async () => {
             this.isNotebookEnabled(
               userContext.authType !== AuthType.ResourceToken &&
-              ((await this._containsDefaultNotebookWorkspace(this.databaseAccount())) ||
-                userContext.features.enableNotebooks)
+                ((await this._containsDefaultNotebookWorkspace(this.databaseAccount())) ||
+                  userContext.features.enableNotebooks)
             );
 
             TelemetryProcessor.trace(Action.NotebookEnabled, ActionModifiers.Mark, {
@@ -308,7 +308,7 @@ export default class Explorer {
                 this.isSparkEnabledForAccount() &&
                 this.arcadiaWorkspaces() &&
                 this.arcadiaWorkspaces().length > 0) ||
-              userContext.features.enableSpark
+                userContext.features.enableSpark
             );
             if (this.isSparkEnabled()) {
               trackEvent(
@@ -1729,11 +1729,8 @@ export default class Explorer {
     }
 
     const databaseAccount = this.databaseAccount();
-    const databaseAccountLocations = databaseAccount && [
-      databaseAccount?.location.toLowerCase(),
-      ...databaseAccount?.properties?.readLocations?.map(location => location?.locationName?.toLowerCase()),
-      ...databaseAccount?.properties?.writeLocations?.map(location => location?.locationName?.toLowerCase())
-    ];
+    const databaseAccountLocation = databaseAccount && databaseAccount?.location.toLowerCase();
+    const firstWriteLocation = databaseAccount?.properties?.writeLocations[0].locationName.toLowerCase();
     const disallowedLocationsUri = `${configContext.BACKEND_ENDPOINT}/api/disallowedLocations`;
     const authorizationHeader = getAuthorizationHeader();
     try {
@@ -1758,15 +1755,12 @@ export default class Explorer {
         this.isNotebooksEnabledForAccount(true);
         return;
       }
-      const isAccountInAllowedLocation = databaseAccountLocations?.some(
-        (accountLocation) => {
-          if (!accountLocation) {
-            return false;
-          }
 
-          return !disallowedLocations.some(disallowedLocation => disallowedLocation === accountLocation); // not a disallowed location
-        }
-      ) || false;
+      // databaseAccountLocation or firstWriteLocation are not disallowed
+      const isAccountInAllowedLocation =
+        disallowedLocations.indexOf(databaseAccountLocation) === -1 ||
+        disallowedLocations.indexOf(firstWriteLocation) === -1;
+
       this.isNotebooksEnabledForAccount(isAccountInAllowedLocation);
     } catch (error) {
       Logger.logError(getErrorMessage(error), "Explorer/isNotebooksEnabledForAccount");


### PR DESCRIPTION
Earlier, the "Enable Notebooks" button in the command bar was enabled only if the databaseAccount location was not a disallowed location. With these changes, the same check is made on both 
- database account location
- first write region of the database account