### PR TITLE
Fix table entity boolean and number type property values

### DIFF
--- a/src/Explorer/Panes/Tables/EditTableEntityPanel.tsx
+++ b/src/Explorer/Panes/Tables/EditTableEntityPanel.tsx
@@ -328,7 +328,7 @@ export const EditTableEntityPanel: FunctionComponent<EditTableEntityPanelProps> 
                   selectedKey={entity.type}
                   entityPropertyPlaceHolder={detailedHelp}
                   entityValuePlaceholder={entity.entityValuePlaceholder}
-                  entityValue={entity.value}
+                  entityValue={entity.value?.toString()}
                   isEntityTypeDate={entity.isEntityTypeDate}
                   entityTimeValue={entity.entityTimeValue}
                   isEntityValueDisable={entity.isEntityValueDisable}

--- a/src/Explorer/Tables/TableEntityProcessor.ts
+++ b/src/Explorer/Tables/TableEntityProcessor.ts
@@ -176,18 +176,21 @@ export function convertEntityToNewDocument(entity: Entities.ITableEntityForTable
       property !== keyProperties.attachments &&
       property !== keyProperties.Id2
     ) {
+      let value;
       if (entity[property].$ === Constants.TableType.DateTime) {
         // Convert javascript date back to ticks with 20 zeros padding
-        document[property] = {
-          $t: (<any>DataTypes)[entity[property].$],
-          $v: DateTimeUtilities.convertJSDateToTicksWithPadding(entity[property]._),
-        };
+        value = DateTimeUtilities.convertJSDateToTicksWithPadding(entity[property]._);
+      } else if (entity[property].$ === Constants.TableType.Boolean) {
+        // Convert string to boolean
+        value = entity[property]._ === "true";
       } else {
-        document[property] = {
-          $t: (<any>DataTypes)[entity[property].$],
-          $v: entity[property]._,
-        };
+        value = entity[property]._;
       }
+
+      document[property] = {
+        $t: (<any>DataTypes)[entity[property].$],
+        $v: value,
+      };
     }
   }
   return document;

--- a/src/Explorer/Tables/TableEntityProcessor.ts
+++ b/src/Explorer/Tables/TableEntityProcessor.ts
@@ -165,7 +165,7 @@ export function convertEntityToNewDocument(entity: Entities.ITableEntityForTable
     $id: entity.RowKey._,
     id: entity.RowKey._,
   };
-  for (var property in entity) {
+  for (const property in entity) {
     if (
       property !== Constants.EntityKeyNames.PartitionKey &&
       property !== Constants.EntityKeyNames.RowKey &&
@@ -176,20 +176,29 @@ export function convertEntityToNewDocument(entity: Entities.ITableEntityForTable
       property !== keyProperties.attachments &&
       property !== keyProperties.Id2
     ) {
-      let value;
-      if (entity[property].$ === Constants.TableType.DateTime) {
-        // Convert javascript date back to ticks with 20 zeros padding
-        value = DateTimeUtilities.convertJSDateToTicksWithPadding(entity[property]._);
-      } else if (entity[property].$ === Constants.TableType.Boolean) {
-        // Convert string to boolean
-        value = entity[property]._ === "true";
-      } else {
-        value = entity[property]._;
+      const propertyValue = entity[property]._;
+      let parsedValue;
+      switch (entity[property].$) {
+        case Constants.TableType.DateTime:
+          parsedValue = DateTimeUtilities.convertJSDateToTicksWithPadding(propertyValue);
+          break;
+        case Constants.TableType.Boolean:
+          parsedValue = propertyValue.toLowerCase() === "true";
+          break;
+        case Constants.TableType.Int32:
+        case Constants.TableType.Int64:
+          parsedValue = parseInt(propertyValue, 10);
+          break;
+        case Constants.TableType.Double:
+          parsedValue = parseFloat(propertyValue);
+          break;
+        default:
+          parsedValue = propertyValue;
       }
 
       document[property] = {
         $t: (<any>DataTypes)[entity[property].$],
-        $v: value,
+        $v: parsedValue,
       };
     }
   }


### PR DESCRIPTION
Currently boolean and number (double and integer) type property values are stored as string. We need to parse the string value based on the property type.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/737)
