### PR TITLE
Disable HTML in markdown cell for NotebookReadOnlyRenderer

### DIFF
--- a/src/Explorer/Notebook/NotebookRenderer/NotebookReadOnlyRenderer.tsx
+++ b/src/Explorer/Notebook/NotebookRenderer/NotebookReadOnlyRenderer.tsx
@@ -1,5 +1,5 @@
 import { actions, ContentRef } from "@nteract/core";
-import { Cells, CodeCell, MarkdownCell, RawCell } from "@nteract/stateful-components";
+import { Cells, CodeCell, RawCell } from "@nteract/stateful-components";
 import MonacoEditor from "@nteract/stateful-components/lib/inputs/connected-editors/monacoEditor";
 import { PassedEditorProps } from "@nteract/stateful-components/lib/inputs/editor";
 import Prompt, { PassedPromptProps } from "@nteract/stateful-components/lib/inputs/prompt";
@@ -11,6 +11,7 @@ import loadTransform from "../NotebookComponent/loadTransform";
 import { AzureTheme } from "./AzureTheme";
 import "./base.css";
 import "./default.css";
+import MarkdownCell from "./markdown-cell";
 import "./NotebookReadOnlyRenderer.less";
 import SandboxOutputs from "./outputs/SandboxOutputs";
 


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/746)

We have a custom implementation of `Markdown` cell that we use in `NotebookRenderer`. This custom implementation disables HTML rendering in markdown cells. This change uses the same for `NotebookReadOnlyRenderer` which we use for Gallery.