### PR TITLE
Use CellOutputViewer for SchemaAnalyzer

### DIFF
--- a/src/CellOutputViewer/CellOutputViewer.less
+++ b/src/CellOutputViewer/CellOutputViewer.less
@@ -1,0 +1,10 @@
+.schema-analyzer-cell-outputs {
+  padding:  10px;
+}
+
+.schema-analyzer-cell-output {
+  margin-bottom: 20px;
+  padding: 10px;
+  border-radius: 2px;
+  box-shadow: rgba(0, 0, 0, 13%) 0px 1.6px 3.6px 0px, rgba(0, 0, 0, 11%) 0px 0.3px 0.9px 0px;
+}

--- a/src/CellOutputViewer/CellOutputViewer.tsx
+++ b/src/CellOutputViewer/CellOutputViewer.tsx
@@ -11,13 +11,14 @@ import * as ReactDOM from "react-dom";
 import "../../externals/iframeResizer.contentWindow.min.js"; // Required for iFrameResizer to work
 import "../Explorer/Notebook/NotebookRenderer/base.css";
 import "../Explorer/Notebook/NotebookRenderer/default.css";
+import "./CellOutputViewer.less";
 import { TransformMedia } from "./TransformMedia";
 
 export interface CellOutputViewerProps {
   id: string;
   contentRef: ContentRef;
-  hidden: boolean;
-  expanded: boolean;
+  outputsContainerClassName: string;
+  outputClassName: string;
   outputs: OnDiskOutput[];
   onMetadataChange: (metadata: JSONObject, mediaType: string, index?: number) => void;
 }
@@ -34,27 +35,26 @@ const onInit = async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const props = (event as any).data as CellOutputViewerProps;
       const outputs = (
-        <div
-          data-iframe-height
-          className={`nteract-cell-outputs ${props.hidden ? "hidden" : ""} ${props.expanded ? "expanded" : ""}`}
-        >
+        <div data-iframe-height className={props.outputsContainerClassName}>
           {props.outputs?.map((output, index) => (
-            <Output output={createImmutableOutput(output)} key={index}>
-              <TransformMedia
-                output_type={"display_data"}
-                id={props.id}
-                contentRef={props.contentRef}
-                onMetadataChange={(metadata, mediaType) => props.onMetadataChange(metadata, mediaType, index)}
-              />
-              <TransformMedia
-                output_type={"execute_result"}
-                id={props.id}
-                contentRef={props.contentRef}
-                onMetadataChange={(metadata, mediaType) => props.onMetadataChange(metadata, mediaType, index)}
-              />
-              <KernelOutputError />
-              <StreamText />
-            </Output>
+            <div className={props.outputClassName} key={index}>
+              <Output output={createImmutableOutput(output)} key={index}>
+                <TransformMedia
+                  output_type={"display_data"}
+                  id={props.id}
+                  contentRef={props.contentRef}
+                  onMetadataChange={(metadata, mediaType) => props.onMetadataChange(metadata, mediaType, index)}
+                />
+                <TransformMedia
+                  output_type={"execute_result"}
+                  id={props.id}
+                  contentRef={props.contentRef}
+                  onMetadataChange={(metadata, mediaType) => props.onMetadataChange(metadata, mediaType, index)}
+                />
+                <KernelOutputError />
+                <StreamText />
+              </Output>
+            </div>
           ))}
         </div>
       );

--- a/src/Explorer/Notebook/NotebookRenderer/outputs/SandboxOutputs.tsx
+++ b/src/Explorer/Notebook/NotebookRenderer/outputs/SandboxOutputs.tsx
@@ -15,6 +15,8 @@ import { CellOutputViewerProps } from "../../../../CellOutputViewer/CellOutputVi
 interface ComponentProps {
   id: string;
   contentRef: ContentRef;
+  outputsContainerClassName?: string;
+  outputClassName?: string;
 }
 
 interface StateProps {
@@ -59,8 +61,10 @@ export class SandboxOutputs extends React.PureComponent<ComponentProps & StatePr
     const props: CellOutputViewerProps = {
       id: this.props.id,
       contentRef: this.props.contentRef,
-      hidden: this.props.hidden,
-      expanded: this.props.expanded,
+      outputsContainerClassName: `nteract-cell-outputs ${this.props.hidden ? "hidden" : ""} ${
+        this.props.expanded ? "expanded" : ""
+      } ${this.props.outputsContainerClassName}`,
+      outputClassName: this.props.outputClassName,
       outputs: this.props.outputs.toArray().map((output) => outputToJS(output)),
       onMetadataChange: this.props.onMetadataChange,
     };

--- a/src/Explorer/Notebook/SchemaAnalyzerComponent/SchemaAnalyzerComponent.less
+++ b/src/Explorer/Notebook/SchemaAnalyzerComponent/SchemaAnalyzerComponent.less
@@ -1,10 +1,5 @@
-.shemaAnalyzerComponent {
+.schemaAnalyzerComponent {
   width: 100%;
   height: 100%;
   overflow-y: auto;
-}
-
-.schemaAnalyzerCard {
-  max-width: 4096px;
-  width: 100%;
 }

--- a/src/Explorer/Notebook/SchemaAnalyzerComponent/SchemaAnalyzerComponent.tsx
+++ b/src/Explorer/Notebook/SchemaAnalyzerComponent/SchemaAnalyzerComponent.tsx
@@ -1,14 +1,12 @@
 import { ImmutableOutput } from "@nteract/commutable";
 import { actions, AppState, ContentRef, KernelRef, selectors } from "@nteract/core";
-import { KernelOutputError, Output, StreamText } from "@nteract/outputs";
-import TransformMedia from "@nteract/stateful-components/lib/outputs/transform-media";
-import { Card } from "@uifabric/react-cards";
 import Immutable from "immutable";
 import { FontIcon, PrimaryButton, Spinner, SpinnerSize, Stack, Text, TextField } from "office-ui-fabric-react";
 import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import loadTransform from "../NotebookComponent/loadTransform";
+import SandboxOutputs from "../NotebookRenderer/outputs/SandboxOutputs";
 import "./SchemaAnalyzerComponent.less";
 
 interface SchemaAnalyzerComponentPureProps {
@@ -91,70 +89,66 @@ export class SchemaAnalyzerComponent extends React.Component<
     const showSchemaOutput = isKernelIdle && outputs.size > 0;
 
     return (
-      <Stack className="schemaAnalyzerComponent" horizontalAlign="center" tokens={{ childrenGap: 20, padding: 20 }}>
-        <Stack.Item grow styles={{ root: { display: "contents" } }}>
-          <Stack horizontal tokens={{ childrenGap: 20 }} styles={{ root: { width: "100%" } }}>
-            <Stack.Item grow align="end">
-              <TextField
-                value={this.state.filter}
-                onChange={this.onFilterTextFieldChange}
-                label="Filter"
-                placeholder="{ field: 'value' }"
-                disabled={!isKernelIdle}
-              />
-            </Stack.Item>
-            <Stack.Item align="end">
-              <PrimaryButton
-                text={isKernelBusy ? "Analyzing..." : "Analyze"}
-                onClick={this.onAnalyzeButtonClick}
-                disabled={!isKernelIdle}
-              />
-            </Stack.Item>
-          </Stack>
-        </Stack.Item>
-
-        {showSchemaOutput ? (
-          outputs.map((output, index) => (
-            <Card className="schemaAnalyzerCard" key={index}>
-              <Card.Item tokens={{ padding: 10 }}>
-                <Output output={output}>
-                  <TransformMedia output_type={"display_data"} id={id} contentRef={contentRef} />
-                  <TransformMedia output_type={"execute_result"} id={id} contentRef={contentRef} />
-                  <KernelOutputError />
-                  <StreamText />
-                </Output>
-              </Card.Item>
-            </Card>
-          ))
-        ) : this.state.isFiltering ? (
-          <Stack.Item>
-            {isKernelBusy && <Spinner styles={{ root: { marginTop: 40 } }} size={SpinnerSize.large} />}
+      <div className="schemaAnalyzerComponent">
+        <Stack horizontalAlign="center" tokens={{ childrenGap: 20, padding: 20 }}>
+          <Stack.Item grow styles={{ root: { display: "contents" } }}>
+            <Stack horizontal tokens={{ childrenGap: 20 }} styles={{ root: { width: "100%" } }}>
+              <Stack.Item grow align="end">
+                <TextField
+                  value={this.state.filter}
+                  onChange={this.onFilterTextFieldChange}
+                  label="Filter"
+                  placeholder="{ field: 'value' }"
+                  disabled={!isKernelIdle}
+                />
+              </Stack.Item>
+              <Stack.Item align="end">
+                <PrimaryButton
+                  text={isKernelBusy ? "Analyzing..." : "Analyze"}
+                  onClick={this.onAnalyzeButtonClick}
+                  disabled={!isKernelIdle}
+                />
+              </Stack.Item>
+            </Stack>
           </Stack.Item>
-        ) : (
-          <>
+
+          {showSchemaOutput ? (
+            <SandboxOutputs
+              id={id}
+              contentRef={contentRef}
+              outputsContainerClassName="schema-analyzer-cell-outputs"
+              outputClassName="schema-analyzer-cell-output"
+            />
+          ) : this.state.isFiltering ? (
             <Stack.Item>
-              <FontIcon iconName="Chart" style={{ fontSize: 100, color: "#43B1E5", marginTop: 40 }} />
+              {isKernelBusy && <Spinner styles={{ root: { marginTop: 40 } }} size={SpinnerSize.large} />}
             </Stack.Item>
-            <Stack.Item>
-              <Text variant="xxLarge">Explore your schema</Text>
-            </Stack.Item>
-            <Stack.Item>
-              <Text variant="large">
-                Quickly visualize your schema to infer the frequency, types and ranges of fields in your data set.
-              </Text>
-            </Stack.Item>
-            <Stack.Item>
-              <PrimaryButton
-                styles={{ root: { fontSize: 18, padding: 30 } }}
-                text={isKernelBusy ? "Analyzing..." : "Analyze Schema"}
-                onClick={this.onAnalyzeButtonClick}
-                disabled={kernelStatus !== "idle"}
-              />
-            </Stack.Item>
-            <Stack.Item>{isKernelBusy && <Spinner size={SpinnerSize.large} />}</Stack.Item>
-          </>
-        )}
-      </Stack>
+          ) : (
+            <>
+              <Stack.Item>
+                <FontIcon iconName="Chart" style={{ fontSize: 100, color: "#43B1E5", marginTop: 40 }} />
+              </Stack.Item>
+              <Stack.Item>
+                <Text variant="xxLarge">Explore your schema</Text>
+              </Stack.Item>
+              <Stack.Item>
+                <Text variant="large">
+                  Quickly visualize your schema to infer the frequency, types and ranges of fields in your data set.
+                </Text>
+              </Stack.Item>
+              <Stack.Item>
+                <PrimaryButton
+                  styles={{ root: { fontSize: 18, padding: 30 } }}
+                  text={isKernelBusy ? "Analyzing..." : "Analyze Schema"}
+                  onClick={this.onAnalyzeButtonClick}
+                  disabled={kernelStatus !== "idle"}
+                />
+              </Stack.Item>
+              <Stack.Item>{isKernelBusy && <Spinner size={SpinnerSize.large} />}</Stack.Item>
+            </>
+          )}
+        </Stack>
+      </div>
     );
   }
 }


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/747?feature.enableSchemaAnalyzer=true)

Use CellOutputViewer for rendering Schema Analyzer outputs too. This way we are using all the supported output transforms in a secure way. Also add support for custom class names to style individual outputs.

This also fixes an issue where `text/html` data isn't rendered in Schema Analyzer tab. That was a regression because of sandboxing outputs work. We now no longer load any Nteract output transforms in Data Explorer. CellOutputViewer is the one which loads all transforms lazily,
