### PR TITLE
Fix table edit entity bug and add collection panel bug for connection string users

### DIFF
--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -525,7 +525,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
               }}
             >
               <Stack className="panelGroupSpacing" id="collapsibleSectionContent">
-                {userContext.databaseAccount.properties.capabilities.find((c) => c.name === "EnableMongo") && (
+                {userContext.databaseAccount.properties?.capabilities?.find((c) => c.name === "EnableMongo") && (
                   <Stack className="panelGroupSpacing">
                     <Stack horizontal>
                       <span className="mandatoryStar">*&nbsp;</span>
@@ -851,7 +851,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
       return true;
     }
 
-    return properties.capabilities.some(
+    return properties.capabilities?.some(
       (capability) => capability.name === Constants.CapabilityNames.EnableStorageAnalytics
     );
   }

--- a/src/Explorer/Tables/TableEntityProcessor.ts
+++ b/src/Explorer/Tables/TableEntityProcessor.ts
@@ -189,7 +189,7 @@ export function convertEntityToNewDocument(entity: Entities.ITableEntityForTable
           parsedValue = parseInt(propertyValue, 10);
           break;
         case Constants.TableType.Int64:
-          parsedValue = parseInt(propertyValue, 10).toString();
+          parsedValue = propertyValue.toString();
           break;
         case Constants.TableType.Double:
           parsedValue = parseFloat(propertyValue);

--- a/src/Explorer/Tables/TableEntityProcessor.ts
+++ b/src/Explorer/Tables/TableEntityProcessor.ts
@@ -183,11 +183,13 @@ export function convertEntityToNewDocument(entity: Entities.ITableEntityForTable
           parsedValue = DateTimeUtilities.convertJSDateToTicksWithPadding(propertyValue);
           break;
         case Constants.TableType.Boolean:
-          parsedValue = propertyValue.toLowerCase() === "true";
+          parsedValue = propertyValue.toString().toLowerCase() === "true";
           break;
         case Constants.TableType.Int32:
-        case Constants.TableType.Int64:
           parsedValue = parseInt(propertyValue, 10);
+          break;
+        case Constants.TableType.Int64:
+          parsedValue = parseInt(propertyValue, 10).toString();
           break;
         case Constants.TableType.Double:
           parsedValue = parseFloat(propertyValue);


### PR DESCRIPTION
Table edit entity bug:
- The boolean entity value could be either string or boolean so we can call `.toString` to convert boolean value into string.

Table int64 bug:
- We need to pass the entity value of a int64 type as a string instead of number.

Add collection panel bug:
- Add null check for `databaseAccount.properties` and `databaseAccount.properties.capabilities`.
