### PR TITLE
Added metrics blade link and fixed SelfServe bugs

### DIFF
--- a/src/SelfServe/SelfServeComponent.tsx
+++ b/src/SelfServe/SelfServeComponent.tsx
@@ -1,4 +1,3 @@
-import { TFunction } from "i18next";
 import {
   CommandBar,
   ICommandBarItemProps,
@@ -10,6 +9,7 @@ import {
   Stack,
   Text,
 } from "@fluentui/react";
+import { TFunction } from "i18next";
 import promiseRetry, { AbortError } from "p-retry";
 import React from "react";
 import { WithTranslation } from "react-i18next";
@@ -131,9 +131,6 @@ export class SelfServeComponent extends React.Component<SelfServeComponentProps,
     const initialValues = await this.props.descriptor.initialize();
     this.props.descriptor.inputNames.map((inputName) => {
       let initialValue = initialValues.get(inputName);
-      if (!initialValue) {
-        initialValue = { value: undefined, hidden: false, disabled: false };
-      }
       currentValues = currentValues.set(inputName, initialValue);
       baselineValues = baselineValues.set(inputName, initialValue);
       initialValues.delete(inputName);

--- a/src/SelfServe/SelfServeComponent.tsx
+++ b/src/SelfServe/SelfServeComponent.tsx
@@ -130,7 +130,7 @@ export class SelfServeComponent extends React.Component<SelfServeComponentProps,
 
     const initialValues = await this.props.descriptor.initialize();
     this.props.descriptor.inputNames.map((inputName) => {
-      let initialValue = initialValues.get(inputName);
+      const initialValue = initialValues.get(inputName);
       currentValues = currentValues.set(inputName, initialValue);
       baselineValues = baselineValues.set(inputName, initialValue);
       initialValues.delete(inputName);

--- a/src/SelfServe/SelfServeUtils.tsx
+++ b/src/SelfServe/SelfServeUtils.tsx
@@ -34,6 +34,7 @@ export enum BladeType {
   CassandraKeys = "cassandraDbKeys",
   GremlinKeys = "keys",
   TableKeys = "tableKeys",
+  Metrics = "metrics",
 }
 
 export interface DecoratorProperties {


### PR DESCRIPTION
This PR
- Adds a Metrics Blade type for selfServe components to generate a link to the metrics blade
- Fixes a bug with Save/Discard buttons not being disabled correctly when an element's default value is set to undefined. 

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/764)
