### PR TITLE
Improve lazy load database/collection offer logic

### DIFF
--- a/src/Explorer/Tree/Collection.ts
+++ b/src/Explorer/Tree/Collection.ts
@@ -90,6 +90,7 @@ export default class Collection implements ViewModels.Collection {
   public storedProceduresFocused: ko.Observable<boolean>;
   public userDefinedFunctionsFocused: ko.Observable<boolean>;
   public triggersFocused: ko.Observable<boolean>;
+  private isOfferRead: boolean;
 
   constructor(container: Explorer, databaseId: string, data: DataModels.Collection) {
     this.nodeKind = "Collection";
@@ -201,6 +202,7 @@ export default class Collection implements ViewModels.Collection {
     this.isStoredProceduresExpanded = ko.observable<boolean>(false);
     this.isUserDefinedFunctionsExpanded = ko.observable<boolean>(false);
     this.isTriggersExpanded = ko.observable<boolean>(false);
+    this.isOfferRead = false;
   }
 
   public expandCollapseCollection() {
@@ -1143,7 +1145,7 @@ export default class Collection implements ViewModels.Collection {
   }
 
   public async loadOffer(): Promise<void> {
-    if (!this.container.isServerlessEnabled() && !this.offer()) {
+    if (!this.isOfferRead && !this.container.isServerlessEnabled() && !this.offer()) {
       const startKey: number = TelemetryProcessor.traceStart(Action.LoadOffers, {
         databaseName: this.databaseId,
         collectionName: this.id(),
@@ -1158,6 +1160,7 @@ export default class Collection implements ViewModels.Collection {
       try {
         this.offer(await readCollectionOffer(params));
         this.usageSizeInKB(await getCollectionUsageSizeInKB(this.databaseId, this.id()));
+        this.isOfferRead = true;
 
         TelemetryProcessor.traceSuccess(
           Action.LoadOffers,

--- a/src/Explorer/Tree/Database.ts
+++ b/src/Explorer/Tree/Database.ts
@@ -30,6 +30,7 @@ export default class Database implements ViewModels.Database {
   public isDatabaseShared: ko.Computed<boolean>;
   public selectedSubnodeKind: ko.Observable<ViewModels.CollectionTabKind>;
   public junoClient: JunoClient;
+  private isOfferRead: boolean;
 
   constructor(container: Explorer, data: any) {
     this.nodeKind = "Database";
@@ -45,6 +46,7 @@ export default class Database implements ViewModels.Database {
       return this.offer && !!this.offer();
     });
     this.junoClient = new JunoClient();
+    this.isOfferRead = false;
   }
 
   public onSettingsClick = () => {
@@ -214,12 +216,13 @@ export default class Database implements ViewModels.Database {
   }
 
   public async loadOffer(): Promise<void> {
-    if (!this.container.isServerlessEnabled() && !this.offer()) {
+    if (!this.isOfferRead && !this.container.isServerlessEnabled() && !this.offer()) {
       const params: DataModels.ReadDatabaseOfferParams = {
         databaseId: this.id(),
         databaseResourceId: this.self,
       };
       this.offer(await readDatabaseOffer(params));
+      this.isOfferRead = true;
     }
   }
 


### PR DESCRIPTION
Currently we use `this.offer()` to determine whether we have read the offer of a database/collection. However, `this.offer()` could be `undefined` in both of the following cases:
1. The offer of a database/collection has not been read
2. The offer of a database/collection has been read and is `undefined`

In the second case, we clearly don't need to read the offer again but our current logic does it anyways.

To fix this issue, I added a new flag to indicate whether the offer has been read and used to in combination with `this.offer()` to determine whether we need to read the offer via ARM.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/768)
