### PR TITLE
Pass undefined analyticalTTL if Synapse is disabled

### DIFF
--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -921,6 +921,10 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
   }
 
   private getAnalyticalStorageTtl(): number {
+    if (!this.isSynapseLinkEnabled()) {
+      return undefined;
+    }
+
     if (!this.shouldShowAnalyticalStoreOptions()) {
       return undefined;
     }


### PR DESCRIPTION
The new collection pane behavior changed for connection string users and ended up passing `analyticalTTL` as `0` which throw a backend error if synapse is not enabled on the account.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/778?feature.someFeatureFlagYouMightNeed=true)
