### PR TITLE
Add 'import 'jquery-typeahead' to fix InputTypeahead in GraphExplorer

### DIFF
--- a/src/Explorer/Controls/InputTypeahead/InputTypeaheadComponent.tsx
+++ b/src/Explorer/Controls/InputTypeahead/InputTypeaheadComponent.tsx
@@ -87,7 +87,7 @@ interface Cache {
   selection: Item;
 }
 
-interface InputTypeaheadComponentState { }
+interface InputTypeaheadComponentState {}
 
 export class InputTypeaheadComponent extends React.Component<
   InputTypeaheadComponentProps,

--- a/src/Explorer/Controls/InputTypeahead/InputTypeaheadComponent.tsx
+++ b/src/Explorer/Controls/InputTypeahead/InputTypeaheadComponent.tsx
@@ -6,9 +6,10 @@
  *   typeaheadOverrideOptions: { dynamic:false }
  *
  */
+import "jquery-typeahead";
 import * as React from "react";
-import "./InputTypeahead.less";
 import { KeyCodes } from "../../../Common/Constants";
+import "./InputTypeahead.less";
 
 export interface Item {
   caption: string;
@@ -86,7 +87,7 @@ interface Cache {
   selection: Item;
 }
 
-interface InputTypeaheadComponentState {}
+interface InputTypeaheadComponentState { }
 
 export class InputTypeaheadComponent extends React.Component<
   InputTypeaheadComponentProps,


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/793?feature.someFeatureFlagYouMightNeed=true)

The old input-typeahead component was removed [here](https://github.com/Azure/cosmos-explorer/commit/f9e8b5eaaae0af2b39b93ab999bcca5f0904a3a8#diff-cdea1174da6c9b0ec78d5aeb7242f54a06e3b87ce846d61731e0ce37955006db), but the React-based input-typeahead component now must import the package, in order to work.