### PR TITLE
Fix container manual throughput for non-shared database

### DIFF
--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -992,13 +992,16 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
 
     let offerThroughput: number;
     let autoPilotMaxThroughput: number;
-    if (this.state.createNewDatabase) {
-      if (this.isNewDatabaseAutoscale) {
-        autoPilotMaxThroughput = this.newDatabaseThroughput;
-      } else {
-        offerThroughput = this.newDatabaseThroughput;
+
+    if (databaseLevelThroughput) {
+      if (this.state.createNewDatabase) {
+        if (this.isNewDatabaseAutoscale) {
+          autoPilotMaxThroughput = this.newDatabaseThroughput;
+        } else {
+          offerThroughput = this.newDatabaseThroughput;
+        }
       }
-    } else if (!databaseLevelThroughput) {
+    } else {
       if (this.isCollectionAutoscale) {
         autoPilotMaxThroughput = this.collectionThroughput;
       } else {


### PR DESCRIPTION
Fixed the logic for setting throughput based on user inputs. There are 4 cases:
1. Shared database + new database: we should use the throughput of the new database
2. Shared database + existing database: no need to set throughput in this case
3. Non-shared database + new database: use throughput of the new container
4. Non-shared database + existing database: use throughput of the new container

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/808)
