### PR TITLE
Sqlx bug fixes

### DIFF
--- a/src/SelfServe/SelfServeComponent.tsx
+++ b/src/SelfServe/SelfServeComponent.tsx
@@ -166,7 +166,7 @@ export class SelfServeComponent extends React.Component<SelfServeComponentProps,
     const { baselineValues } = this.state;
     for (const key of currentValues.keys()) {
       const baselineValue = baselineValues.get(key);
-      currentValues = currentValues.set(key, { ...baselineValue });
+      currentValues = currentValues.set(key, baselineValue ? { ...baselineValue } : baselineValue);
     }
     this.setState({ currentValues });
   };

--- a/src/SelfServe/SqlX/SqlX.rp.ts
+++ b/src/SelfServe/SqlX/SqlX.rp.ts
@@ -50,6 +50,7 @@ export const updateDedicatedGatewayResource = async (sku: string, instances: num
   } catch (e) {
     const failureTelemetry = { ...body, e, selfServeClassName: SqlX.name };
     selfServeTraceFailure(failureTelemetry, updateTimeStamp);
+    throw e;
   }
   return armRequestResult?.operationStatusUrl;
 };
@@ -70,6 +71,7 @@ export const deleteDedicatedGatewayResource = async (): Promise<string> => {
   } catch (e) {
     const failureTelemetry = { e, selfServeClassName: SqlX.name };
     selfServeTraceFailure(failureTelemetry, deleteTimeStamp);
+    throw e;
   }
   return armRequestResult?.operationStatusUrl;
 };
@@ -90,6 +92,7 @@ export const getDedicatedGatewayResource = async (): Promise<SqlxServiceResource
   } catch (e) {
     const failureTelemetry = { e, selfServeClassName: SqlX.name };
     selfServeTraceFailure(failureTelemetry, getResourceTimeStamp);
+    throw e;
   }
   return armRequestResult?.result;
 };


### PR DESCRIPTION
This PR ensures errors from RP calls are thrown so that they are correctly surfaced by the Self Serve Framework.
Also fixed a bug with DISCARD.

<img width="916" alt="error bar" src="https://user-images.githubusercontent.com/13487215/119185625-8d17b780-ba94-11eb-9ed0-0db4e214e61a.PNG">


[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/816?feature.someFeatureFlagYouMightNeed=true)
