### PR TITLE
Disable caching for cellOutputViewer.html

### DIFF
--- a/web.config
+++ b/web.config
@@ -42,6 +42,13 @@
       </staticContent>
     </system.webServer>
   </location>
+  <location path="cellOutputViewer.html">
+    <system.webServer>
+      <staticContent>
+        <clientCache cacheControlMode="DisableCache" />
+      </staticContent>
+    </system.webServer>
+  </location>
   <location path="config.json">
     <system.webServer>
       <staticContent>
@@ -57,6 +64,13 @@
     </system.webServer>
   </location>
   <location path="mpac/hostedExplorer.html">
+    <system.webServer>
+      <staticContent>
+        <clientCache cacheControlMode="DisableCache" />
+      </staticContent>
+    </system.webServer>
+  </location>
+  <location path="mpac/cellOutputViewer.html">
     <system.webServer>
       <staticContent>
         <clientCache cacheControlMode="DisableCache" />


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/829)

We bundle js/css along with `cellOutputViewer.html`. So if we don't disable cache the browser wouldn't pickup new changes in the file. This is causing issues with rendering cell outputs (in both notebooks and schema analyzer) in prod.
