### PR TITLE
Show 10k RU instead of unlimited as max RU for unsharded collection

### DIFF
--- a/src/Explorer/Controls/ThroughputInput/ThroughputInput.test.tsx
+++ b/src/Explorer/Controls/ThroughputInput/ThroughputInput.test.tsx
@@ -4,7 +4,7 @@ import { ThroughputInput } from "./ThroughputInput";
 const props = {
   isDatabase: false,
   showFreeTierExceedThroughputTooltip: true,
-  isSharded: false,
+  isSharded: true,
   setThroughputValue: () => jest.fn(),
   setIsAutoscale: () => jest.fn(),
   onCostAcknowledgeChange: () => jest.fn(),

--- a/src/Explorer/Controls/ThroughputInput/ThroughputInput.tsx
+++ b/src/Explorer/Controls/ThroughputInput/ThroughputInput.tsx
@@ -41,9 +41,16 @@ export const ThroughputInput: FunctionComponent<ThroughputInputProps> = ({
       throughputHeaderText = AutoPilotUtils.getAutoPilotHeaderText().toLocaleLowerCase();
     } else {
       const minRU: string = SharedConstants.CollectionCreation.DefaultCollectionRUs400.toLocaleString();
-      const maxRU: string = userContext.isTryCosmosDBSubscription
-        ? Constants.TryCosmosExperience.maxRU.toLocaleString()
-        : "unlimited";
+
+      let maxRU: string;
+      if (userContext.isTryCosmosDBSubscription) {
+        maxRU = Constants.TryCosmosExperience.maxRU.toLocaleString();
+      } else if (!isSharded) {
+        maxRU = "10000";
+      } else {
+        maxRU = "unlimited";
+      }
+
       throughputHeaderText = `throughput (${minRU} - ${maxRU} RU/s)`;
     }
     return `${isDatabase ? "Database" : getCollectionName()} ${throughputHeaderText}`;

--- a/src/Explorer/Controls/ThroughputInput/__snapshots__/ThroughputInput.test.tsx.snap
+++ b/src/Explorer/Controls/ThroughputInput/__snapshots__/ThroughputInput.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ThroughputInput Pane should render Default properly 1`] = `
 <ThroughputInput
   isDatabase={false}
-  isSharded={false}
+  isSharded={true}
   onCostAcknowledgeChange={[Function]}
   setIsAutoscale={[Function]}
   setThroughputValue={[Function]}

--- a/src/Explorer/Panes/UploadItemsPane/__snapshots__/UploadItemsPane.test.tsx.snap
+++ b/src/Explorer/Panes/UploadItemsPane/__snapshots__/UploadItemsPane.test.tsx.snap
@@ -15,7 +15,9 @@ exports[`Upload Items Pane should render Default properly 1`] = `
       multiple={true}
       onUpload={[Function]}
       tabIndex={0}
-      tooltip="Select one or more JSON files to upload. Each file can contain a single JSON document or an array of JSON documents. The combined size of all files in an individual upload operation must be less than 2 MB. You can perform multiple upload operations for larger data sets."
+      tooltip="Select one or more JSON files to upload. Each file can contain a single JSON document or an array of JSON
+ documents. The combined size of all files in an individual upload operation must be less than 2 MB. You
+ can perform multiple upload operations for larger data sets."
     />
   </div>
 </RightPaneForm>

--- a/src/Explorer/Panes/UploadItemsPane/__snapshots__/UploadItemsPane.test.tsx.snap
+++ b/src/Explorer/Panes/UploadItemsPane/__snapshots__/UploadItemsPane.test.tsx.snap
@@ -15,9 +15,7 @@ exports[`Upload Items Pane should render Default properly 1`] = `
       multiple={true}
       onUpload={[Function]}
       tabIndex={0}
-      tooltip="Select one or more JSON files to upload. Each file can contain a single JSON document or an array of JSON
- documents. The combined size of all files in an individual upload operation must be less than 2 MB. You
- can perform multiple upload operations for larger data sets."
+      tooltip="Select one or more JSON files to upload. Each file can contain a single JSON document or an array of JSON documents. The combined size of all files in an individual upload operation must be less than 2 MB. You can perform multiple upload operations for larger data sets."
     />
   </div>
 </RightPaneForm>


### PR DESCRIPTION
This is for fixing: https://msdata.visualstudio.com/CosmosDB/_workitems/edit/1200815. We should use 400 - 10000 RU instead of 400 - unlimited for unsharded collection.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/845)
