### PR TITLE
Mongo tabs UX fixes

### DIFF
--- a/src/Contracts/ViewModels.ts
+++ b/src/Contracts/ViewModels.ts
@@ -286,6 +286,7 @@ export interface TabOptions {
   rid?: string;
   node?: TreeNode;
   theme?: string;
+  index?: number;
 }
 
 export interface DocumentsTabOptions extends TabOptions {

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -1394,7 +1394,13 @@ export default class Explorer {
       tab.hashLocation().startsWith(hashLocation)
     ) as TerminalTab[];
 
-    const index = terminalTabs.length + 1;
+    let index = 1;
+    if (terminalTabs.length > 0) {
+      index = terminalTabs
+        .map((tab) => tab.getIndex())
+        .reduce((prevMaxIndex, currentIndex) => Math.max(prevMaxIndex, currentIndex));
+    }
+
     const newTab = new TerminalTab({
       account: userContext.databaseAccount,
       tabKind: ViewModels.CollectionTabKind.Terminal,
@@ -1407,6 +1413,7 @@ export default class Explorer {
       onLoadStartKey: null,
       container: this,
       kind: kind,
+      index: index + 1,
     });
 
     this.tabsManager.activateNewTab(newTab);

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -1396,9 +1396,7 @@ export default class Explorer {
 
     let index = 1;
     if (terminalTabs.length > 0) {
-      index = terminalTabs
-        .map((tab) => tab.getIndex())
-        .reduce((prevMaxIndex, currentIndex) => Math.max(prevMaxIndex, currentIndex));
+      index = terminalTabs[terminalTabs.length - 1].getIndex() + 1;
     }
 
     const newTab = new TerminalTab({
@@ -1413,7 +1411,7 @@ export default class Explorer {
       onLoadStartKey: null,
       container: this,
       kind: kind,
-      index: index + 1,
+      index: index,
     });
 
     this.tabsManager.activateNewTab(newTab);

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -1396,7 +1396,7 @@ export default class Explorer {
 
     let index = 1;
     if (terminalTabs.length > 0) {
-      index = terminalTabs[terminalTabs.length - 1].getIndex() + 1;
+      index = terminalTabs[terminalTabs.length - 1].index + 1;
     }
 
     const newTab = new TerminalTab({

--- a/src/Explorer/Tabs/MongoShellTab.ts
+++ b/src/Explorer/Tabs/MongoShellTab.ts
@@ -11,15 +11,21 @@ import Explorer from "../Explorer";
 import template from "./MongoShellTab.html";
 import TabsBase from "./TabsBase";
 
+export interface MongoShellTabOptions extends ViewModels.TabOptions {
+  index: number;
+}
+
 export default class MongoShellTab extends TabsBase {
   public readonly html = template;
   public url: ko.Computed<string>;
   private _container: Explorer;
   private _runtimeEndpoint: string;
   private _logTraces: Map<string, number>;
+  private index: number;
 
-  constructor(options: ViewModels.TabOptions) {
+  constructor(options: MongoShellTabOptions) {
     super(options);
+    this.index = options.index;
     this._logTraces = new Map();
     this._container = options.collection.container;
     this.url = ko.computed<string>(() => {
@@ -49,6 +55,10 @@ export default class MongoShellTab extends TabsBase {
     //         activeShell.focus();
     //     },2000);
     // }
+  }
+
+  public getIndex(): number {
+    return this.index;
   }
 
   public onTabClick(): void {

--- a/src/Explorer/Tabs/MongoShellTab.ts
+++ b/src/Explorer/Tabs/MongoShellTab.ts
@@ -11,21 +11,15 @@ import Explorer from "../Explorer";
 import template from "./MongoShellTab.html";
 import TabsBase from "./TabsBase";
 
-export interface MongoShellTabOptions extends ViewModels.TabOptions {
-  index: number;
-}
-
 export default class MongoShellTab extends TabsBase {
   public readonly html = template;
   public url: ko.Computed<string>;
   private _container: Explorer;
   private _runtimeEndpoint: string;
   private _logTraces: Map<string, number>;
-  private index: number;
 
-  constructor(options: MongoShellTabOptions) {
+  constructor(options: ViewModels.TabOptions) {
     super(options);
-    this.index = options.index;
     this._logTraces = new Map();
     this._container = options.collection.container;
     this.url = ko.computed<string>(() => {
@@ -55,10 +49,6 @@ export default class MongoShellTab extends TabsBase {
     //         activeShell.focus();
     //     },2000);
     // }
-  }
-
-  public getIndex(): number {
-    return this.index;
   }
 
   public onTabClick(): void {

--- a/src/Explorer/Tabs/TabsBase.ts
+++ b/src/Explorer/Tabs/TabsBase.ts
@@ -16,7 +16,7 @@ import { TabsManager } from "./TabsManager";
 // TODO: Use specific actions for logging telemetry data
 export default class TabsBase extends WaitsForTemplateViewModel {
   private static id = 0;
-  private index: number;
+  public readonly index: number;
   public closeTabButton: ViewModels.Button;
   public node: ViewModels.TreeNode;
   public collection: ViewModels.CollectionBase;
@@ -61,10 +61,6 @@ export default class TabsBase extends WaitsForTemplateViewModel {
         return true;
       }),
     };
-  }
-
-  public getIndex(): number {
-    return this.index;
   }
 
   public onCloseTabButtonClick(): void {

--- a/src/Explorer/Tabs/TabsBase.ts
+++ b/src/Explorer/Tabs/TabsBase.ts
@@ -16,6 +16,7 @@ import { TabsManager } from "./TabsManager";
 // TODO: Use specific actions for logging telemetry data
 export default class TabsBase extends WaitsForTemplateViewModel {
   private static id = 0;
+  private index: number;
   public closeTabButton: ViewModels.Button;
   public node: ViewModels.TreeNode;
   public collection: ViewModels.CollectionBase;
@@ -35,6 +36,7 @@ export default class TabsBase extends WaitsForTemplateViewModel {
 
   constructor(options: ViewModels.TabOptions) {
     super();
+    this.index = options.index;
     this._theme = ThemeUtility.getMonacoTheme(options.theme);
     this.node = options.node;
     this.collection = options.collection;
@@ -59,6 +61,10 @@ export default class TabsBase extends WaitsForTemplateViewModel {
         return true;
       }),
     };
+  }
+
+  public getIndex(): number {
+    return this.index;
   }
 
   public onCloseTabButtonClick(): void {

--- a/src/Explorer/Tabs/TerminalTab.tsx
+++ b/src/Explorer/Tabs/TerminalTab.tsx
@@ -1,3 +1,4 @@
+import { Spinner, SpinnerSize } from "@fluentui/react";
 import * as ko from "knockout";
 import * as React from "react";
 import { ReactAdapter } from "../../Bindings/ReactBindingHandler";
@@ -13,6 +14,7 @@ export interface TerminalTabOptions extends ViewModels.TabOptions {
   account: DataModels.DatabaseAccount;
   container: Explorer;
   kind: ViewModels.TerminalKind;
+  index: number;
 }
 
 /**
@@ -33,7 +35,7 @@ class NotebookTerminalComponentAdapter implements ReactAdapter {
         databaseAccount={this.getDatabaseAccount()}
       />
     ) : (
-      <></>
+      <Spinner styles={{ root: { marginTop: 10 } }} size={SpinnerSize.large}></Spinner>
     );
   }
 }
@@ -42,16 +44,22 @@ export default class TerminalTab extends TabsBase {
   public readonly html = '<div style="height: 100%" data-bind="react:notebookTerminalComponentAdapter"></div>  ';
   private container: Explorer;
   private notebookTerminalComponentAdapter: NotebookTerminalComponentAdapter;
+  private index: number;
 
   constructor(options: TerminalTabOptions) {
     super(options);
+    this.index = options.index;
     this.container = options.container;
     this.notebookTerminalComponentAdapter = new NotebookTerminalComponentAdapter(
       () => this.getNotebookServerInfo(options),
       () => userContext?.databaseAccount
     );
     this.notebookTerminalComponentAdapter.parameters = ko.computed<boolean>(() => {
-      if (this.isTemplateReady() && this.container.isNotebookEnabled()) {
+      if (
+        this.isTemplateReady() &&
+        this.container.isNotebookEnabled() &&
+        this.container.notebookServerInfo().notebookServerEndpoint
+      ) {
         return true;
       }
       return false;
@@ -60,6 +68,10 @@ export default class TerminalTab extends TabsBase {
 
   public getContainer(): Explorer {
     return this.container;
+  }
+
+  public getIndex(): number {
+    return this.index;
   }
 
   protected getTabsButtons(): CommandButtonComponentProps[] {

--- a/src/Explorer/Tabs/TerminalTab.tsx
+++ b/src/Explorer/Tabs/TerminalTab.tsx
@@ -14,7 +14,6 @@ export interface TerminalTabOptions extends ViewModels.TabOptions {
   account: DataModels.DatabaseAccount;
   container: Explorer;
   kind: ViewModels.TerminalKind;
-  index: number;
 }
 
 /**
@@ -44,11 +43,9 @@ export default class TerminalTab extends TabsBase {
   public readonly html = '<div style="height: 100%" data-bind="react:notebookTerminalComponentAdapter"></div>  ';
   private container: Explorer;
   private notebookTerminalComponentAdapter: NotebookTerminalComponentAdapter;
-  private index: number;
 
   constructor(options: TerminalTabOptions) {
     super(options);
-    this.index = options.index;
     this.container = options.container;
     this.notebookTerminalComponentAdapter = new NotebookTerminalComponentAdapter(
       () => this.getNotebookServerInfo(options),
@@ -68,10 +65,6 @@ export default class TerminalTab extends TabsBase {
 
   public getContainer(): Explorer {
     return this.container;
-  }
-
-  public getIndex(): number {
-    return this.index;
   }
 
   protected getTabsButtons(): CommandButtonComponentProps[] {

--- a/src/Explorer/Tree/Collection.ts
+++ b/src/Explorer/Tree/Collection.ts
@@ -690,14 +690,25 @@ export default class Collection implements ViewModels.Collection {
   }
 
   public onNewMongoShellClick() {
-    const id = this.container.tabsManager.getTabs(ViewModels.CollectionTabKind.MongoShell).length + 1;
+    const mongoShellTabs = this.container.tabsManager.getTabs(
+      ViewModels.CollectionTabKind.MongoShell
+    ) as MongoShellTab[];
+
+    let index = 1;
+    if (mongoShellTabs.length > 0) {
+      index = mongoShellTabs
+        .map((tab) => tab.getIndex())
+        .reduce((prevMaxIndex, currentIndex) => Math.max(prevMaxIndex, currentIndex));
+    }
+
     const mongoShellTab: MongoShellTab = new MongoShellTab({
       tabKind: ViewModels.CollectionTabKind.MongoShell,
-      title: "Shell " + id,
+      title: "Shell " + index,
       tabPath: "",
       collection: this,
       node: this,
       hashLocation: `${Constants.HashRoutePrefixes.collectionsWithIds(this.databaseId, this.id())}/mongoShell`,
+      index: index + 1,
     });
 
     this.container.tabsManager.activateNewTab(mongoShellTab);

--- a/src/Explorer/Tree/Collection.ts
+++ b/src/Explorer/Tree/Collection.ts
@@ -696,9 +696,7 @@ export default class Collection implements ViewModels.Collection {
 
     let index = 1;
     if (mongoShellTabs.length > 0) {
-      index = mongoShellTabs
-        .map((tab) => tab.getIndex())
-        .reduce((prevMaxIndex, currentIndex) => Math.max(prevMaxIndex, currentIndex));
+      index = mongoShellTabs[mongoShellTabs.length - 1].getIndex() + 1;
     }
 
     const mongoShellTab: MongoShellTab = new MongoShellTab({
@@ -708,7 +706,7 @@ export default class Collection implements ViewModels.Collection {
       collection: this,
       node: this,
       hashLocation: `${Constants.HashRoutePrefixes.collectionsWithIds(this.databaseId, this.id())}/mongoShell`,
-      index: index + 1,
+      index: index,
     });
 
     this.container.tabsManager.activateNewTab(mongoShellTab);

--- a/src/Explorer/Tree/Collection.ts
+++ b/src/Explorer/Tree/Collection.ts
@@ -696,7 +696,7 @@ export default class Collection implements ViewModels.Collection {
 
     let index = 1;
     if (mongoShellTabs.length > 0) {
-      index = mongoShellTabs[mongoShellTabs.length - 1].getIndex() + 1;
+      index = mongoShellTabs[mongoShellTabs.length - 1].index + 1;
     }
 
     const mongoShellTab: MongoShellTab = new MongoShellTab({


### PR DESCRIPTION
This PR 
- FIxes the terminal tabs and mongo shell tabs numbering. 
Earlier, 
**new tab index = number of tabs of the same type open + 1** 
So if 
   - tab 1 was opened
   - tab 2 was opened
   - tab 1 was closed
   - new tab is opened ----> New tab would be "Mongo Terminal 2", when it should be actually be "Mongo Terminal 3". 

  So I introduce an 'index' property. now 
  **new tab index = index of the latest tab (of the same type) open + 1** 
- Adds a spinner to the terminal tab when terminal is loading
- Fixed error due to which terminal tabs did not load if they were opened quickly after DE loads, and the notebookServerEndpoint is not populated yet. Now, the terminal tabs are populated only after the notebookServerEndpoint is populated to a non null value.
 
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/851)

![mongo tabs numbering](https://user-images.githubusercontent.com/13487215/120066269-817b5080-c093-11eb-8b53-c9149530c58d.gif)

