### PR TITLE
Fix 400% zoom accessibility bug in add collection panel

### DIFF
--- a/src/Explorer/Panes/PanelComponent.less
+++ b/src/Explorer/Panes/PanelComponent.less
@@ -10,6 +10,7 @@
     padding: 0 34px;
     margin: 20px 0;
     overflow: auto;
+    min-height: 30px;
 
     & > :not(.collapsibleSection) {
       margin-bottom: @DefaultSpace;


### PR DESCRIPTION
Add min-height to `.panelMainContent` class to make the panel content visible after zooming to 400%.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
