### PR TITLE
Adds disableLocalAuth check for listKeys call

### DIFF
--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -9,6 +9,7 @@ export interface DatabaseAccount {
 
 export interface DatabaseAccountExtendedProperties {
   documentEndpoint?: string;
+  disableLocalAuth?: boolean;
   tableEndpoint?: string;
   gremlinEndpoint?: string;
   cassandraEndpoint?: string;

--- a/src/hooks/useDatabaseAccounts.tsx
+++ b/src/hooks/useDatabaseAccounts.tsx
@@ -15,7 +15,7 @@ export async function fetchDatabaseAccounts(subscriptionId: string, accessToken:
 
   let accounts: Array<DatabaseAccount> = [];
 
-  let nextLink = `${configContext.ARM_ENDPOINT}/subscriptions/${subscriptionId}/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2020-06-01-preview`;
+  let nextLink = `${configContext.ARM_ENDPOINT}/subscriptions/${subscriptionId}/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2021-06-15`;
 
   while (nextLink) {
     const response: Response = await fetch(nextLink, { headers });

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -105,7 +105,9 @@ async function configureHostedWithAAD(config: AAD, explorerParams: ExplorerParam
     aadToken = aadTokenResponse.accessToken;
   }
   try {
-    keys = await listKeys(subscriptionId, resourceGroup, account.name);
+    if (!account.properties.disableLocalAuth) {
+      keys = await listKeys(subscriptionId, resourceGroup, account.name);
+    }
   } catch (e) {
     if (userContext.features.enableAadDataPlane) {
       console.warn(e);


### PR DESCRIPTION
Data explorer is currently completely broken for users with disableLocalAuth = true as we try to call listKeys which succeeds, but the key itself doesn't work in the data plane. this ensures we only use AAD auth from the beginning

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.enableAadDataPlane=true)
