### PR TITLE
Fix connect to github

### DIFF
--- a/src/Explorer/Notebook/useNotebook.ts
+++ b/src/Explorer/Notebook/useNotebook.ts
@@ -153,35 +153,31 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
     set({ myNotebooksContentRoot: root });
   },
   initializeNotebooksTree: async (notebookManager: NotebookManager): Promise<void> => {
-    set({
-      myNotebooksContentRoot: {
-        name: "My Notebooks",
-        path: get().notebookBasePath,
-        type: NotebookContentItemType.Directory,
-      },
-      galleryContentRoot: {
-        name: "Gallery",
-        path: "Gallery",
-        type: NotebookContentItemType.File,
-      },
-    });
-
-    if (notebookManager?.gitHubOAuthService?.isLoggedIn()) {
-      set({
-        gitHubNotebooksContentRoot: {
+    const myNotebooksContentRoot = {
+      name: "My Notebooks",
+      path: get().notebookBasePath,
+      type: NotebookContentItemType.Directory,
+    };
+    const galleryContentRoot = {
+      name: "Gallery",
+      path: "Gallery",
+      type: NotebookContentItemType.File,
+    };
+    const gitHubNotebooksContentRoot = notebookManager?.gitHubOAuthService?.isLoggedIn()
+      ? {
           name: "GitHub repos",
           path: "PsuedoDir",
           type: NotebookContentItemType.Directory,
-        },
-      });
-    }
+        }
+      : undefined;
+    set({
+      myNotebooksContentRoot,
+      galleryContentRoot,
+      gitHubNotebooksContentRoot,
+    });
 
     if (get().notebookServerInfo?.notebookServerEndpoint) {
-      const updatedRoot = await notebookManager?.notebookContentClient?.updateItemChildren({
-        name: "My Notebooks",
-        path: get().notebookBasePath,
-        type: NotebookContentItemType.Directory,
-      });
+      const updatedRoot = await notebookManager?.notebookContentClient?.updateItemChildren(myNotebooksContentRoot);
       set({ myNotebooksContentRoot: updatedRoot });
 
       if (updatedRoot?.children) {


### PR DESCRIPTION
When initializing the notebooks tree, the `gitHubNotebooksContentRoot` needs to be set at the same time as `myNotebooksContentRoot` and `galleryContentRoot`. Otherwise, it would trigger two re-renders of the resource tree, and the first re-render would throw an error since `gitHubNotebooksContentRoot` hasn't been set and is still undefined.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/951?feature.someFeatureFlagYouMightNeed=true)
