### PR TITLE
Fix validateCollectionId for new tables account

### DIFF
--- a/src/Explorer/useDatabases.ts
+++ b/src/Explorer/useDatabases.ts
@@ -2,6 +2,7 @@ import _ from "underscore";
 import create, { UseStore } from "zustand";
 import * as Constants from "../Common/Constants";
 import * as ViewModels from "../Contracts/ViewModels";
+import { userContext } from "../UserContext";
 import { useSelectedNode } from "./useSelectedNode";
 
 interface DatabasesState {
@@ -136,6 +137,11 @@ export const useDatabases: UseStore<DatabasesState> = create((set, get) => ({
   },
   validateCollectionId: async (databaseId: string, collectionId: string): Promise<boolean> => {
     const database = get().databases.find((db) => db.id() === databaseId);
+    // For a new tables account, database is undefined when creating the first table
+    if (!database && userContext.apiType === "Tables") {
+      return true;
+    }
+
     await database.loadCollections();
     return !database.collections().some((collection) => collection.id() === collectionId);
   },


### PR DESCRIPTION
For a new tables account, the database is undefined when creating the first table.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/958?feature.someFeatureFlagYouMightNeed=true)
