### PR TITLE
Fix new resource tree

### DIFF
--- a/src/Common/ResourceTreeContainer.tsx
+++ b/src/Common/ResourceTreeContainer.tsx
@@ -54,10 +54,10 @@ export const ResourceTreeContainer: FunctionComponent<ResourceTreeContainerProps
         </div>
         {userContext.authType === AuthType.ResourceToken ? (
           <ResourceTokenTree />
-        ) : userContext.features.enableReactResourceTree ? (
-          <ResourceTree container={container} />
-        ) : (
+        ) : userContext.features.enableKoResourceTree ? (
           <div style={{ overflowY: "auto" }} data-bind="react:resourceTree" />
+        ) : (
+          <ResourceTree container={container} />
         )}
       </div>
       {/*  Collections Window - End */}

--- a/src/Explorer/Notebook/NotebookContentClient.ts
+++ b/src/Explorer/Notebook/NotebookContentClient.ts
@@ -36,7 +36,7 @@ export class NotebookContentClient {
    *
    * @param parent parent folder
    */
-  public createNewNotebookFile(parent: NotebookContentItem): Promise<NotebookContentItem> {
+  public createNewNotebookFile(parent: NotebookContentItem, isGithubTree?: boolean): Promise<NotebookContentItem> {
     if (!parent || parent.type !== NotebookContentItemType.Directory) {
       throw new Error(`Parent must be a directory: ${parent}`);
     }
@@ -57,6 +57,8 @@ export class NotebookContentClient {
         const notebookFile = xhr.response;
 
         const item = NotebookUtil.createNotebookContentItem(notebookFile.name, notebookFile.path, notebookFile.type);
+        useNotebook.getState().insertNotebookItem(parent, cloneDeep(item), isGithubTree);
+        // TODO: delete when ResourceTreeAdapter is removed
         if (parent.children) {
           item.parent = parent;
           parent.children.push(item);
@@ -66,9 +68,9 @@ export class NotebookContentClient {
       });
   }
 
-  public async deleteContentItem(item: NotebookContentItem): Promise<void> {
+  public async deleteContentItem(item: NotebookContentItem, isGithubTree?: boolean): Promise<void> {
     const path = await this.deleteNotebookFile(item.path);
-    useNotebook.getState().deleteNotebookItem(item);
+    useNotebook.getState().deleteNotebookItem(item, isGithubTree);
 
     // TODO: Delete once old resource tree is removed
     if (!path || path !== item.path) {
@@ -91,7 +93,8 @@ export class NotebookContentClient {
   public async uploadFileAsync(
     name: string,
     content: string,
-    parent: NotebookContentItem
+    parent: NotebookContentItem,
+    isGithubTree?: boolean
   ): Promise<NotebookContentItem> {
     if (!parent || parent.type !== NotebookContentItemType.Directory) {
       throw new Error(`Parent must be a directory: ${parent}`);
@@ -115,6 +118,8 @@ export class NotebookContentClient {
       .then((xhr: AjaxResponse) => {
         const notebookFile = xhr.response;
         const item = NotebookUtil.createNotebookContentItem(notebookFile.name, notebookFile.path, notebookFile.type);
+        useNotebook.getState().insertNotebookItem(parent, cloneDeep(item), isGithubTree);
+        // TODO: delete when ResourceTreeAdapter is removed
         if (parent.children) {
           item.parent = parent;
           parent.children.push(item);
@@ -137,7 +142,11 @@ export class NotebookContentClient {
    * @param sourcePath
    * @param targetName is not prefixed with path
    */
-  public renameNotebook(item: NotebookContentItem, targetName: string): Promise<NotebookContentItem> {
+  public renameNotebook(
+    item: NotebookContentItem,
+    targetName: string,
+    isGithubTree?: boolean
+  ): Promise<NotebookContentItem> {
     const sourcePath = item.path;
     // Match extension
     if (sourcePath.indexOf(".") !== -1) {
@@ -163,6 +172,9 @@ export class NotebookContentClient {
         item.name = notebookFile.name;
         item.path = notebookFile.path;
         item.timestamp = NotebookUtil.getCurrentTimestamp();
+
+        useNotebook.getState().updateNotebookItem(item, isGithubTree);
+
         return item;
       });
   }
@@ -172,7 +184,11 @@ export class NotebookContentClient {
    * @param parent
    * @param newDirectoryName basename of the new directory
    */
-  public async createDirectory(parent: NotebookContentItem, newDirectoryName: string): Promise<NotebookContentItem> {
+  public async createDirectory(
+    parent: NotebookContentItem,
+    newDirectoryName: string,
+    isGithubTree?: boolean
+  ): Promise<NotebookContentItem> {
     if (parent.type !== NotebookContentItemType.Directory) {
       throw new Error(`Parent is not a directory: ${parent.path}`);
     }
@@ -199,8 +215,11 @@ export class NotebookContentClient {
 
         const dir = xhr.response;
         const item = NotebookUtil.createNotebookContentItem(dir.name, dir.path, dir.type);
+        useNotebook.getState().insertNotebookItem(parent, cloneDeep(item), isGithubTree);
+        // TODO: delete when ResourceTreeAdapter is removed
         item.parent = parent;
         parent.children?.push(item);
+
         return item;
       });
   }

--- a/src/Explorer/Panes/CopyNotebookPane/CopyNotebookPane.tsx
+++ b/src/Explorer/Panes/CopyNotebookPane/CopyNotebookPane.tsx
@@ -98,6 +98,7 @@ export const CopyNotebookPane: FunctionComponent<CopyNotebookPanelProps> = ({
 
   const copyNotebook = async (location: Location): Promise<NotebookContentItem> => {
     let parent: NotebookContentItem;
+    let isGithubTree: boolean;
     switch (location.type) {
       case "MyNotebooks":
         parent = {
@@ -105,21 +106,23 @@ export const CopyNotebookPane: FunctionComponent<CopyNotebookPanelProps> = ({
           path: useNotebook.getState().notebookBasePath,
           type: NotebookContentItemType.Directory,
         };
+        isGithubTree = false;
         break;
 
       case "GitHub":
         parent = {
-          name: ResourceTreeAdapter.GitHubReposTitle,
+          name: selectedLocation.branch,
           path: GitHubUtils.toContentUri(selectedLocation.owner, selectedLocation.repo, selectedLocation.branch, ""),
           type: NotebookContentItemType.Directory,
         };
+        isGithubTree = true;
         break;
 
       default:
         throw new Error(`Unsupported location type ${location.type}`);
     }
 
-    return container.uploadFile(name, content, parent);
+    return container.uploadFile(name, content, parent, isGithubTree);
   };
 
   const onDropDownChange = (_: FormEvent<HTMLDivElement>, option?: IDropdownOption): void => {

--- a/src/Juno/JunoClient.ts
+++ b/src/Juno/JunoClient.ts
@@ -79,6 +79,13 @@ export class JunoClient {
   }
 
   public async getPinnedRepos(scope: string): Promise<IJunoResponse<IPinnedRepo[]>> {
+    if (this.cachedPinnedRepos()?.length > 0) {
+      return {
+        status: HttpStatusCodes.OK,
+        data: this.cachedPinnedRepos(),
+      };
+    }
+
     const response = await window.fetch(`${this.getNotebooksSubscriptionIdAccountUrl()}/github/pinnedrepos`, {
       headers: JunoClient.getHeaders(),
     });

--- a/src/Juno/JunoClient.ts
+++ b/src/Juno/JunoClient.ts
@@ -79,13 +79,6 @@ export class JunoClient {
   }
 
   public async getPinnedRepos(scope: string): Promise<IJunoResponse<IPinnedRepo[]>> {
-    if (this.cachedPinnedRepos()?.length > 0) {
-      return {
-        status: HttpStatusCodes.OK,
-        data: this.cachedPinnedRepos(),
-      };
-    }
-
     const response = await window.fetch(`${this.getNotebooksSubscriptionIdAccountUrl()}/github/pinnedrepos`, {
       headers: JunoClient.getHeaders(),
     });

--- a/src/Platform/Hosted/extractFeatures.ts
+++ b/src/Platform/Hosted/extractFeatures.ts
@@ -16,7 +16,7 @@ export type Features = {
   readonly enableTtl: boolean;
   readonly executeSproc: boolean;
   readonly enableAadDataPlane: boolean;
-  readonly enableReactResourceTree: boolean;
+  readonly enableKoResourceTree: boolean;
   readonly hostedDataExplorer: boolean;
   readonly junoEndpoint?: string;
   readonly livyEndpoint?: string;
@@ -58,7 +58,7 @@ export function extractFeatures(given = new URLSearchParams(window.location.sear
     enableSDKoperations: "true" === get("enablesdkoperations"),
     enableSpark: "true" === get("enablespark"),
     enableTtl: "true" === get("enablettl"),
-    enableReactResourceTree: "true" === get("enablereactresourcetree"),
+    enableKoResourceTree: "true" === get("enablekoresourcetree"),
     executeSproc: "true" === get("dataexplorerexecutesproc"),
     hostedDataExplorer: "true" === get("hosteddataexplorerenabled"),
     junoEndpoint: get("junoendpoint"),


### PR DESCRIPTION
Currently the new resource tree re-renders every 5 seconds if notebooks is enabled for the account because it listens to the entire `useNotebooks` store instead of just the states that it needs. The memory tracker component updates the `memoryUsageInfo` state in the store every 5 seconds which triggers the resource tree to re-render. This behavior also masked some other issues since the resource tree is able to pick up the latest state every 5 seconds, making it look like the resource tree re-renders correctly for certain actions when it's actually not.

Here's a list of issues exposed after fixing the re-rendering issue:
- The resource tree does not re-render after creating a new notebook
- The resource tree does not re-render after renaming a notebook
- The resource tree does not re-render after creating a new directory
- The resource tree does not re-render after copying a notebook

In addition, most of the github repo workflows are broken because the current logic only tries to find the notebook item under the "My Notebooks" tree. I added a flag to indicate whether the item is a github file.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/962?feature.someFeatureFlagYouMightNeed=true)
