### PR TITLE
Removing author from publish notebook payload

### DIFF
--- a/src/Explorer/Panes/PublishNotebookPane/PublishNotebookPane.tsx
+++ b/src/Explorer/Panes/PublishNotebookPane/PublishNotebookPane.tsx
@@ -105,7 +105,6 @@ export const PublishNotebookPane: FunctionComponent<PublishNotebookPaneAProps> =
         notebookName,
         notebookDescription,
         notebookTags?.split(","),
-        author,
         imageSrc,
         content
       );

--- a/src/Juno/JunoClient.test.ts
+++ b/src/Juno/JunoClient.test.ts
@@ -364,7 +364,6 @@ describe("Gallery", () => {
     const name = "name";
     const description = "description";
     const tags = ["tag"];
-    const author = "author";
     const thumbnailUrl = "thumbnailUrl";
     const content = `{ "key": "value" }`;
     const addLinkToNotebookViewer = true;
@@ -373,7 +372,7 @@ describe("Gallery", () => {
       json: () => undefined as any,
     });
 
-    const response = await junoClient.publishNotebook(name, description, tags, author, thumbnailUrl, content);
+    const response = await junoClient.publishNotebook(name, description, tags, thumbnailUrl, content);
 
     const authorizationHeader = getAuthorizationHeader();
     expect(response.status).toBe(HttpStatusCodes.OK);
@@ -391,7 +390,6 @@ describe("Gallery", () => {
           name,
           description,
           tags,
-          author,
           thumbnailUrl,
           content: JSON.parse(content),
           addLinkToNotebookViewer,

--- a/src/Juno/JunoClient.ts
+++ b/src/Juno/JunoClient.ts
@@ -61,7 +61,6 @@ export interface IPublishNotebookRequest {
   name: string;
   description: string;
   tags: string[];
-  author: string;
   thumbnailUrl: string;
   content: any;
   addLinkToNotebookViewer: boolean;

--- a/src/Juno/JunoClient.ts
+++ b/src/Juno/JunoClient.ts
@@ -359,7 +359,6 @@ export class JunoClient {
     name: string,
     description: string,
     tags: string[],
-    author: string,
     thumbnailUrl: string,
     content: string
   ): Promise<IJunoResponse<IGalleryItem>> {
@@ -370,7 +369,6 @@ export class JunoClient {
         name,
         description,
         tags,
-        author,
         thumbnailUrl,
         content: JSON.parse(content),
         addLinkToNotebookViewer: true,


### PR DESCRIPTION
DE change to address this pentest bug: https://msdata.visualstudio.com/CosmosDB/_queries/edit/1223992/?triage=true

The author name can currently be spoofed since it is part of the payload for notebook publish request.
This PR removes the author name from the payload.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/966)
