### PR TITLE
Add Security Warning Bar for untrusted notebooks

### DIFF
--- a/src/Explorer/Notebook/NotebookComponent/NotebookComponentBootstrapper.tsx
+++ b/src/Explorer/Notebook/NotebookComponent/NotebookComponentBootstrapper.tsx
@@ -277,6 +277,10 @@ export class NotebookComponentBootstrapper {
     return selectors.notebook.isDirty(content.model as Immutable.RecordOf<DocumentRecordProps>);
   }
 
+  public isNotebookUntrusted(): boolean {
+    return NotebookUtil.isNotebookUntrusted(this.getStore().getState(), this.contentRef);
+  }
+
   /**
    * For display purposes, only return non-killed kernels
    */

--- a/src/Explorer/Notebook/NotebookComponent/VirtualCommandBarComponent.tsx
+++ b/src/Explorer/Notebook/NotebookComponent/VirtualCommandBarComponent.tsx
@@ -1,12 +1,14 @@
 import { AppState, ContentRef, selectors } from "@nteract/core";
 import * as React from "react";
 import { connect } from "react-redux";
+import { NotebookUtil } from "../NotebookUtil";
 import * as NteractUtil from "../NTeractUtil";
 
 interface VirtualCommandBarComponentProps {
   kernelSpecName: string;
   kernelStatus: string;
   currentCellType: string;
+  isNotebookUntrusted: boolean;
   onRender: () => void;
 }
 
@@ -20,7 +22,8 @@ class VirtualCommandBarComponent extends React.Component<VirtualCommandBarCompon
     return (
       this.props.kernelStatus !== nextProps.kernelStatus ||
       this.props.kernelSpecName !== nextProps.kernelSpecName ||
-      this.props.currentCellType !== nextProps.currentCellType
+      this.props.currentCellType !== nextProps.currentCellType ||
+      this.props.isNotebookUntrusted !== nextProps.isNotebookUntrusted
     );
   }
 
@@ -50,6 +53,7 @@ const makeMapStateToProps = (
         kernelStatus,
         kernelSpecName,
         currentCellType,
+        isNotebookUntrusted: NotebookUtil.isNotebookUntrusted(state, contentRef),
       } as VirtualCommandBarComponentProps;
     }
 
@@ -69,6 +73,7 @@ const makeMapStateToProps = (
       kernelStatus,
       kernelSpecName,
       currentCellType,
+      isNotebookUntrusted: NotebookUtil.isNotebookUntrusted(state, contentRef),
       onRender: initialProps.onRender,
     };
   };

--- a/src/Explorer/Notebook/NotebookRenderer/NotebookRenderer.tsx
+++ b/src/Explorer/Notebook/NotebookRenderer/NotebookRenderer.tsx
@@ -108,10 +108,10 @@ class BaseNotebookRenderer extends React.Component<NotebookRendererProps> {
     return (
       <>
         <div className="NotebookRendererContainer">
-          <div className="NotebookRenderer" ref={this.notebookRendererRef}>
-            <DndProvider backend={HTML5Backend}>
+          <DndProvider backend={HTML5Backend}>
+            <SecurityWarningBar contentRef={this.props.contentRef} />
+            <div className="NotebookRenderer" ref={this.notebookRendererRef}>
               <KeyboardShortcuts contentRef={this.props.contentRef}>
-                <SecurityWarningBar contentRef={this.props.contentRef} />
                 <Cells contentRef={this.props.contentRef}>
                   {{
                     code: ({ id, contentRef }: { id: CellId; contentRef: ContentRef }) =>
@@ -175,9 +175,9 @@ class BaseNotebookRenderer extends React.Component<NotebookRendererProps> {
                 </Cells>
               </KeyboardShortcuts>
               <AzureTheme />
-            </DndProvider>
-          </div>
-          <StatusBar contentRef={this.props.contentRef} />
+            </div>
+            <StatusBar contentRef={this.props.contentRef} />
+          </DndProvider>
         </div>
       </>
     );

--- a/src/Explorer/Notebook/NotebookRenderer/NotebookRenderer.tsx
+++ b/src/Explorer/Notebook/NotebookRenderer/NotebookRenderer.tsx
@@ -108,9 +108,9 @@ class BaseNotebookRenderer extends React.Component<NotebookRendererProps> {
     return (
       <>
         <div className="NotebookRendererContainer">
-          <DndProvider backend={HTML5Backend}>
-            <SecurityWarningBar contentRef={this.props.contentRef} />
-            <div className="NotebookRenderer" ref={this.notebookRendererRef}>
+          <SecurityWarningBar contentRef={this.props.contentRef} />
+          <div className="NotebookRenderer" ref={this.notebookRendererRef}>
+            <DndProvider backend={HTML5Backend}>
               <KeyboardShortcuts contentRef={this.props.contentRef}>
                 <Cells contentRef={this.props.contentRef}>
                   {{
@@ -175,9 +175,9 @@ class BaseNotebookRenderer extends React.Component<NotebookRendererProps> {
                 </Cells>
               </KeyboardShortcuts>
               <AzureTheme />
-            </div>
-            <StatusBar contentRef={this.props.contentRef} />
-          </DndProvider>
+            </DndProvider>
+          </div>
+          <StatusBar contentRef={this.props.contentRef} />
         </div>
       </>
     );

--- a/src/Explorer/Notebook/NotebookRenderer/NotebookRenderer.tsx
+++ b/src/Explorer/Notebook/NotebookRenderer/NotebookRenderer.tsx
@@ -14,6 +14,7 @@ import * as cdbActions from "../NotebookComponent/actions";
 import loadTransform from "../NotebookComponent/loadTransform";
 import { CdbAppState, SnapshotFragment, SnapshotRequest } from "../NotebookComponent/types";
 import { NotebookUtil } from "../NotebookUtil";
+import SecurityWarningBar from "../SecurityWarningBar/SecurityWarningBar";
 import { AzureTheme } from "./AzureTheme";
 import "./base.css";
 import CellCreator from "./decorators/CellCreator";
@@ -110,6 +111,7 @@ class BaseNotebookRenderer extends React.Component<NotebookRendererProps> {
           <div className="NotebookRenderer" ref={this.notebookRendererRef}>
             <DndProvider backend={HTML5Backend}>
               <KeyboardShortcuts contentRef={this.props.contentRef}>
+                <SecurityWarningBar contentRef={this.props.contentRef} />
                 <Cells contentRef={this.props.contentRef}>
                   {{
                     code: ({ id, contentRef }: { id: CellId; contentRef: ContentRef }) =>

--- a/src/Explorer/Notebook/NotebookRenderer/Prompt.less
+++ b/src/Explorer/Notebook/NotebookRenderer/Prompt.less
@@ -19,6 +19,12 @@
     }
 }
 
+.disabledRunCellButton {
+    .runCellButton .ms-Button-flexContainer .ms-Button-icon {
+        color: @BaseMediumHigh;
+    }
+}
+
 .greyStopButton {
     .runCellButton .ms-Button-flexContainer .ms-Button-icon {
         color: @BaseMediumHigh;

--- a/src/Explorer/Notebook/NotebookRenderer/Prompt.tsx
+++ b/src/Explorer/Notebook/NotebookRenderer/Prompt.tsx
@@ -13,7 +13,7 @@ export interface PassedPromptProps {
   status?: string;
   executionCount?: number;
   isHovered?: boolean;
-  isHidden?: boolean;
+  isRunDisabled?: boolean;
   runCell?: () => void;
   stopCell?: () => void;
 }
@@ -50,7 +50,7 @@ export class PromptPure extends React.Component<Props> {
           runCell: this.props.executeCell,
           stopCell: this.props.stopExecution,
           isHovered: this.props.isHovered,
-          isHidden: this.props.isNotebookUntrusted,
+          isRunDisabled: this.props.isNotebookUntrusted,
         })}
       </div>
     );

--- a/src/Explorer/Notebook/NotebookRenderer/Prompt.tsx
+++ b/src/Explorer/Notebook/NotebookRenderer/Prompt.tsx
@@ -5,6 +5,7 @@ import { Dispatch } from "redux";
 import { Action, ActionModifiers } from "../../../Shared/Telemetry/TelemetryConstants";
 import * as cdbActions from "../NotebookComponent/actions";
 import { CdbAppState } from "../NotebookComponent/types";
+import { NotebookUtil } from "../NotebookUtil";
 
 export interface PassedPromptProps {
   id: string;
@@ -12,6 +13,7 @@ export interface PassedPromptProps {
   status?: string;
   executionCount?: number;
   isHovered?: boolean;
+  isHidden?: boolean;
   runCell?: () => void;
   stopCell?: () => void;
 }
@@ -20,6 +22,7 @@ interface ComponentProps {
   id: string;
   contentRef: ContentRef;
   isHovered?: boolean;
+  isNotebookUntrusted?: boolean;
   children: (props: PassedPromptProps) => React.ReactNode;
 }
 
@@ -47,6 +50,7 @@ export class PromptPure extends React.Component<Props> {
           runCell: this.props.executeCell,
           stopCell: this.props.stopExecution,
           isHovered: this.props.isHovered,
+          isHidden: this.props.isNotebookUntrusted,
         })}
       </div>
     );
@@ -75,6 +79,7 @@ const makeMapStateToProps = (_state: CdbAppState, ownProps: ComponentProps): ((s
       status,
       executionCount,
       isHovered,
+      isNotebookUntrusted: NotebookUtil.isNotebookUntrusted(state, contentRef),
     };
   };
   return mapStateToProps;

--- a/src/Explorer/Notebook/NotebookRenderer/PromptContent.test.tsx
+++ b/src/Explorer/Notebook/NotebookRenderer/PromptContent.test.tsx
@@ -1,0 +1,27 @@
+import { shallow } from "enzyme";
+import { PassedPromptProps } from "./Prompt";
+import { promptContent } from "./PromptContent";
+
+describe("PromptContent", () => {
+  it("renders for busy status", () => {
+    const props: PassedPromptProps = {
+      id: "id",
+      contentRef: "contentRef",
+      status: "busy",
+    };
+    const wrapper = shallow(promptContent(props));
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("renders when hovered", () => {
+    const props: PassedPromptProps = {
+      id: "id",
+      contentRef: "contentRef",
+      isHovered: true,
+    };
+    const wrapper = shallow(promptContent(props));
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/Explorer/Notebook/NotebookRenderer/PromptContent.tsx
+++ b/src/Explorer/Notebook/NotebookRenderer/PromptContent.tsx
@@ -22,7 +22,7 @@ export const promptContent = (props: PassedPromptProps): JSX.Element => {
         <Spinner size={SpinnerSize.large} style={{ position: "absolute", width: "100%", paddingTop: 5 }} />
       </div>
     );
-  } else if (props.isHovered) {
+  } else if (props.isHovered && !props.isHidden) {
     const playButtonText = "Run cell";
     return (
       <IconButton

--- a/src/Explorer/Notebook/NotebookRenderer/PromptContent.tsx
+++ b/src/Explorer/Notebook/NotebookRenderer/PromptContent.tsx
@@ -1,5 +1,6 @@
 import { IconButton, Spinner, SpinnerSize } from "@fluentui/react";
 import * as React from "react";
+import { NotebookUtil } from "../NotebookUtil";
 import { PassedPromptProps } from "./Prompt";
 import "./Prompt.less";
 
@@ -22,16 +23,19 @@ export const promptContent = (props: PassedPromptProps): JSX.Element => {
         <Spinner size={SpinnerSize.large} style={{ position: "absolute", width: "100%", paddingTop: 5 }} />
       </div>
     );
-  } else if (props.isHovered && !props.isHidden) {
-    const playButtonText = "Run cell";
+  } else if (props.isHovered) {
+    const playButtonText = props.isRunDisabled ? NotebookUtil.UntrustedNotebookRunHint : "Run cell";
     return (
-      <IconButton
-        className="runCellButton"
-        iconProps={{ iconName: "MSNVideosSolid" }}
-        title={playButtonText}
-        ariaLabel={playButtonText}
-        onClick={props.runCell}
-      />
+      <div className={props.isRunDisabled ? "disabledRunCellButton" : ""}>
+        <IconButton
+          className="runCellButton"
+          iconProps={{ iconName: "MSNVideosSolid" }}
+          title={playButtonText}
+          ariaLabel={playButtonText}
+          disabled={props.isRunDisabled}
+          onClick={props.runCell}
+        />
+      </div>
     );
   } else {
     return <div style={{ paddingTop: 7 }}>{promptText(props)}</div>;

--- a/src/Explorer/Notebook/NotebookRenderer/Toolbar.tsx
+++ b/src/Explorer/Notebook/NotebookRenderer/Toolbar.tsx
@@ -36,6 +36,7 @@ interface StateProps {
   cellIdAbove: CellId;
   cellIdBelow: CellId;
   hasCodeOutput: boolean;
+  isNotebookUntrusted: boolean;
 }
 
 class BaseToolbar extends React.PureComponent<ComponentProps & DispatchProps & StateProps> {
@@ -43,12 +44,16 @@ class BaseToolbar extends React.PureComponent<ComponentProps & DispatchProps & S
 
   render(): JSX.Element {
     let items: IContextualMenuItem[] = [];
+    const isNotebookUntrusted = this.props.isNotebookUntrusted;
+    const runTooltip = isNotebookUntrusted ? NotebookUtil.UntrustedNotebookRunHint : undefined;
 
     if (this.props.cellType === "code") {
       items = items.concat([
         {
           key: "Run",
           text: "Run",
+          title: runTooltip,
+          disabled: isNotebookUntrusted,
           onClick: () => {
             this.props.executeCell();
             this.props.traceNotebookTelemetry(Action.NotebooksExecuteCellFromMenu, ActionModifiers.Mark);
@@ -223,6 +228,7 @@ const makeMapStateToProps = (state: AppState, ownProps: ComponentProps): ((state
       cellIdAbove,
       cellIdBelow,
       hasCodeOutput: cellType === "code" && NotebookUtil.hasCodeCellOutput(cell as ImmutableCodeCell),
+      isNotebookUntrusted: NotebookUtil.isNotebookUntrusted(state, ownProps.contentRef),
     };
   };
   return mapStateToProps;

--- a/src/Explorer/Notebook/NotebookRenderer/__snapshots__/PromptContent.test.tsx.snap
+++ b/src/Explorer/Notebook/NotebookRenderer/__snapshots__/PromptContent.test.tsx.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PromptContent renders for busy status 1`] = `
+<div
+  className="greyStopButton"
+  style={
+    Object {
+      "left": 0,
+      "maxHeight": "100%",
+      "position": "sticky",
+      "top": 0,
+      "width": "100%",
+      "zIndex": 300,
+    }
+  }
+>
+  <CustomizedIconButton
+    ariaLabel="Stop cell execution"
+    className="runCellButton"
+    iconProps={
+      Object {
+        "iconName": "CircleStopSolid",
+      }
+    }
+    style={
+      Object {
+        "position": "absolute",
+      }
+    }
+    title="Stop cell execution"
+  />
+  <StyledSpinnerBase
+    size={3}
+    style={
+      Object {
+        "paddingTop": 5,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`PromptContent renders when hovered 1`] = `
+<div
+  className=""
+>
+  <CustomizedIconButton
+    ariaLabel="Run cell"
+    className="runCellButton"
+    iconProps={
+      Object {
+        "iconName": "MSNVideosSolid",
+      }
+    }
+    title="Run cell"
+  />
+</div>
+`;
+
+exports[`SecurityWarningBar renders if notebook is untrusted 1`] = `
+<div
+  style={
+    Object {
+      "paddingTop": 7,
+    }
+  }
+>
+  [ ]
+</div>
+`;

--- a/src/Explorer/Notebook/NotebookRenderer/__snapshots__/PromptContent.test.tsx.snap
+++ b/src/Explorer/Notebook/NotebookRenderer/__snapshots__/PromptContent.test.tsx.snap
@@ -58,15 +58,3 @@ exports[`PromptContent renders when hovered 1`] = `
   />
 </div>
 `;
-
-exports[`SecurityWarningBar renders if notebook is untrusted 1`] = `
-<div
-  style={
-    Object {
-      "paddingTop": 7,
-    }
-  }
->
-  [ ]
-</div>
-`;

--- a/src/Explorer/Notebook/NotebookRenderer/decorators/kbd-shortcuts/index.tsx
+++ b/src/Explorer/Notebook/NotebookRenderer/decorators/kbd-shortcuts/index.tsx
@@ -4,6 +4,7 @@ import Immutable from "immutable";
 import React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
+import { NotebookUtil } from "../../../NotebookUtil";
 
 interface ComponentProps {
   contentRef: ContentRef;
@@ -14,6 +15,7 @@ interface StateProps {
   cellMap: Immutable.Map<string, any>;
   cellOrder: Immutable.List<string>;
   focusedCell?: string | null;
+  isNotebookUntrusted: boolean;
 }
 
 interface DispatchProps {
@@ -59,7 +61,12 @@ export class KeyboardShortcuts extends React.Component<Props> {
       cellOrder,
       focusedCell,
       cellMap,
+      isNotebookUntrusted,
     } = this.props;
+
+    if (isNotebookUntrusted) {
+      return;
+    }
 
     let ctrlKeyPressed = e.ctrlKey;
     // Allow cmd + enter (macOS) to operate like ctrl + enter
@@ -125,6 +132,7 @@ export const makeMapStateToProps = (_state: AppState, ownProps: ComponentProps) 
       cellOrder,
       cellMap,
       focusedCell,
+      isNotebookUntrusted: NotebookUtil.isNotebookUntrusted(state, contentRef),
     };
   };
   return mapStateToProps;

--- a/src/Explorer/Notebook/NotebookUtil.ts
+++ b/src/Explorer/Notebook/NotebookUtil.ts
@@ -12,6 +12,8 @@ import { NotebookContentItem, NotebookContentItemType } from "./NotebookContentI
 export type FileType = "directory" | "file" | "notebook";
 // Utilities for notebooks
 export class NotebookUtil {
+  public static UntrustedNotebookRunHint = "Please trust notebook first before running any code cells";
+
   /**
    * It's a notebook file if the filename ends with .ipynb.
    */

--- a/src/Explorer/Notebook/NotebookUtil.ts
+++ b/src/Explorer/Notebook/NotebookUtil.ts
@@ -1,4 +1,5 @@
 import { ImmutableCodeCell, ImmutableNotebook } from "@nteract/commutable";
+import { AppState, selectors } from "@nteract/core";
 import domtoimage from "dom-to-image";
 import Html2Canvas from "html2canvas";
 import path from "path";
@@ -151,6 +152,16 @@ export class NotebookUtil {
         output.output_type === "execute_result" ||
         output.output_type === "stream"
     );
+  }
+
+  public static isNotebookUntrusted(state: AppState, contentRef: string): boolean {
+    const content = selectors.content(state, { contentRef });
+    if (content?.type === "notebook") {
+      const metadata = selectors.notebook.metadata(content.model);
+      return metadata.getIn(["untrusted"]) as boolean;
+    }
+
+    return false;
   }
 
   /**

--- a/src/Explorer/Notebook/SecurityWarningBar/SecurityWarningBar.test.tsx
+++ b/src/Explorer/Notebook/SecurityWarningBar/SecurityWarningBar.test.tsx
@@ -1,0 +1,31 @@
+import { shallow } from "enzyme";
+import React from "react";
+import { SecurityWarningBar } from "./SecurityWarningBar";
+
+describe("SecurityWarningBar", () => {
+  it("renders if notebook is untrusted", () => {
+    const wrapper = shallow(
+      <SecurityWarningBar
+        contentRef={"contentRef"}
+        isNotebookUntrusted={true}
+        markNotebookAsTrusted={undefined}
+        saveNotebook={undefined}
+      />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("renders if notebook is trusted", () => {
+    const wrapper = shallow(
+      <SecurityWarningBar
+        contentRef={"contentRef"}
+        isNotebookUntrusted={false}
+        markNotebookAsTrusted={undefined}
+        saveNotebook={undefined}
+      />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/Explorer/Notebook/SecurityWarningBar/SecurityWarningBar.tsx
+++ b/src/Explorer/Notebook/SecurityWarningBar/SecurityWarningBar.tsx
@@ -1,0 +1,104 @@
+import { MessageBar, MessageBarButton, MessageBarType } from "@fluentui/react";
+import { actions, AppState, selectors } from "@nteract/core";
+import React from "react";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+
+export interface SecurityWarningBarPureProps {
+  contentRef: string;
+}
+
+interface SecurityWarningBarDispatchProps {
+  markNotebookAsTrusted: (contentRef: string) => void;
+  saveNotebook: (contentRef: string) => void;
+}
+
+type SecurityWarningBarProps = SecurityWarningBarPureProps & StateProps & SecurityWarningBarDispatchProps;
+
+interface SecurityWarningBarState {
+  isBarDismissed: boolean;
+}
+
+export class SecurityWarningBar extends React.Component<SecurityWarningBarProps, SecurityWarningBarState> {
+  constructor(props: SecurityWarningBarProps) {
+    super(props);
+
+    this.state = {
+      isBarDismissed: false,
+    };
+  }
+
+  render(): JSX.Element {
+    return this.props.isNotebookUntrusted && !this.state.isBarDismissed ? (
+      <MessageBar
+        messageBarType={MessageBarType.warning}
+        isMultiline={false}
+        onDismiss={() => this.setState({ isBarDismissed: true })}
+        actions={
+          <div>
+            <MessageBarButton
+              onClick={() => {
+                this.props.markNotebookAsTrusted(this.props.contentRef);
+                this.props.saveNotebook(this.props.contentRef);
+              }}
+            >
+              Trust Notebook
+            </MessageBarButton>
+          </div>
+        }
+      >
+        <b>SECURITY WARNING</b>&nbsp; Be careful - this notebook is from an untrusted author. Run code cells at your own
+        risk.
+      </MessageBar>
+    ) : (
+      <></>
+    );
+  }
+}
+
+interface StateProps {
+  isNotebookUntrusted: boolean;
+}
+
+interface InitialProps {
+  contentRef: string;
+}
+
+// Redux
+const makeMapStateToProps = (state: AppState, initialProps: InitialProps) => {
+  const { contentRef } = initialProps;
+  const mapStateToProps = (state: AppState): StateProps => {
+    let isNotebookUntrusted = false;
+
+    const content = selectors.content(state, { contentRef });
+    if (content?.type === "notebook") {
+      const metadata = selectors.notebook.metadata(content.model);
+      isNotebookUntrusted = metadata.getIn(["cosmos", "untrusted"]) as boolean;
+    }
+
+    return {
+      isNotebookUntrusted,
+    };
+  };
+  return mapStateToProps;
+};
+
+const makeMapDispatchToProps = () => {
+  const mapDispatchToProps = (dispatch: Dispatch): SecurityWarningBarDispatchProps => {
+    return {
+      markNotebookAsTrusted: (contentRef: string) => {
+        return dispatch(
+          actions.overwriteMetadataField({
+            contentRef,
+            field: "cosmos",
+            value: {},
+          })
+        );
+      },
+      saveNotebook: (contentRef: string) => dispatch(actions.save({ contentRef })),
+    };
+  };
+  return mapDispatchToProps;
+};
+
+export default connect(makeMapStateToProps, makeMapDispatchToProps)(SecurityWarningBar);

--- a/src/Explorer/Notebook/SecurityWarningBar/SecurityWarningBar.tsx
+++ b/src/Explorer/Notebook/SecurityWarningBar/SecurityWarningBar.tsx
@@ -73,7 +73,7 @@ const makeMapStateToProps = (state: AppState, initialProps: InitialProps) => {
     const content = selectors.content(state, { contentRef });
     if (content?.type === "notebook") {
       const metadata = selectors.notebook.metadata(content.model);
-      isNotebookUntrusted = metadata.getIn(["cosmos", "untrusted"]) as boolean;
+      isNotebookUntrusted = metadata.getIn(["untrusted"]) as boolean;
     }
 
     return {
@@ -88,10 +88,9 @@ const makeMapDispatchToProps = () => {
     return {
       markNotebookAsTrusted: (contentRef: string) => {
         return dispatch(
-          actions.overwriteMetadataField({
+          actions.deleteMetadataField({
             contentRef,
-            field: "cosmos",
-            value: {},
+            field: "untrusted",
           })
         );
       },

--- a/src/Explorer/Notebook/SecurityWarningBar/SecurityWarningBar.tsx
+++ b/src/Explorer/Notebook/SecurityWarningBar/SecurityWarningBar.tsx
@@ -1,8 +1,9 @@
 import { MessageBar, MessageBarButton, MessageBarType } from "@fluentui/react";
-import { actions, AppState, selectors } from "@nteract/core";
+import { actions, AppState } from "@nteract/core";
 import React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
+import { NotebookUtil } from "../NotebookUtil";
 
 export interface SecurityWarningBarPureProps {
   contentRef: string;
@@ -66,20 +67,9 @@ interface InitialProps {
 
 // Redux
 const makeMapStateToProps = (state: AppState, initialProps: InitialProps) => {
-  const { contentRef } = initialProps;
-  const mapStateToProps = (state: AppState): StateProps => {
-    let isNotebookUntrusted = false;
-
-    const content = selectors.content(state, { contentRef });
-    if (content?.type === "notebook") {
-      const metadata = selectors.notebook.metadata(content.model);
-      isNotebookUntrusted = metadata.getIn(["untrusted"]) as boolean;
-    }
-
-    return {
-      isNotebookUntrusted,
-    };
-  };
+  const mapStateToProps = (state: AppState): StateProps => ({
+    isNotebookUntrusted: NotebookUtil.isNotebookUntrusted(state, initialProps.contentRef),
+  });
   return mapStateToProps;
 };
 

--- a/src/Explorer/Notebook/SecurityWarningBar/SecurityWarningBar.tsx
+++ b/src/Explorer/Notebook/SecurityWarningBar/SecurityWarningBar.tsx
@@ -35,21 +35,21 @@ export class SecurityWarningBar extends React.Component<SecurityWarningBarProps,
         messageBarType={MessageBarType.warning}
         isMultiline={false}
         onDismiss={() => this.setState({ isBarDismissed: true })}
+        dismissButtonAriaLabel="Close"
         actions={
-          <div>
-            <MessageBarButton
-              onClick={() => {
-                this.props.markNotebookAsTrusted(this.props.contentRef);
-                this.props.saveNotebook(this.props.contentRef);
-              }}
-            >
-              Trust Notebook
-            </MessageBarButton>
-          </div>
+          <MessageBarButton
+            onClick={() => {
+              this.props.markNotebookAsTrusted(this.props.contentRef);
+              this.props.saveNotebook(this.props.contentRef);
+            }}
+          >
+            Trust Notebook
+          </MessageBarButton>
         }
       >
-        <b>SECURITY WARNING</b>&nbsp; This notebook was downloaded from the public gallery. Running code cells from a
-        notebook authored by someone else may involve security risks. risk.
+        {" "}
+        This notebook was downloaded from the public gallery. Running code cells from a notebook authored by someone
+        else may involve security risks.
       </MessageBar>
     ) : (
       <></>

--- a/src/Explorer/Notebook/SecurityWarningBar/SecurityWarningBar.tsx
+++ b/src/Explorer/Notebook/SecurityWarningBar/SecurityWarningBar.tsx
@@ -48,8 +48,8 @@ export class SecurityWarningBar extends React.Component<SecurityWarningBarProps,
           </div>
         }
       >
-        <b>SECURITY WARNING</b>&nbsp; Be careful - this notebook is from an untrusted author. Run code cells at your own
-        risk.
+        <b>SECURITY WARNING</b>&nbsp; This notebook was downloaded from the public gallery. Running code cells from a
+        notebook authored by someone else may involve security risks. risk.
       </MessageBar>
     ) : (
       <></>

--- a/src/Explorer/Notebook/SecurityWarningBar/__snapshots__/SecurityWarningBar.test.tsx.snap
+++ b/src/Explorer/Notebook/SecurityWarningBar/__snapshots__/SecurityWarningBar.test.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SecurityWarningBar renders if notebook is trusted 1`] = `<Fragment />`;
+
+exports[`SecurityWarningBar renders if notebook is untrusted 1`] = `
+<StyledMessageBar
+  actions={
+    <div>
+      <CustomizedMessageBarButton
+        onClick={[Function]}
+      >
+        Trust Notebook
+      </CustomizedMessageBarButton>
+    </div>
+  }
+  isMultiline={false}
+  messageBarType={5}
+  onDismiss={[Function]}
+>
+  <b>
+    SECURITY WARNING
+  </b>
+    Be careful - this notebook is from an untrusted author. Run code cells at your own risk.
+</StyledMessageBar>
+`;

--- a/src/Explorer/Notebook/SecurityWarningBar/__snapshots__/SecurityWarningBar.test.tsx.snap
+++ b/src/Explorer/Notebook/SecurityWarningBar/__snapshots__/SecurityWarningBar.test.tsx.snap
@@ -5,21 +5,18 @@ exports[`SecurityWarningBar renders if notebook is trusted 1`] = `<Fragment />`;
 exports[`SecurityWarningBar renders if notebook is untrusted 1`] = `
 <StyledMessageBar
   actions={
-    <div>
-      <CustomizedMessageBarButton
-        onClick={[Function]}
-      >
-        Trust Notebook
-      </CustomizedMessageBarButton>
-    </div>
+    <CustomizedMessageBarButton
+      onClick={[Function]}
+    >
+      Trust Notebook
+    </CustomizedMessageBarButton>
   }
+  dismissButtonAriaLabel="Close"
   isMultiline={false}
   messageBarType={5}
   onDismiss={[Function]}
 >
-  <b>
-    SECURITY WARNING
-  </b>
-    This notebook was downloaded from the public gallery. Running code cells from a notebook authored by someone else may involve security risks. risk.
+   
+  This notebook was downloaded from the public gallery. Running code cells from a notebook authored by someone else may involve security risks.
 </StyledMessageBar>
 `;

--- a/src/Explorer/Notebook/SecurityWarningBar/__snapshots__/SecurityWarningBar.test.tsx.snap
+++ b/src/Explorer/Notebook/SecurityWarningBar/__snapshots__/SecurityWarningBar.test.tsx.snap
@@ -20,6 +20,6 @@ exports[`SecurityWarningBar renders if notebook is untrusted 1`] = `
   <b>
     SECURITY WARNING
   </b>
-    Be careful - this notebook is from an untrusted author. Run code cells at your own risk.
+    This notebook was downloaded from the public gallery. Running code cells from a notebook authored by someone else may involve security risks. risk.
 </StyledMessageBar>
 `;

--- a/src/Explorer/Tabs/NotebookV2Tab.ts
+++ b/src/Explorer/Tabs/NotebookV2Tab.ts
@@ -23,6 +23,7 @@ import * as CdbActions from "../Notebook/NotebookComponent/actions";
 import { NotebookComponentAdapter } from "../Notebook/NotebookComponent/NotebookComponentAdapter";
 import { CdbAppState, SnapshotRequest } from "../Notebook/NotebookComponent/types";
 import { NotebookContentItem } from "../Notebook/NotebookContentItem";
+import { NotebookUtil } from "../Notebook/NotebookUtil";
 import { useNotebook } from "../Notebook/useNotebook";
 import NotebookTabBase, { NotebookTabBaseOptions } from "./NotebookTabBase";
 
@@ -84,6 +85,9 @@ export default class NotebookTabV2 extends NotebookTabBase {
 
   protected getTabsButtons(): CommandButtonComponentProps[] {
     const availableKernels = NotebookTabV2.clientManager.getAvailableKernelSpecs();
+    const isNotebookUntrusted = this.notebookComponentAdapter.isNotebookUntrusted();
+
+    const runBtnTooltip = isNotebookUntrusted ? NotebookUtil.UntrustedNotebookRunHint : undefined;
 
     const saveLabel = "Save";
     const copyToLabel = "Copy to ...";
@@ -184,9 +188,10 @@ export default class NotebookTabV2 extends NotebookTabBase {
           this.traceTelemetry(Action.ExecuteCell);
         },
         commandButtonLabel: runLabel,
+        tooltipText: runBtnTooltip,
         ariaLabel: runLabel,
         hasPopup: false,
-        disabled: this.notebookComponentAdapter.isNotebookUntrusted(),
+        disabled: isNotebookUntrusted,
         children: [
           {
             iconSrc: RunIcon,

--- a/src/Explorer/Tabs/NotebookV2Tab.ts
+++ b/src/Explorer/Tabs/NotebookV2Tab.ts
@@ -88,7 +88,6 @@ export default class NotebookTabV2 extends NotebookTabBase {
     const saveLabel = "Save";
     const copyToLabel = "Copy to ...";
     const publishLabel = "Publish to gallery";
-    const workspaceLabel = "No Workspace";
     const kernelLabel = "No Kernel";
     const runLabel = "Run";
     const runActiveCellLabel = "Run Active Cell";
@@ -105,8 +104,6 @@ export default class NotebookTabV2 extends NotebookTabBase {
     const copyLabel = "Copy";
     const cutLabel = "Cut";
     const pasteLabel = "Paste";
-    const undoLabel = "Undo";
-    const redoLabel = "Redo";
     const cellCodeType = "code";
     const cellMarkdownType = "markdown";
     const cellRawType = "raw";
@@ -189,7 +186,7 @@ export default class NotebookTabV2 extends NotebookTabBase {
         commandButtonLabel: runLabel,
         ariaLabel: runLabel,
         hasPopup: false,
-        disabled: false,
+        disabled: this.notebookComponentAdapter.isNotebookUntrusted(),
         children: [
           {
             iconSrc: RunIcon,

--- a/src/Utils/GalleryUtils.ts
+++ b/src/Utils/GalleryUtils.ts
@@ -282,18 +282,9 @@ export function downloadItem(
   );
 }
 
-export function markNotebookAsUntrusted(notebook: Notebook): void {
-  if (!notebook.metadata) {
-    notebook.metadata = {};
-  }
-
+function markNotebookAsUntrusted(notebook: Notebook): void {
   const metadata = notebook.metadata as { [name: string]: unknown };
-  if (!metadata["cosmos"]) {
-    metadata.cosmos = {};
-  }
-
-  const cosmosMetadata = metadata.cosmos as { [name: string]: unknown };
-  cosmosMetadata.untrusted = true;
+  metadata.untrusted = true;
 }
 
 export const removeNotebookViewerLink = (notebook: Notebook, newCellId: string): void => {

--- a/src/Utils/GalleryUtils.ts
+++ b/src/Utils/GalleryUtils.ts
@@ -243,6 +243,10 @@ export function downloadItem(
         const notebook = JSON.parse(response.data) as Notebook;
         removeNotebookViewerLink(notebook, data.newCellId);
 
+        if (!data.isSample) {
+          markNotebookAsUntrusted(notebook);
+        }
+
         await container.importAndOpenContent(data.name, JSON.stringify(notebook));
         logConsoleInfo(`Successfully downloaded ${name} to My Notebooks`);
 
@@ -276,6 +280,30 @@ export function downloadItem(
     "Cancel",
     undefined
   );
+}
+
+export function markNotebookAsUntrusted(notebook: Notebook): void {
+  if (!notebook.metadata) {
+    notebook.metadata = {};
+  }
+
+  const metadata = notebook.metadata as { [name: string]: unknown };
+  if (!metadata.hasOwnProperty("cosmos")) {
+    metadata.cosmos = {};
+  }
+
+  const cosmosMetadata = metadata.cosmos as { [name: string]: unknown };
+  cosmosMetadata.untrusted = true;
+}
+
+export function markNotebookAsTrusted(notebook: Notebook): void {
+  const metadata = notebook.metadata as { [name: string]: unknown };
+  if (metadata?.hasOwnProperty("cosmos")) {
+    const cosmosMetadata = metadata.cosmos as { [name: string]: unknown };
+    if (cosmosMetadata?.hasOwnProperty("untrusted")) {
+      delete cosmosMetadata.untrusted;
+    }
+  }
 }
 
 export const removeNotebookViewerLink = (notebook: Notebook, newCellId: string): void => {

--- a/src/Utils/GalleryUtils.ts
+++ b/src/Utils/GalleryUtils.ts
@@ -288,22 +288,12 @@ export function markNotebookAsUntrusted(notebook: Notebook): void {
   }
 
   const metadata = notebook.metadata as { [name: string]: unknown };
-  if (!metadata.hasOwnProperty("cosmos")) {
+  if (!metadata["cosmos"]) {
     metadata.cosmos = {};
   }
 
   const cosmosMetadata = metadata.cosmos as { [name: string]: unknown };
   cosmosMetadata.untrusted = true;
-}
-
-export function markNotebookAsTrusted(notebook: Notebook): void {
-  const metadata = notebook.metadata as { [name: string]: unknown };
-  if (metadata?.hasOwnProperty("cosmos")) {
-    const cosmosMetadata = metadata.cosmos as { [name: string]: unknown };
-    if (cosmosMetadata?.hasOwnProperty("untrusted")) {
-      delete cosmosMetadata.untrusted;
-    }
-  }
 }
 
 export const removeNotebookViewerLink = (notebook: Notebook, newCellId: string): void => {

--- a/src/Utils/GalleryUtils.ts
+++ b/src/Utils/GalleryUtils.ts
@@ -244,7 +244,8 @@ export function downloadItem(
         removeNotebookViewerLink(notebook, data.newCellId);
 
         if (!data.isSample) {
-          markNotebookAsUntrusted(notebook);
+          const metadata = notebook.metadata as { [name: string]: unknown };
+          metadata.untrusted = true;
         }
 
         await container.importAndOpenContent(data.name, JSON.stringify(notebook));
@@ -280,11 +281,6 @@ export function downloadItem(
     "Cancel",
     undefined
   );
-}
-
-function markNotebookAsUntrusted(notebook: Notebook): void {
-  const metadata = notebook.metadata as { [name: string]: unknown };
-  metadata.untrusted = true;
 }
 
 export const removeNotebookViewerLink = (notebook: Notebook, newCellId: string): void => {


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/970)

1. Mark all notebooks downloaded from the Public Gallery as untrusted (by setting "untrusted" flag in notebook metadata)
2. Block executing Untrusted notebook from Keyboard shortcut, Hover button, Context Menu, and Command bar menu
3. Allow a user to Trust Notebook

Addresses this bug - https://msdata.visualstudio.com/CosmosDB/_workitems/edit/1224092/

![image](https://user-images.githubusercontent.com/693092/128555467-13a84567-afba-4b4a-93df-d62e72240265.png)
