### PR TITLE
Fetch aad token against tenant's authority

### DIFF
--- a/src/hooks/useAADAuth.ts
+++ b/src/hooks/useAADAuth.ts
@@ -56,6 +56,7 @@ export function useAADAuth(): ReturnType {
       });
       setTenantId(response.tenantId);
       setAccount(response.account);
+      localStorage.setItem("cachedTenantId", response.tenantId);
     },
     [account, tenantId]
   );

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -98,9 +98,11 @@ async function configureHostedWithAAD(config: AAD): Promise<Explorer> {
     const msalInstance = getMsalInstance();
     const cachedAccount = msalInstance.getAllAccounts()?.[0];
     msalInstance.setActiveAccount(cachedAccount);
+    const cachedTenantId = localStorage.getItem("cachedTenantId");
     const aadTokenResponse = await msalInstance.acquireTokenSilent({
       forceRefresh: true,
       scopes: [hrefEndpoint],
+      authority: `${configContext.AAD_ENDPOINT}${cachedTenantId}`,
     });
     aadToken = aadTokenResponse.accessToken;
   }


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1004?feature.enableAadDataPlane=true)


We were fetching the aadToken always against the default authority (I believe that's login.microsoftonline/common) but we have access to and can set the cachedTenantId when they change directories or accounts or login/out, so we can fetch with that tenantId.