### PR TITLE
Fixed add collection tooltip accessibility issue

### DIFF
--- a/src/Common/Tooltip/InfoTooltip.tsx
+++ b/src/Common/Tooltip/InfoTooltip.tsx
@@ -9,7 +9,7 @@ export const InfoTooltip: React.FunctionComponent<TooltipProps> = ({ children }:
   return (
     <span>
       <TooltipHost content={children}>
-        <Icon iconName="Info" ariaLabel="Info" className="panelInfoIcon" />
+        <Icon iconName="Info" ariaLabel="Info" className="panelInfoIcon" tabIndex={0} />
       </TooltipHost>
     </span>
   );

--- a/src/Explorer/Controls/ThroughputInput/__snapshots__/ThroughputInput.test.tsx.snap
+++ b/src/Explorer/Controls/ThroughputInput/__snapshots__/ThroughputInput.test.tsx.snap
@@ -345,12 +345,14 @@ exports[`ThroughputInput Pane should render Default properly 1`] = `
                     ariaLabel="Info"
                     className="panelInfoIcon"
                     iconName="Info"
+                    tabIndex={0}
                   >
                     <IconBase
                       ariaLabel="Info"
                       className="panelInfoIcon"
                       iconName="Info"
                       styles={[Function]}
+                      tabIndex={0}
                       theme={
                         Object {
                           "disableGlobalClassNames": false,
@@ -630,6 +632,7 @@ exports[`ThroughputInput Pane should render Default properly 1`] = `
                         className="panelInfoIcon root-57"
                         data-icon-name="Info"
                         role="img"
+                        tabIndex={0}
                       >
                         
                       </i>
@@ -1327,12 +1330,14 @@ exports[`ThroughputInput Pane should render Default properly 1`] = `
                         ariaLabel="Info"
                         className="panelInfoIcon"
                         iconName="Info"
+                        tabIndex={0}
                       >
                         <IconBase
                           ariaLabel="Info"
                           className="panelInfoIcon"
                           iconName="Info"
                           styles={[Function]}
+                          tabIndex={0}
                           theme={
                             Object {
                               "disableGlobalClassNames": false,
@@ -1612,6 +1617,7 @@ exports[`ThroughputInput Pane should render Default properly 1`] = `
                             className="panelInfoIcon root-57"
                             data-icon-name="Info"
                             role="img"
+                            tabIndex={0}
                           >
                             
                           </i>

--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -576,7 +576,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                   type="radio"
                   role="radio"
                   id="enableAnalyticalStoreBtn"
-                  // tabIndex={0}
+                  tabIndex={0}
                   onChange={this.onEnableAnalyticalStoreRadioBtnChange.bind(this)}
                 />
                 <span className="panelRadioBtnLabel">On</span>
@@ -591,7 +591,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                   type="radio"
                   role="radio"
                   id="disableAnalyticalStoreBtn"
-                  // tabIndex={0}
+                  tabIndex={0}
                   onChange={this.onDisableAnalyticalStoreRadioBtnChange.bind(this)}
                 />
                 <span className="panelRadioBtnLabel">Off</span>

--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -161,7 +161,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                   true
                 ).toLocaleLowerCase()}.`}
               >
-                <Icon iconName="Info" className="panelInfoIcon" />
+                <Icon iconName="Info" className="panelInfoIcon" tabIndex={0} />
               </TooltipHost>
             </Stack>
 
@@ -210,6 +210,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                   className="panelTextField"
                   aria-label="New database id"
                   autoFocus
+                  tabIndex={0}
                   value={this.state.newDatabaseId}
                   onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
                     this.setState({ newDatabaseId: event.target.value })
@@ -236,7 +237,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                         true
                       ).toLocaleLowerCase()} within the database.`}
                     >
-                      <Icon iconName="Info" className="panelInfoIcon" />
+                      <Icon iconName="Info" className="panelInfoIcon" tabIndex={0} />
                     </TooltipHost>
                   </Stack>
                 )}
@@ -279,7 +280,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                 directionalHint={DirectionalHint.bottomLeftEdge}
                 content={`Unique identifier for the ${getCollectionName().toLocaleLowerCase()} and used for id-based routing through REST and all SDKs.`}
               >
-                <Icon iconName="Info" className="panelInfoIcon" />
+                <Icon iconName="Info" className="panelInfoIcon" tabIndex={0} />
               </TooltipHost>
             </Stack>
 
@@ -362,7 +363,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                       "Sharded collections split your data across many replica sets (shards) to achieve unlimited scalability. Sharded collections require choosing a shard key (field) to evenly distribute your data."
                     }
                   >
-                    <Icon iconName="Info" className="panelInfoIcon" />
+                    <Icon iconName="Info" className="panelInfoIcon" tabIndex={0} />
                   </TooltipHost>
                 </Stack>
 
@@ -376,7 +377,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                     type="radio"
                     role="radio"
                     id="unshardedOption"
-                    tabIndex={0}
+                    // tabIndex={0}
                     onChange={this.onUnshardedRadioBtnChange.bind(this)}
                   />
                   <span className="panelRadioBtnLabel">Unsharded (20GB limit)</span>
@@ -390,7 +391,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                     type="radio"
                     role="radio"
                     id="shardedOption"
-                    tabIndex={0}
+                    // tabIndex={0}
                     onChange={this.onShardedRadioBtnChange.bind(this)}
                   />
                   <span className="panelRadioBtnLabel">Sharded</span>
@@ -409,7 +410,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                   directionalHint={DirectionalHint.bottomLeftEdge}
                   content={this.getPartitionKeyTooltipText()}
                 >
-                  <Icon iconName="Info" className="panelInfoIcon" />
+                  <Icon iconName="Info" className="panelInfoIcon" tabIndex={0} />
                 </TooltipHost>
               </Stack>
 
@@ -467,7 +468,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                   does not count towards the throughput you provisioned for the database. This throughput amount will be
                   billed in addition to the throughput amount you provisioned at the database level.`}
               >
-                <Icon iconName="Info" className="panelInfoIcon" />
+                <Icon iconName="Info" className="panelInfoIcon" tabIndex={0} />
               </TooltipHost>
             </Stack>
           )}
@@ -497,7 +498,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                       creating a unique key policy when a container is created, you ensure the uniqueness of one or more values
                       per partition key."
                 >
-                  <Icon iconName="Info" className="panelInfoIcon" />
+                  <Icon iconName="Info" className="panelInfoIcon" tabIndex={0} />
                 </TooltipHost>
               </Stack>
 
@@ -560,7 +561,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                   directionalHint={DirectionalHint.bottomLeftEdge}
                   content={this.getAnalyticalStorageTooltipContent()}
                 >
-                  <Icon iconName="Info" className="panelInfoIcon" />
+                  <Icon iconName="Info" className="panelInfoIcon" tabIndex={0} />
                 </TooltipHost>
               </Stack>
 
@@ -575,7 +576,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                   type="radio"
                   role="radio"
                   id="enableAnalyticalStoreBtn"
-                  tabIndex={0}
+                  // tabIndex={0}
                   onChange={this.onEnableAnalyticalStoreRadioBtnChange.bind(this)}
                 />
                 <span className="panelRadioBtnLabel">On</span>
@@ -590,7 +591,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                   type="radio"
                   role="radio"
                   id="disableAnalyticalStoreBtn"
-                  tabIndex={0}
+                  // tabIndex={0}
                   onChange={this.onDisableAnalyticalStoreRadioBtnChange.bind(this)}
                 />
                 <span className="panelRadioBtnLabel">Off</span>
@@ -637,7 +638,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                         directionalHint={DirectionalHint.bottomLeftEdge}
                         content="The _id field is indexed by default. Creating a wildcard index for all fields will optimize queries and is recommended for development."
                       >
-                        <Icon iconName="Info" className="panelInfoIcon" />
+                        <Icon iconName="Info" className="panelInfoIcon" tabIndex={0} />
                       </TooltipHost>
                     </Stack>
 

--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -377,7 +377,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                     type="radio"
                     role="radio"
                     id="unshardedOption"
-                    // tabIndex={0}
+                    tabIndex={0}
                     onChange={this.onUnshardedRadioBtnChange.bind(this)}
                   />
                   <span className="panelRadioBtnLabel">Unsharded (20GB limit)</span>
@@ -391,7 +391,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                     type="radio"
                     role="radio"
                     id="shardedOption"
-                    // tabIndex={0}
+                    tabIndex={0}
                     onChange={this.onShardedRadioBtnChange.bind(this)}
                   />
                   <span className="panelRadioBtnLabel">Sharded</span>


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1022?feature.someFeatureFlagYouMightNeed=true)

Fixed 'Info' icons containing tooltip information under 'New collection' blade accessible using keyboard issue.



https://user-images.githubusercontent.com/79906609/132536564-3414fd8a-8163-4673-a004-0eee9c680f1c.mp4

