### PR TITLE
Data pane expand issue

### DIFF
--- a/src/Explorer/Notebook/useNotebook.ts
+++ b/src/Explorer/Notebook/useNotebook.ts
@@ -189,10 +189,10 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
     };
     const gitHubNotebooksContentRoot = notebookManager?.gitHubOAuthService?.isLoggedIn()
       ? {
-          name: "GitHub repos",
-          path: "PsuedoDir",
-          type: NotebookContentItemType.Directory,
-        }
+        name: "GitHub repos",
+        path: "PsuedoDir",
+        type: NotebookContentItemType.Directory,
+      }
       : undefined;
     set({
       myNotebooksContentRoot,

--- a/src/Explorer/Notebook/useNotebook.ts
+++ b/src/Explorer/Notebook/useNotebook.ts
@@ -187,11 +187,13 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
       path: "Gallery",
       type: NotebookContentItemType.File,
     };
-    const gitHubNotebooksContentRoot = {
-      name: "GitHub repos",
-      path: "PsuedoDir",
-      type: NotebookContentItemType.Directory,
-    };
+    const gitHubNotebooksContentRoot = notebookManager?.gitHubOAuthService?.isLoggedIn()
+      ? {
+        name: "GitHub repos",
+        path: "PsuedoDir",
+        type: NotebookContentItemType.Directory,
+      }
+      : undefined;
     set({
       myNotebooksContentRoot,
       galleryContentRoot,

--- a/src/Explorer/Notebook/useNotebook.ts
+++ b/src/Explorer/Notebook/useNotebook.ts
@@ -189,11 +189,12 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
     };
     const gitHubNotebooksContentRoot = notebookManager?.gitHubOAuthService?.isLoggedIn()
       ? {
-        name: "GitHub repos",
-        path: "PsuedoDir",
-        type: NotebookContentItemType.Directory,
-      }
+          name: "GitHub repos",
+          path: "PsuedoDir",
+          type: NotebookContentItemType.Directory,
+        }
       : undefined;
+
     set({
       myNotebooksContentRoot,
       galleryContentRoot,

--- a/src/Explorer/Notebook/useNotebook.ts
+++ b/src/Explorer/Notebook/useNotebook.ts
@@ -189,10 +189,10 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
     };
     const gitHubNotebooksContentRoot = notebookManager?.gitHubOAuthService?.isLoggedIn()
       ? {
-        name: "GitHub repos",
-        path: "PsuedoDir",
-        type: NotebookContentItemType.Directory,
-      }
+          name: "GitHub repos",
+          path: "PsuedoDir",
+          type: NotebookContentItemType.Directory,
+        }
       : undefined;
     set({
       myNotebooksContentRoot,


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Data pane expansion issue fixed.

**Issue Context:**
Data Node expansion was linked to GitHub tree connection i.e., when user connects to GitHub we collapse Data and expand GitHub. During phoenix changes I have created a GitHub tree in left menu with the context menu to connect to GitHub and as part it this got broke. We reverted the GitHub left menu changes but this missed. This PR fix this. 