### PR TITLE
Scale and Settings: Text content of 'Info status message' and 'Warnin…

### DIFF
--- a/src/Explorer/Controls/Settings/SettingsRenderUtils.tsx
+++ b/src/Explorer/Controls/Settings/SettingsRenderUtils.tsx
@@ -65,7 +65,7 @@ export interface PriceBreakdown {
   currencySign: string;
 }
 
-export const infoAndToolTipTextStyle: ITextStyles = { root: { fontSize: 14 } };
+export const infoAndToolTipTextStyle: ITextStyles = { root: { fontSize: 14, color: "windowtext" } };
 
 export const noLeftPaddingCheckBoxStyle: ICheckboxStyles = {
   label: {


### PR DESCRIPTION
…g' message is not visible properly at high contrast black mode.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1090?feature.someFeatureFlagYouMightNeed=true)

![image](https://user-images.githubusercontent.com/80053762/133725509-8d80249d-43bc-4de7-a3e8-f6174850934d.png)
