### PR TITLE
Close tab fixes

### DIFF
--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -69,7 +69,11 @@ export const useTabs: UseStore<TabsState> = create((set, get) => ({
     if (tab.tabId === activeTab.tabId && tabIndex !== -1) {
       const tabToTheRight = updatedTabs[tabIndex];
       const lastOpenTab = updatedTabs[updatedTabs.length - 1];
-      set({ activeTab: tabToTheRight || lastOpenTab });
+      const newActiveTab = tabToTheRight ?? lastOpenTab;
+      if (newActiveTab) {
+        set({ activeTab: newActiveTab });
+        newActiveTab.onActivate();
+      }
     }
 
     set({ openedTabs: updatedTabs });

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -70,8 +70,8 @@ export const useTabs: UseStore<TabsState> = create((set, get) => ({
       const tabToTheRight = updatedTabs[tabIndex];
       const lastOpenTab = updatedTabs[updatedTabs.length - 1];
       const newActiveTab = tabToTheRight ?? lastOpenTab;
+      set({ activeTab: newActiveTab });
       if (newActiveTab) {
-        set({ activeTab: newActiveTab });
         newActiveTab.onActivate();
       }
     }


### PR DESCRIPTION
Ensure that when promoting a new tab to being the 'active' tab (as a consequence of, say, closing the active tab) that the newly promoted tab has a chance to install its buttons and what not.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1107)

https://user-images.githubusercontent.com/3104/134435353-68bcb0e2-8a4c-4981-823e-7aa6c50725ea.mov
