### PR TITLE
Users/kcheekuri/phoenix reconnect intergration

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -346,6 +346,11 @@ export enum ConnectionStatusType {
   ReConnect = "Reconnect",
 }
 
+export enum ConatinerStatusType {
+  Active = "Active",
+  InActive = "InActive",
+}
+
 export const EmulatorMasterKey =
   //[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Well known public masterKey for emulator")]
   "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
@@ -356,6 +361,7 @@ export const StyleConstants = require("less-vars-loader!../../less/Common/Consta
 export class Notebook {
   public static readonly defaultBasePath = "./notebooks";
   public static readonly heartbeatDelayMs = 60000;
+  public static readonly containerStatusHeartbeatDelayMs = 30000;
   public static readonly kernelRestartInitialDelayMs = 1000;
   public static readonly kernelRestartMaxDelayMs = 20000;
   public static readonly autoSaveIntervalMs = 120000;
@@ -365,11 +371,11 @@ export class Notebook {
     "We have identified an issue with the Mongo Shell and it is unavailable right now. We are actively working on the mitigation.";
   public static readonly cassandraShellTemporarilyDownMsg =
     "We have identified an issue with the Cassandra Shell and it is unavailable right now. We are actively working on the mitigation.";
-  public static saveNotebookModalTitle = "Save Notebook in temporary workspace";
+  public static saveNotebookModalTitle = "Save notebook in temporary workspace";
   public static saveNotebookModalContent =
     "This notebook will be saved in the temporary workspace and will be removed when the session expires. To save your work permanently, save your notebooks to a GitHub repository or download the notebooks to your local machine before the session ends.";
-  public static newNotebookModalTitle = "Create Notebook in temporary workspace";
-  public static newNotebookUploadModalTitle = "Upload Notebook in temporary workspace";
+  public static newNotebookModalTitle = "Create notebook in temporary workspace";
+  public static newNotebookUploadModalTitle = "Upload notebook to temporary workspace";
   public static newNotebookModalContent1 =
     "A temporary workspace will be created to enable you to work with notebooks. When the session expires, any notebooks in the workspace will be removed.";
   public static newNotebookModalContent2 =

--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -1,4 +1,4 @@
-import { ConnectionStatusType } from "../Common/Constants";
+import { ConatinerStatusType, ConnectionStatusType } from "../Common/Constants";
 
 export interface DatabaseAccount {
   id: string;
@@ -426,6 +426,13 @@ export interface OperationStatus {
 export interface NotebookWorkspaceConnectionInfo {
   authToken: string;
   notebookServerEndpoint: string;
+  forwardingId: string;
+}
+
+export interface ConatinerInfo {
+  durationLeftInMinutes: number;
+  notebookServerInfo: NotebookWorkspaceConnectionInfo;
+  status: ConatinerStatusType;
 }
 
 export interface NotebookWorkspaceFeedResponse {

--- a/src/Explorer/Controls/Dialog.tsx
+++ b/src/Explorer/Controls/Dialog.tsx
@@ -13,7 +13,6 @@ import {
   Link,
   PrimaryButton,
   ProgressIndicator,
-  Text,
   TextField,
 } from "@fluentui/react";
 import React, { FC } from "react";
@@ -197,7 +196,7 @@ export const Dialog: FC = () => {
           {linkProps.linkText} <FontIcon iconName="NavigateExternalInline" />
         </Link>
       )}
-      {contentHtml && <Text>{contentHtml}</Text>}
+      {contentHtml}
       {progressIndicatorProps && <ProgressIndicator {...progressIndicatorProps} />}
       <DialogFooter>
         <PrimaryButton {...primaryButtonProps} />

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -700,7 +700,7 @@ export default class Explorer {
       throw new Error(`Invalid notebookContentItem: ${notebookContentItem}`);
     }
     if (notebookContentItem.type === NotebookContentItemType.Notebook && NotebookUtil.isPhoenixEnabled()) {
-      this.allocateContainer();
+      await this.allocateContainer();
     }
 
     const notebookTabs = useTabs
@@ -1024,8 +1024,8 @@ export default class Explorer {
         useDialog
           .getState()
           .showOkModalDialog(
-            "Failed to Connect",
-            "Failed to connect temporary workspace, this could happen because of network issue please refresh and try again."
+            "Failed to connect",
+            "Failed to connect to temporary workspace. This could happen because of network issues. Please refresh the page and try again."
           );
       }
     } else {

--- a/src/Explorer/Menus/CommandBar/ConnectionStatusComponent.tsx
+++ b/src/Explorer/Menus/CommandBar/ConnectionStatusComponent.tsx
@@ -1,8 +1,9 @@
-import { Icon, ProgressIndicator, Stack, TooltipHost } from "@fluentui/react";
-import { ActionButton } from "@fluentui/react/lib/Button";
+import { FocusTrapCallout, FocusZone, FocusZoneTabbableElements, FontWeights, Icon, mergeStyleSets, ProgressIndicator, Stack, Text, TooltipHost } from "@fluentui/react";
+import { useId } from '@fluentui/react-hooks';
+import { ActionButton, DefaultButton } from "@fluentui/react/lib/Button";
 import * as React from "react";
 import "../../../../less/hostedexplorer.less";
-import { ConnectionStatusType, Notebook } from "../../../Common/Constants";
+import { ConatinerStatusType, ConnectionStatusType, Notebook } from "../../../Common/Constants";
 import Explorer from "../../Explorer";
 import { useNotebook } from "../../Notebook/useNotebook";
 import "../CommandBar/ConnectionStatusComponent.less";
@@ -16,6 +17,26 @@ export const ConnectionStatus: React.FC<Props> = ({ container }: Props): JSX.Ele
   const [counter, setCounter] = React.useState(0);
   const [statusColor, setStatusColor] = React.useState("");
   const [toolTipContent, setToolTipContent] = React.useState("Connect to temporary workspace.");
+  const [isBarDismissed, setIsBarDismissed] = React.useState<boolean>(false);
+  const buttonId = useId('callout-button');
+  const containerInfo = useNotebook((state) => state.conatinerStatus);
+
+  const styles = mergeStyleSets({
+    callout: {
+      width: 320,
+      padding: '20px 24px',
+    },
+    title: {
+      marginBottom: 12,
+      fontWeight: FontWeights.semilight,
+    },
+    buttons: {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      marginTop: 20,
+    },
+  });
+
   React.useEffect(() => {
     let intervalId: NodeJS.Timeout;
 
@@ -78,30 +99,55 @@ export const ConnectionStatus: React.FC<Props> = ({ container }: Props): JSX.Ele
     setToolTipContent("Click here to Reconnect to temporary workspace.");
   }
   return (
-    <ActionButton
-      className={connectionInfo.status === ConnectionStatusType.Failed ? "commandReactBtn" : "connectedReactBtn"}
-      onClick={(e: React.MouseEvent<HTMLSpanElement>) =>
-        connectionInfo.status === ConnectionStatusType.Failed ? container.allocateContainer() : e.preventDefault()
-      }
-    >
-      <TooltipHost content={toolTipContent}>
-        <Stack className="connectionStatusContainer" horizontal>
-          <i className={statusColor}></i>
-          <span className={connectionInfo.status === ConnectionStatusType.Failed ? "connectionStatusFailed" : ""}>
-            {connectionInfo.status}
-          </span>
-          {connectionInfo.status === ConnectionStatusType.Connecting && isActive && (
-            <ProgressIndicator description={minute + ":" + second} />
-          )}
-          {connectionInfo.status === ConnectionStatusType.Connected && !isActive && (
-            <ProgressIndicator
-              className={usedGB / totalGB > 0.8 ? "lowMemory" : ""}
-              description={usedGB.toFixed(1) + " of " + totalGB.toFixed(1) + " GB"}
-              percentComplete={usedGB / totalGB}
-            />
-          )}
-        </Stack>
+    <>
+      <TooltipHost content={(containerInfo.status && containerInfo.status === ConatinerStatusType.Active && Math.round(containerInfo.durationLeftInMinutes) <= 10) ?
+        `Connected to temporary workspace. This temporary workspace will get disconnected in ${Math.round(containerInfo.durationLeftInMinutes)} minutes.` : toolTipContent}>
+        <ActionButton id={buttonId}
+          className={connectionInfo.status === ConnectionStatusType.Failed ? "commandReactBtn" : "connectedReactBtn"}
+          onClick={(e: React.MouseEvent<HTMLSpanElement>) =>
+            connectionInfo.status === ConnectionStatusType.Failed ? container.allocateContainer() : e.preventDefault()
+          }
+        >
+          <Stack className="connectionStatusContainer" horizontal>
+            <i className={statusColor}></i>
+            <span className={connectionInfo.status === ConnectionStatusType.Failed ? "connectionStatusFailed" : ""}>
+              {connectionInfo.status}
+            </span>
+            {connectionInfo.status === ConnectionStatusType.Connecting && isActive && (
+              <ProgressIndicator description={minute + ":" + second} />
+            )}
+            {connectionInfo.status === ConnectionStatusType.Connected && !isActive && (
+              <ProgressIndicator
+                className={usedGB / totalGB > 0.8 ? "lowMemory" : ""}
+                description={usedGB.toFixed(1) + " of " + totalGB.toFixed(1) + " GB"}
+                percentComplete={usedGB / totalGB}
+              />
+            )}
+          </Stack>
+          {(!isBarDismissed && containerInfo.status && containerInfo.status === ConatinerStatusType.Active && Math.round(containerInfo.durationLeftInMinutes) <= 10) ? (
+            <FocusTrapCallout
+              role="alertdialog"
+              className={styles.callout}
+              gapSpace={0}
+              target={`#${buttonId}`}
+              onDismiss={() => setIsBarDismissed(true)}
+              setInitialFocus
+            >
+              <Text block variant="xLarge" className={styles.title}>
+                Remaining Time
+              </Text>
+              <Text block variant="small">
+                This temporary workspace will get disconnected in {Math.round(containerInfo.durationLeftInMinutes)} minutes. To save your work permanently, save your notebooks to a GitHub repository or download the notebooks to your local machine before the session ends.
+              </Text>
+              <FocusZone handleTabKey={FocusZoneTabbableElements.all} isCircularNavigation>
+                <Stack className={styles.buttons} gap={8} horizontal>
+                  <DefaultButton onClick={() => setIsBarDismissed(true)}>Dimiss</DefaultButton>
+                </Stack>
+              </FocusZone>
+            </FocusTrapCallout>
+          ) : null}
+        </ActionButton>
       </TooltipHost>
-    </ActionButton>
+    </>
   );
 };

--- a/src/Explorer/Menus/CommandBar/ConnectionStatusComponent.tsx
+++ b/src/Explorer/Menus/CommandBar/ConnectionStatusComponent.tsx
@@ -1,5 +1,16 @@
-import { FocusTrapCallout, FocusZone, FocusZoneTabbableElements, FontWeights, Icon, mergeStyleSets, ProgressIndicator, Stack, Text, TooltipHost } from "@fluentui/react";
-import { useId } from '@fluentui/react-hooks';
+import {
+  FocusTrapCallout,
+  FocusZone,
+  FocusZoneTabbableElements,
+  FontWeights,
+  Icon,
+  mergeStyleSets,
+  ProgressIndicator,
+  Stack,
+  Text,
+  TooltipHost,
+} from "@fluentui/react";
+import { useId } from "@fluentui/react-hooks";
 import { ActionButton, DefaultButton } from "@fluentui/react/lib/Button";
 import * as React from "react";
 import "../../../../less/hostedexplorer.less";
@@ -18,21 +29,21 @@ export const ConnectionStatus: React.FC<Props> = ({ container }: Props): JSX.Ele
   const [statusColor, setStatusColor] = React.useState("");
   const [toolTipContent, setToolTipContent] = React.useState("Connect to temporary workspace.");
   const [isBarDismissed, setIsBarDismissed] = React.useState<boolean>(false);
-  const buttonId = useId('callout-button');
+  const buttonId = useId("callout-button");
   const containerInfo = useNotebook((state) => state.conatinerStatus);
 
   const styles = mergeStyleSets({
     callout: {
       width: 320,
-      padding: '20px 24px',
+      padding: "20px 24px",
     },
     title: {
       marginBottom: 12,
       fontWeight: FontWeights.semilight,
     },
     buttons: {
-      display: 'flex',
-      justifyContent: 'flex-end',
+      display: "flex",
+      justifyContent: "flex-end",
       marginTop: 20,
     },
   });
@@ -100,9 +111,19 @@ export const ConnectionStatus: React.FC<Props> = ({ container }: Props): JSX.Ele
   }
   return (
     <>
-      <TooltipHost content={(containerInfo.status && containerInfo.status === ConatinerStatusType.Active && Math.round(containerInfo.durationLeftInMinutes) <= 10) ?
-        `Connected to temporary workspace. This temporary workspace will get disconnected in ${Math.round(containerInfo.durationLeftInMinutes)} minutes.` : toolTipContent}>
-        <ActionButton id={buttonId}
+      <TooltipHost
+        content={
+          containerInfo.status &&
+          containerInfo.status === ConatinerStatusType.Active &&
+          Math.round(containerInfo.durationLeftInMinutes) <= 10
+            ? `Connected to temporary workspace. This temporary workspace will get disconnected in ${Math.round(
+                containerInfo.durationLeftInMinutes
+              )} minutes.`
+            : toolTipContent
+        }
+      >
+        <ActionButton
+          id={buttonId}
           className={connectionInfo.status === ConnectionStatusType.Failed ? "commandReactBtn" : "connectedReactBtn"}
           onClick={(e: React.MouseEvent<HTMLSpanElement>) =>
             connectionInfo.status === ConnectionStatusType.Failed ? container.allocateContainer() : e.preventDefault()
@@ -124,7 +145,10 @@ export const ConnectionStatus: React.FC<Props> = ({ container }: Props): JSX.Ele
               />
             )}
           </Stack>
-          {(!isBarDismissed && containerInfo.status && containerInfo.status === ConatinerStatusType.Active && Math.round(containerInfo.durationLeftInMinutes) <= 10) ? (
+          {!isBarDismissed &&
+          containerInfo.status &&
+          containerInfo.status === ConatinerStatusType.Active &&
+          Math.round(containerInfo.durationLeftInMinutes) <= 10 ? (
             <FocusTrapCallout
               role="alertdialog"
               className={styles.callout}
@@ -137,7 +161,9 @@ export const ConnectionStatus: React.FC<Props> = ({ container }: Props): JSX.Ele
                 Remaining Time
               </Text>
               <Text block variant="small">
-                This temporary workspace will get disconnected in {Math.round(containerInfo.durationLeftInMinutes)} minutes. To save your work permanently, save your notebooks to a GitHub repository or download the notebooks to your local machine before the session ends.
+                This temporary workspace will get disconnected in {Math.round(containerInfo.durationLeftInMinutes)}{" "}
+                minutes. To save your work permanently, save your notebooks to a GitHub repository or download the
+                notebooks to your local machine before the session ends.
               </Text>
               <FocusZone handleTabKey={FocusZoneTabbableElements.all} isCircularNavigation>
                 <Stack className={styles.buttons} gap={8} horizontal>
@@ -145,7 +171,7 @@ export const ConnectionStatus: React.FC<Props> = ({ container }: Props): JSX.Ele
                 </Stack>
               </FocusZone>
             </FocusTrapCallout>
-          ) : null}
+          ) : undefined}
         </ActionButton>
       </TooltipHost>
     </>

--- a/src/Explorer/Notebook/useNotebook.ts
+++ b/src/Explorer/Notebook/useNotebook.ts
@@ -7,7 +7,7 @@ import { getErrorMessage } from "../../Common/ErrorHandlingUtils";
 import * as Logger from "../../Common/Logger";
 import { configContext } from "../../ConfigContext";
 import * as DataModels from "../../Contracts/DataModels";
-import { ContainerConnectionInfo } from "../../Contracts/DataModels";
+import { ConatinerInfo, ContainerConnectionInfo } from "../../Contracts/DataModels";
 import { IPinnedRepo } from "../../Juno/JunoClient";
 import { Action, ActionModifiers } from "../../Shared/Telemetry/TelemetryConstants";
 import * as TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
@@ -35,6 +35,7 @@ interface NotebookState {
   notebookFolderName: string;
   isAllocating: boolean;
   isRefreshed: boolean;
+  conatinerStatus: ConatinerInfo;
   setIsNotebookEnabled: (isNotebookEnabled: boolean) => void;
   setIsNotebooksEnabledForAccount: (isNotebooksEnabledForAccount: boolean) => void;
   setNotebookServerInfo: (notebookServerInfo: DataModels.NotebookWorkspaceConnectionInfo) => void;
@@ -55,6 +56,7 @@ interface NotebookState {
   setIsAllocating: (isAllocating: boolean) => void;
   resetConatinerConnection: (connectionStatus: ContainerConnectionInfo) => void;
   setIsRefreshed: (isAllocating: boolean) => void;
+  setConatinerStatus: (conatinerStatus: ConatinerInfo) => void;
 }
 
 export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
@@ -63,6 +65,7 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
   notebookServerInfo: {
     notebookServerEndpoint: undefined,
     authToken: undefined,
+    forwardingId: undefined,
   },
   sparkClusterConnectionInfo: {
     userName: undefined,
@@ -83,6 +86,11 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
   notebookFolderName: undefined,
   isAllocating: false,
   isRefreshed: false,
+  conatinerStatus: {
+    status: undefined,
+    durationLeftInMinutes: undefined,
+    notebookServerInfo: undefined,
+  },
   setIsNotebookEnabled: (isNotebookEnabled: boolean) => set({ isNotebookEnabled }),
   setIsNotebooksEnabledForAccount: (isNotebooksEnabledForAccount: boolean) => set({ isNotebooksEnabledForAccount }),
   setNotebookServerInfo: (notebookServerInfo: DataModels.NotebookWorkspaceConnectionInfo) =>
@@ -275,8 +283,15 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
     useNotebook.getState().setNotebookServerInfo({
       notebookServerEndpoint: undefined,
       authToken: undefined,
+      forwardingId: undefined,
     });
     useNotebook.getState().setIsAllocating(false);
+    useNotebook.getState().setConatinerStatus({
+      status: undefined,
+      durationLeftInMinutes: undefined,
+      notebookServerInfo: undefined,
+    });
   },
   setIsRefreshed: (isRefreshed: boolean) => set({ isRefreshed }),
+  setConatinerStatus: (conatinerStatus: ConatinerInfo) => set({ conatinerStatus }),
 }));

--- a/src/Phoenix/PhoenixClient.ts
+++ b/src/Phoenix/PhoenixClient.ts
@@ -102,8 +102,7 @@ export class PhoenixClient {
         notebookServerInfo: undefined,
         status: ConatinerStatusType.InActive,
       };
-    }
-    catch (error) {
+    } catch (error) {
       Logger.logError(getErrorMessage(error), "PhoenixClient/getContainerStatus");
       return {
         durationLeftInMinutes: undefined,

--- a/src/Utils/GalleryUtils.ts
+++ b/src/Utils/GalleryUtils.ts
@@ -239,8 +239,8 @@ export function downloadItem(
         useDialog
           .getState()
           .showOkModalDialog(
-            "Failed to Connect",
-            "Failed to connect to temporary workspace. Please refresh the page and try again."
+            "Failed to connect",
+            "Failed to connect to temporary workspace. This could happen because of network issues. Please refresh the page and try again."
           );
       }
     },


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

This PR:

- Reconnect experience with callout[Like a tooltip] at the left over time of 10 minutes time of container deprovision.
- Container Heart beat with 30 seconds
- Fixed: while connecting to container on click of git notebook, pointing to different URL. Need to point to gateway.
- Open Mongo shell/Cassandra shell container connection.
Connected state:
![image](https://user-images.githubusercontent.com/88904658/136497216-a3777abf-e7ad-4266-b8fd-9312f9aa3151.png)
Callout Notification:
![image](https://user-images.githubusercontent.com/88904658/136497272-8dadc679-696f-4a70-8269-b086b569f439.png)
Timer on Hover of connection :
![image](https://user-images.githubusercontent.com/88904658/136497334-4fc2fcaf-7582-4e8d-a788-2ec5b0578d47.png)
This comes only for last 10 minutes of hard deprovision of 1hr[BRS configured].


