### PR TITLE
Set partition key to undefined when creating an unsharded mongo collection

### DIFF
--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -999,7 +999,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
 
     const collectionId: string = this.state.collectionId.trim();
     let databaseId = this.state.createNewDatabase ? this.state.newDatabaseId.trim() : this.state.selectedDatabaseId;
-    let partitionKeyString = this.state.partitionKey.trim();
+    let partitionKeyString = this.state.isSharded ? this.state.partitionKey.trim() : undefined;
 
     if (userContext.apiType === "Tables") {
       // Table require fixed Database: TablesDB, and fixed Partition Key: /'$pk'


### PR DESCRIPTION
If the unsharded checkboxed is selected, override any existing shard key values with `undefined`.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1128?feature.someFeatureFlagYouMightNeed=true)
