### PR TITLE
Fix cassandra update query bug

### DIFF
--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -202,14 +202,21 @@ export class CassandraAPIDataClient extends TableDataClient {
 
       let updateQuery = `UPDATE ${collection.databaseId}.${collection.id()}`;
       let isPropertyUpdated = false;
+      let isFirstPropertyToUpdate = true;
       for (let property in newEntity) {
         if (
           !originalDocument[property] ||
           newEntity[property]._.toString() !== originalDocument[property]._.toString()
         ) {
-          updateQuery += this.isStringType(newEntity[property].$)
-            ? ` SET ${property} = '${newEntity[property]._}',`
-            : ` SET ${property} = ${newEntity[property]._},`;
+          let propertyQuerySegment = this.isStringType(newEntity[property].$)
+            ? `${property} = '${newEntity[property]._}',`
+            : `${property} = ${newEntity[property]._},`;
+          // Only add the "SET" keyword once
+          if (isFirstPropertyToUpdate) {
+            propertyQuerySegment = " SET " + propertyQuerySegment;
+            isFirstPropertyToUpdate = false;
+          }
+          updateQuery += propertyQuerySegment;
           isPropertyUpdated = true;
         }
       }


### PR DESCRIPTION
Only use the SET keyword once in the update query.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
