### PR TITLE
Fixed bug with github integration

### DIFF
--- a/src/Explorer/Controls/GitHub/AddRepoComponent.tsx
+++ b/src/Explorer/Controls/GitHub/AddRepoComponent.tsx
@@ -1,14 +1,14 @@
 import { DefaultButton, IButtonProps, ITextFieldProps, TextField } from "@fluentui/react";
 import * as React from "react";
 import * as Constants from "../../../Common/Constants";
+import * as UrlUtility from "../../../Common/UrlUtility";
+import { IGitHubRepo } from "../../../GitHub/GitHubClient";
 import { Action } from "../../../Shared/Telemetry/TelemetryConstants";
+import * as TelemetryProcessor from "../../../Shared/Telemetry/TelemetryProcessor";
+import * as GitHubUtils from "../../../Utils/GitHubUtils";
+import Explorer from "../../Explorer";
 import { RepoListItem } from "./GitHubReposComponent";
 import { ChildrenMargin } from "./GitHubStyleConstants";
-import * as GitHubUtils from "../../../Utils/GitHubUtils";
-import { IGitHubRepo } from "../../../GitHub/GitHubClient";
-import * as TelemetryProcessor from "../../../Shared/Telemetry/TelemetryProcessor";
-import * as UrlUtility from "../../../Common/UrlUtility";
-import Explorer from "../../Explorer";
 
 export interface AddRepoComponentProps {
   container: Explorer;
@@ -27,7 +27,6 @@ export class AddRepoComponent extends React.Component<AddRepoComponentProps, Add
   private static readonly ButtonText = "Add";
   private static readonly TextFieldPlaceholder = "https://github.com/owner/repo/tree/branch";
   private static readonly TextFieldErrorMessage = "Invalid url";
-  private static readonly DefaultBranchName = "master";
 
   constructor(props: AddRepoComponentProps) {
     super(props);
@@ -78,7 +77,7 @@ export class AddRepoComponent extends React.Component<AddRepoComponentProps, Add
     });
     let enteredUrl = this.state.textFieldValue;
     if (enteredUrl.indexOf("/tree/") === -1) {
-      enteredUrl = UrlUtility.createUri(enteredUrl, `tree/${AddRepoComponent.DefaultBranchName}`);
+      enteredUrl = UrlUtility.createUri(enteredUrl, `tree/`);
     }
 
     const repoInfo = GitHubUtils.fromRepoUri(enteredUrl);
@@ -93,11 +92,7 @@ export class AddRepoComponent extends React.Component<AddRepoComponentProps, Add
         const item: RepoListItem = {
           key: GitHubUtils.toRepoFullName(repo.owner, repo.name),
           repo,
-          branches: [
-            {
-              name: repoInfo.branch,
-            },
-          ],
+          branches: repoInfo.branch ? [{ name: repoInfo.branch }] : [],
         };
 
         TelemetryProcessor.traceSuccess(

--- a/src/Explorer/Controls/GitHub/ReposListComponent.tsx
+++ b/src/Explorer/Controls/GitHub/ReposListComponent.tsx
@@ -24,11 +24,11 @@ import { RepoListItem } from "./GitHubReposComponent";
 import {
   BranchesDropdownCheckboxStyles,
   BranchesDropdownOptionContainerStyle,
+  BranchesDropdownStyles,
+  BranchesDropdownWidth,
+  ReposListBranchesColumnWidth,
   ReposListCheckboxStyles,
   ReposListRepoColumnMinWidth,
-  ReposListBranchesColumnWidth,
-  BranchesDropdownWidth,
-  BranchesDropdownStyles,
 } from "./GitHubStyleConstants";
 
 export interface ReposListComponentProps {
@@ -44,6 +44,7 @@ export interface BranchesProps {
   lastPageInfo?: IGitHubPageInfo;
   hasMore: boolean;
   isLoading: boolean;
+  defaultBranchName: string;
   loadMore: () => void;
 }
 
@@ -64,7 +65,7 @@ export class ReposListComponent extends React.Component<ReposListComponentProps>
   private static readonly BranchesColumnName = "Branches";
   private static readonly LoadingText = "Loading...";
   private static readonly LoadMoreText = "Load more";
-  private static readonly DefaultBranchName = "master";
+  private static readonly DefaultBranchNames = "master/main";
   private static readonly FooterIndex = -1;
 
   public render(): JSX.Element {
@@ -155,6 +156,10 @@ export class ReposListComponent extends React.Component<ReposListComponentProps>
     }
 
     const branchesProps = this.props.branchesProps[GitHubUtils.toRepoFullName(item.repo.owner, item.repo.name)];
+    if (item.branches.length === 0 && branchesProps.defaultBranchName) {
+      item.branches = [{ name: branchesProps.defaultBranchName }];
+    }
+
     const options: IDropdownOption[] = branchesProps.branches.map((branch) => ({
       key: branch.name,
       text: branch.name,
@@ -198,7 +203,7 @@ export class ReposListComponent extends React.Component<ReposListComponentProps>
     const dropdownProps: IDropdownProps = {
       styles: BranchesDropdownStyles,
       options: [],
-      placeholder: ReposListComponent.DefaultBranchName,
+      placeholder: ReposListComponent.DefaultBranchNames,
       disabled: true,
     };
 
@@ -272,7 +277,7 @@ export class ReposListComponent extends React.Component<ReposListComponentProps>
       styles: ReposListCheckboxStyles,
       onChange: () => {
         const repoListItem = { ...item };
-        repoListItem.branches = [{ name: ReposListComponent.DefaultBranchName }];
+        repoListItem.branches = [];
         this.props.pinRepo(repoListItem);
       },
     };

--- a/src/Explorer/Panes/GitHubReposPanel/GitHubReposPanel.tsx
+++ b/src/Explorer/Panes/GitHubReposPanel/GitHubReposPanel.tsx
@@ -35,6 +35,9 @@ interface IGitHubReposPanelState {
 }
 export class GitHubReposPanel extends React.Component<IGitHubReposPanelProps, IGitHubReposPanelState> {
   private static readonly PageSize = 30;
+  private static readonly MasterBranchName = "master";
+  private static readonly MainBranchName = "main";
+
   private isAddedRepo = false;
   private gitHubClient: GitHubClient;
   private junoClient: JunoClient;
@@ -116,6 +119,8 @@ export class GitHubReposPanel extends React.Component<IGitHubReposPanelProps, IG
         if (response.status !== HttpStatusCodes.OK) {
           throw new Error(`Received HTTP ${response.status} when saving pinned repos`);
         }
+
+        this.props.explorer.notebookManager?.refreshPinnedRepos();
       } catch (error) {
         handleError(error, "GitHubReposPane/submit", "Failed to save pinned repos");
       }
@@ -207,6 +212,14 @@ export class GitHubReposPanel extends React.Component<IGitHubReposPanelProps, IG
       if (response.data) {
         branchesProps.branches = branchesProps.branches.concat(response.data);
         branchesProps.lastPageInfo = response.pageInfo;
+        branchesProps.defaultBranchName = branchesProps.branches[0].name;
+        const defaultbranchName = branchesProps.branches.find(
+          (branch) =>
+            branch.name === GitHubReposPanel.MasterBranchName || branch.name === GitHubReposPanel.MainBranchName
+        )?.name;
+        if (defaultbranchName) {
+          branchesProps.defaultBranchName = defaultbranchName;
+        }
       }
     } catch (error) {
       handleError(error, "GitHubReposPane/loadMoreBranches", "Failed to fetch branches");
@@ -298,6 +311,17 @@ export class GitHubReposPanel extends React.Component<IGitHubReposPanelProps, IG
     const existingRepo = this.pinnedReposProps.repos.find((repo) => repo.key === item.key);
     if (existingRepo) {
       existingRepo.branches = item.branches;
+      this.setState({
+        gitHubReposState: {
+          ...this.state.gitHubReposState,
+          reposListProps: {
+            ...this.state.gitHubReposState.reposListProps,
+            pinnedReposProps: {
+              repos: this.pinnedReposProps.repos,
+            },
+          },
+        },
+      });
     } else {
       this.pinnedReposProps.repos = [...this.pinnedReposProps.repos, item];
     }
@@ -374,6 +398,7 @@ export class GitHubReposPanel extends React.Component<IGitHubReposPanelProps, IG
           lastPageInfo: undefined,
           hasMore: true,
           isLoading: true,
+          defaultBranchName: undefined,
           loadMore: (): Promise<void> => this.loadMoreBranches(item.repo),
         };
         this.loadMoreBranches(item.repo);


### PR DESCRIPTION
This PR
- removes hardcoded "master" default branch. Instead default branch is added to each RepoItem and is populated when branches are fetched. This is needed since github recently made "main" as the master branch for newly created repos.
- Fixes a bug due to which, when multiple branches are selected for a pinned repo, it does not reflect in the UI

![main-master fix](https://user-images.githubusercontent.com/13487215/139149142-a5cd5835-8b07-4472-b60f-da7b2c96ed91.gif)


[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1150)
