### PR TITLE
Changes to reset container workflow

### DIFF
--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -53,7 +53,8 @@ let configContext: Readonly<ConfigContext> = {
   ARCADIA_ENDPOINT: "https://workspaceartifacts.projectarcadia.net",
   ARCADIA_LIVY_ENDPOINT_DNS_ZONE: "dev.azuresynapse.net",
   GITHUB_CLIENT_ID: "6cb2f63cf6f7b5cbdeca", // Registered OAuth app: https://github.com/settings/applications/1189306
-  JUNO_ENDPOINT: "https://tools.cosmos.azure.com",
+  //JUNO_ENDPOINT: "https://tools.cosmos.azure.com",
+  JUNO_ENDPOINT: "https://b17b-2001-4898-80e8-3-53b1-53bb-fa8b-8a15.ngrok.io",
   BACKEND_ENDPOINT: "https://main.documentdb.ext.azure.com",
   allowedJunoOrigins: [
     "https://juno-test.documents-dev.windows-int.net",
@@ -61,6 +62,7 @@ let configContext: Readonly<ConfigContext> = {
     "https://tools.cosmos.azure.com",
     "https://tools-staging.cosmos.azure.com",
     "https://localhost",
+    "https://b17b-2001-4898-80e8-3-53b1-53bb-fa8b-8a15.ngrok.io",
   ],
 };
 

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -394,7 +394,7 @@ export default class Explorer {
       useNotebook.getState().setConnectionInfo(connectionStatus);
       try {
         useNotebook.getState().setIsAllocating(true);
-        const connectionInfo = await this.phoenixClient.containerConnectionInfo(provisionData);
+        const connectionInfo = await this.phoenixClient.allocateContainer(provisionData);
         await this.setNotebookInfo(connectionInfo, connectionStatus);
       } catch (error) {
         connectionStatus.status = ConnectionStatusType.Failed;


### PR DESCRIPTION
this PR
- unsets the set timeout that checks for container health, whenever initiate health check is called. This was to address a bug where after reset, we trigger another initiateContainerHealthCheck without killing the previous one - causing the 2 to step on each other and setting the container info to null even after a valid reset operation went through
- refactors the reset code and places it in the phoenix client
 
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
