### PR TITLE
Check for -1 throughput cap value

### DIFF
--- a/src/Explorer/Controls/Settings/SettingsComponent.tsx
+++ b/src/Explorer/Controls/Settings/SettingsComponent.tsx
@@ -213,7 +213,8 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
       },
     };
 
-    if (userContext.databaseAccount?.properties.capacity?.totalThroughputLimit) {
+    const throughputCap = userContext.databaseAccount?.properties.capacity?.totalThroughputLimit;
+    if (throughputCap && throughputCap !== -1) {
       this.calculateTotalThroughputUsed();
     }
   }
@@ -680,7 +681,7 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
     const throughputCap = userContext.databaseAccount?.properties.capacity?.totalThroughputLimit;
     const numberOfRegions = userContext.databaseAccount?.properties.locations?.length || 1;
     const throughputDelta = (newThroughput - this.offer.autoscaleMaxThroughput) * numberOfRegions;
-    if (throughputCap && throughputCap - this.totalThroughputUsed < throughputDelta) {
+    if (throughputCap && throughputCap !== -1 && throughputCap - this.totalThroughputUsed < throughputDelta) {
       throughputError = `Your account is currently configured with a total throughput limit of ${throughputCap} RU/s. This update isn't possible because it would increase the total throughput to ${
         this.totalThroughputUsed + throughputDelta
       } RU/s. Change total throughput limit in cost management.`;
@@ -693,7 +694,7 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
     const throughputCap = userContext.databaseAccount?.properties.capacity?.totalThroughputLimit;
     const numberOfRegions = userContext.databaseAccount?.properties.locations?.length || 1;
     const throughputDelta = (newThroughput - this.offer.manualThroughput) * numberOfRegions;
-    if (throughputCap && throughputCap - this.totalThroughputUsed < newThroughput - this.offer.manualThroughput) {
+    if (throughputCap && throughputCap !== -1 && throughputCap - this.totalThroughputUsed < throughputDelta) {
       throughputError = `Your account is currently configured with a total throughput limit of ${throughputCap} RU/s. This update isn't possible because it would increase the total throughput to ${
         this.totalThroughputUsed + throughputDelta
       } RU/s. Change total throughput limit in cost management.`;

--- a/src/Explorer/Controls/ThroughputInput/ThroughputInput.tsx
+++ b/src/Explorer/Controls/ThroughputInput/ThroughputInput.tsx
@@ -61,7 +61,7 @@ export const ThroughputInput: FunctionComponent<ThroughputInputProps> = ({
     totalThroughput *= numberOfRegions;
     setTotalThroughputUsed(totalThroughput);
 
-    if (throughputCap && throughputCap - totalThroughput < throughput) {
+    if (throughputCap && throughputCap !== -1 && throughputCap - totalThroughput < throughput) {
       setThroughputError(
         `Your account is currently configured with a total throughput limit of ${throughputCap} RU/s. This update isn't possible because it would increase the total throughput to ${
           totalThroughput + throughput * numberOfRegions
@@ -73,7 +73,7 @@ export const ThroughputInput: FunctionComponent<ThroughputInputProps> = ({
   }, []);
 
   const checkThroughputCap = (newThroughput: number): boolean => {
-    if (throughputCap && throughputCap - totalThroughputUsed < newThroughput) {
+    if (throughputCap && throughputCap !== -1 && throughputCap - totalThroughputUsed < newThroughput) {
       setThroughputError(
         `Your account is currently configured with a total throughput limit of ${throughputCap} RU/s. This update isn't possible because it would increase the total throughput to ${
           totalThroughputUsed + newThroughput * numberOfRegions

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -1176,7 +1176,8 @@ export default class Explorer {
           <CassandraAddCollectionPane explorer={this} cassandraApiClient={new CassandraAPIDataClient()} />
         );
     } else {
-      userContext.databaseAccount?.properties.capacity?.totalThroughputLimit
+      const throughputCap = userContext.databaseAccount?.properties.capacity?.totalThroughputLimit;
+      throughputCap && throughputCap !== -1
         ? await useDatabases.getState().loadAllOffers()
         : await useDatabases.getState().loadDatabaseOffers();
       useSidePanel

--- a/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
@@ -311,7 +311,8 @@ function createNewDatabase(container: Explorer): CommandButtonComponentProps {
     iconSrc: AddDatabaseIcon,
     iconAlt: label,
     onCommandClick: async () => {
-      if (userContext.databaseAccount?.properties.capacity?.totalThroughputLimit) {
+      const throughputCap = userContext.databaseAccount?.properties.capacity?.totalThroughputLimit;
+      if (throughputCap && throughputCap !== -1) {
         await useDatabases.getState().loadAllOffers();
       }
       useSidePanel.getState().openSidePanel("New " + getDatabaseName(), <AddDatabasePanel explorer={container} />);

--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -308,7 +308,8 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
         title: "New " + getDatabaseName(),
         description: undefined,
         onClick: async () => {
-          if (userContext.databaseAccount?.properties.capacity?.totalThroughputLimit) {
+          const throughputCap = userContext.databaseAccount?.properties.capacity?.totalThroughputLimit;
+          if (throughputCap && throughputCap !== -1) {
             await useDatabases.getState().loadAllOffers();
           }
           useSidePanel

--- a/src/Explorer/Tree/Collection.ts
+++ b/src/Explorer/Tree/Collection.ts
@@ -576,9 +576,8 @@ export default class Collection implements ViewModels.Collection {
 
   public onSettingsClick = async (): Promise<void> => {
     useSelectedNode.getState().setSelectedNode(this);
-    userContext.databaseAccount?.properties.capacity?.totalThroughputLimit
-      ? await useDatabases.getState().loadAllOffers()
-      : await this.loadOffer();
+    const throughputCap = userContext.databaseAccount?.properties.capacity?.totalThroughputLimit;
+    throughputCap && throughputCap !== -1 ? await useDatabases.getState().loadAllOffers() : await this.loadOffer();
     this.selectedSubnodeKind(ViewModels.CollectionTabKind.Settings);
     TelemetryProcessor.trace(Action.SelectItem, ActionModifiers.Mark, {
       description: "Settings node",

--- a/src/Explorer/Tree/Database.tsx
+++ b/src/Explorer/Tree/Database.tsx
@@ -66,7 +66,8 @@ export default class Database implements ViewModels.Database {
       dataExplorerArea: Constants.Areas.ResourceTree,
     });
 
-    if (userContext.databaseAccount?.properties.capacity?.totalThroughputLimit) {
+    const throughputCap = userContext.databaseAccount?.properties.capacity?.totalThroughputLimit;
+    if (throughputCap && throughputCap !== -1) {
       await useDatabases.getState().loadAllOffers();
     }
 


### PR DESCRIPTION
With the latest change in portal, when throughput cap is turned off for an account, the value is set to -1 instead of null. Therefore, when we check the throughput cap value in data explorer, we need to account for the -1 value.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1159?feature.someFeatureFlagYouMightNeed=true)
