### PR TITLE
Add Timestamp type to cassandra column types and wrap Timestamp value inside single quotes when creating queries

### DIFF
--- a/src/Explorer/Panes/Tables/Validators/EntityTableHelper.tsx
+++ b/src/Explorer/Panes/Tables/Validators/EntityTableHelper.tsx
@@ -33,6 +33,7 @@ const {
   Inet,
   Smallint,
   Tinyint,
+  Timestamp,
 } = TableConstants.CassandraType;
 export const cassandraOptions = [
   { key: Text, text: Text },
@@ -50,6 +51,7 @@ export const cassandraOptions = [
   { key: Inet, text: Inet },
   { key: Smallint, text: Smallint },
   { key: Tinyint, text: Tinyint },
+  { key: Timestamp, text: Timestamp },
 ];
 
 export const imageProps: IImageProps = {

--- a/src/Explorer/Tables/Constants.ts
+++ b/src/Explorer/Tables/Constants.ts
@@ -19,6 +19,7 @@ export const CassandraType = {
   Float: "Float",
   Int: "Int",
   Text: "Text",
+  Timestamp: "Timestamp",
   Uuid: "Uuid",
   Varchar: "Varchar",
   Varint: "Varint",

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -535,7 +535,8 @@ export class CassandraAPIDataClient extends TableDataClient {
       dataType === TableConstants.CassandraType.Text ||
       dataType === TableConstants.CassandraType.Inet ||
       dataType === TableConstants.CassandraType.Ascii ||
-      dataType === TableConstants.CassandraType.Varchar
+      dataType === TableConstants.CassandraType.Varchar ||
+      dataType === TableConstants.CassandraType.Timestamp
     );
   }
 


### PR DESCRIPTION
- added Timestamp type to CassandraTypes
- treat Timestamp values as string and wrap the values inside single quotes when creating queries

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1163?feature.someFeatureFlagYouMightNeed=true)
