### PR TITLE
Properly update table columns

### DIFF
--- a/src/Explorer/Tables/DataTable/TableEntityListViewModel.ts
+++ b/src/Explorer/Tables/DataTable/TableEntityListViewModel.ts
@@ -431,7 +431,7 @@ export default class TableEntityListViewModel extends DataTableViewModel {
           if (newHeaders.length > 0) {
             // Any new columns found will be added into headers array, which will trigger a re-render of the DataTable.
             // So there is no need to call it here.
-            this.updateHeaders(newHeaders, /* notifyColumnChanges */ true);
+            this.updateHeaders(selectedHeadersUnion, /* notifyColumnChanges */ true);
           } else {
             if (columnSortOrder) {
               this.sortColumns(columnSortOrder, oSettings);


### PR DESCRIPTION
Currently if the table columns change after sending a query, instead of setting the tables header to the new set of columns, we incorrectly set it to the difference between the old columns and the new columns. The fix is to simply pass the entire array of the new columns to the `updateHeaders` function instead of just the difference.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1166?feature.someFeatureFlagYouMightNeed=true)
