### PR TITLE
Added integration for new github client for test env

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -412,3 +412,11 @@ export class TerminalQueryParams {
   public static readonly SubscriptionId = "subscriptionId";
   public static readonly TerminalEndpoint = "terminalEndpoint";
 }
+
+export class JunoEndpoints {
+  public static readonly Test = "https://juno-test.documents-dev.windows-int.net";
+  public static readonly Test2 = "https://juno-test2.documents-dev.windows-int.net";
+  public static readonly Test3 = "https://juno-test3.documents-dev.windows-int.net";
+  public static readonly Prod = "https://tools.cosmos.azure.com";
+  public static readonly Stage = "https://tools-staging.cosmos.azure.com";
+}

--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -1,3 +1,5 @@
+import { JunoEndpoints } from "Common/Constants";
+
 export enum Platform {
   Portal = "Portal",
   Hosted = "Hosted",
@@ -23,6 +25,7 @@ export interface ConfigContext {
   PROXY_PATH?: string;
   JUNO_ENDPOINT: string;
   GITHUB_CLIENT_ID: string;
+  GITHUB_TEST_ENV_CLIENT_ID: string;
   GITHUB_CLIENT_SECRET?: string; // No need to inject secret for prod. Juno already knows it.
   hostedExplorerURL: string;
   armAPIVersion?: string;
@@ -52,15 +55,16 @@ let configContext: Readonly<ConfigContext> = {
   GRAPH_API_VERSION: "1.6",
   ARCADIA_ENDPOINT: "https://workspaceartifacts.projectarcadia.net",
   ARCADIA_LIVY_ENDPOINT_DNS_ZONE: "dev.azuresynapse.net",
-  GITHUB_CLIENT_ID: "6cb2f63cf6f7b5cbdeca", // Registered OAuth app: https://github.com/settings/applications/1189306
+  GITHUB_CLIENT_ID: "6cb2f63cf6f7b5cbdeca", // Registered OAuth app: https://github.com/organizations/AzureCosmosDBNotebooks/settings/applications/1189306
+  GITHUB_TEST_ENV_CLIENT_ID: "b63fc8cbf87fd3c6e2eb", // Registered OAuth app: https://github.com/organizations/AzureCosmosDBNotebooks/settings/applications/1777772
   JUNO_ENDPOINT: "https://tools.cosmos.azure.com",
   BACKEND_ENDPOINT: "https://main.documentdb.ext.azure.com",
   allowedJunoOrigins: [
-    "https://juno-test.documents-dev.windows-int.net",
-    "https://juno-test2.documents-dev.windows-int.net",
-    "https://juno-test3.documents-dev.windows-int.net",
-    "https://tools.cosmos.azure.com",
-    "https://tools-staging.cosmos.azure.com",
+    JunoEndpoints.Test,
+    JunoEndpoints.Test2,
+    JunoEndpoints.Test3,
+    JunoEndpoints.Prod,
+    JunoEndpoints.Stage,
     "https://localhost",
   ],
 };

--- a/src/GitHub/GitHubOAuthService.ts
+++ b/src/GitHub/GitHubOAuthService.ts
@@ -1,8 +1,8 @@
 import ko from "knockout";
 import postRobot from "post-robot";
+import { GetGithubClientId } from "Utils/GitHubUtils";
 import { HttpStatusCodes } from "../Common/Constants";
 import { handleError } from "../Common/ErrorHandlingUtils";
-import { configContext } from "../ConfigContext";
 import { AuthorizeAccessComponent } from "../Explorer/Controls/GitHub/AuthorizeAccessComponent";
 import { JunoClient } from "../Juno/JunoClient";
 import { logConsoleInfo } from "../Utils/NotificationConsoleUtils";
@@ -55,7 +55,7 @@ export class GitHubOAuthService {
 
     const params = {
       scope,
-      client_id: configContext.GITHUB_CLIENT_ID,
+      client_id: GetGithubClientId(),
       redirect_uri: new URL("./connectToGitHub.html", window.location.href).href,
       state: this.resetState(),
     };

--- a/src/Juno/JunoClient.ts
+++ b/src/Juno/JunoClient.ts
@@ -1,4 +1,5 @@
 import ko from "knockout";
+import { GetGithubClientId } from "Utils/GitHubUtils";
 import { HttpHeaders, HttpStatusCodes } from "../Common/Constants";
 import { configContext } from "../ConfigContext";
 import * as DataModels from "../Contracts/DataModels";
@@ -522,7 +523,7 @@ export class JunoClient {
 
   private static getGitHubClientParams(): URLSearchParams {
     const githubParams = new URLSearchParams({
-      client_id: configContext.GITHUB_CLIENT_ID,
+      client_id: GetGithubClientId(),
     });
 
     if (configContext.GITHUB_CLIENT_SECRET) {

--- a/src/Utils/GitHubUtils.ts
+++ b/src/Utils/GitHubUtils.ts
@@ -1,4 +1,9 @@
 // https://github.com/<owner>/<repo>/tree/<branch>
+
+import { JunoEndpoints } from "Common/Constants";
+import { configContext } from "ConfigContext";
+import { userContext } from "UserContext";
+
 // The url when users visit a repo/branch on github.com
 export const RepoUriPattern = /https:\/\/github.com\/([^/]*)\/([^/]*)\/tree\/([^?]*)/;
 
@@ -59,4 +64,16 @@ export function toContentUri(owner: string, repo: string, branch: string, path: 
 
 export function toRawContentUri(owner: string, repo: string, branch: string, path: string): string {
   return `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${path}`;
+}
+
+export function GetGithubClientId(): string {
+  const junoEndpoint = userContext.features.junoEndpoint ?? configContext.JUNO_ENDPOINT;
+  if (
+    junoEndpoint === JunoEndpoints.Test ||
+    junoEndpoint === JunoEndpoints.Test2 ||
+    junoEndpoint === JunoEndpoints.Test3
+  ) {
+    return configContext.GITHUB_TEST_ENV_CLIENT_ID;
+  }
+  return configContext.GITHUB_CLIENT_ID;
 }


### PR DESCRIPTION
This PR
- Adds a new config context for github test env client id
- Adds logic to pick this client id to send for github OAuth call and to junoin case juno endpoint used is test/test2/test3

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1168)
