### PR TITLE
Close mongo and casssandra terminal tabs once the shells are exited

### DIFF
--- a/src/Contracts/ExplorerContracts.ts
+++ b/src/Contracts/ExplorerContracts.ts
@@ -33,7 +33,7 @@ export enum MessageTypes {
   CreateWorkspace,
   CreateSparkPool,
   RefreshDatabaseAccount,
-  CloseTab
+  CloseTab,
 }
 
 export { Versions, ActionContracts, Diagnostics };

--- a/src/Contracts/ExplorerContracts.ts
+++ b/src/Contracts/ExplorerContracts.ts
@@ -33,6 +33,7 @@ export enum MessageTypes {
   CreateWorkspace,
   CreateSparkPool,
   RefreshDatabaseAccount,
+  CloseTab
 }
 
 export { Versions, ActionContracts, Diagnostics };

--- a/src/Explorer/Controls/Notebook/NotebookTerminalComponent.test.tsx
+++ b/src/Explorer/Controls/Notebook/NotebookTerminalComponent.test.tsx
@@ -55,6 +55,7 @@ describe("NotebookTerminalComponent", () => {
     const props: NotebookTerminalComponentProps = {
       databaseAccount: testAccount,
       notebookServerInfo: testNotebookServerInfo,
+      tabId: undefined,
     };
 
     const wrapper = shallow(<NotebookTerminalComponent {...props} />);
@@ -65,6 +66,7 @@ describe("NotebookTerminalComponent", () => {
     const props: NotebookTerminalComponentProps = {
       databaseAccount: testMongo32Account,
       notebookServerInfo: testMongoNotebookServerInfo,
+      tabId: undefined,
     };
 
     const wrapper = shallow(<NotebookTerminalComponent {...props} />);
@@ -75,6 +77,7 @@ describe("NotebookTerminalComponent", () => {
     const props: NotebookTerminalComponentProps = {
       databaseAccount: testMongo36Account,
       notebookServerInfo: testMongoNotebookServerInfo,
+      tabId: undefined,
     };
 
     const wrapper = shallow(<NotebookTerminalComponent {...props} />);
@@ -85,6 +88,7 @@ describe("NotebookTerminalComponent", () => {
     const props: NotebookTerminalComponentProps = {
       databaseAccount: testCassandraAccount,
       notebookServerInfo: testCassandraNotebookServerInfo,
+      tabId: undefined,
     };
 
     const wrapper = shallow(<NotebookTerminalComponent {...props} />);

--- a/src/Explorer/Controls/Notebook/NotebookTerminalComponent.tsx
+++ b/src/Explorer/Controls/Notebook/NotebookTerminalComponent.tsx
@@ -12,7 +12,7 @@ import * as StringUtils from "../../../Utils/StringUtils";
 export interface NotebookTerminalComponentProps {
   notebookServerInfo: DataModels.NotebookWorkspaceConnectionInfo;
   databaseAccount: DataModels.DatabaseAccount;
-  tabId: string
+  tabId: string;
 }
 
 export class NotebookTerminalComponent extends React.Component<NotebookTerminalComponentProps> {
@@ -56,7 +56,7 @@ export class NotebookTerminalComponent extends React.Component<NotebookTerminalC
       apiType: userContext.apiType,
       authType: userContext.authType,
       databaseAccount: userContext.databaseAccount,
-      tabId: this.props.tabId
+      tabId: this.props.tabId,
     };
 
     postRobot.send(this.terminalWindow, "props", props, {

--- a/src/Explorer/Controls/Notebook/NotebookTerminalComponent.tsx
+++ b/src/Explorer/Controls/Notebook/NotebookTerminalComponent.tsx
@@ -12,6 +12,7 @@ import * as StringUtils from "../../../Utils/StringUtils";
 export interface NotebookTerminalComponentProps {
   notebookServerInfo: DataModels.NotebookWorkspaceConnectionInfo;
   databaseAccount: DataModels.DatabaseAccount;
+  tabId: string
 }
 
 export class NotebookTerminalComponent extends React.Component<NotebookTerminalComponentProps> {
@@ -55,6 +56,7 @@ export class NotebookTerminalComponent extends React.Component<NotebookTerminalC
       apiType: userContext.apiType,
       authType: userContext.authType,
       databaseAccount: userContext.databaseAccount,
+      tabId: this.props.tabId
     };
 
     postRobot.send(this.terminalWindow, "props", props, {

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -18,7 +18,7 @@ import {
   ContainerConnectionInfo,
   IPhoenixConnectionInfoResult,
   IProvisionData,
-  IResponse,
+  IResponse
 } from "../Contracts/DataModels";
 import * as ViewModels from "../Contracts/ViewModels";
 import { GitHubOAuthService } from "../GitHub/GitHubOAuthService";
@@ -35,7 +35,7 @@ import { update } from "../Utils/arm/generatedClients/cosmos/databaseAccounts";
 import {
   get as getWorkspace,
   listByDatabaseAccount,
-  start,
+  start
 } from "../Utils/arm/generatedClients/cosmosNotebooks/notebookWorkspaces";
 import { stringToBlob } from "../Utils/BlobUtils";
 import { isCapabilityEnabled } from "../Utils/CapabilityUtils";
@@ -1096,7 +1096,7 @@ export default class Explorer {
 
     const terminalTabs: TerminalTab[] = useTabs
       .getState()
-      .getTabs(ViewModels.CollectionTabKind.Terminal, (tab) => tab.tabTitle() === title) as TerminalTab[];
+      .getTabs(ViewModels.CollectionTabKind.Terminal, (tab) => tab.tabTitle().startsWith(title)) as TerminalTab[];
 
     let index = 1;
     if (terminalTabs.length > 0) {

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -18,7 +18,7 @@ import {
   ContainerConnectionInfo,
   IPhoenixConnectionInfoResult,
   IProvisionData,
-  IResponse
+  IResponse,
 } from "../Contracts/DataModels";
 import * as ViewModels from "../Contracts/ViewModels";
 import { GitHubOAuthService } from "../GitHub/GitHubOAuthService";
@@ -35,7 +35,7 @@ import { update } from "../Utils/arm/generatedClients/cosmos/databaseAccounts";
 import {
   get as getWorkspace,
   listByDatabaseAccount,
-  start
+  start,
 } from "../Utils/arm/generatedClients/cosmosNotebooks/notebookWorkspaces";
 import { stringToBlob } from "../Utils/BlobUtils";
 import { isCapabilityEnabled } from "../Utils/CapabilityUtils";

--- a/src/Explorer/Tabs/TerminalTab.tsx
+++ b/src/Explorer/Tabs/TerminalTab.tsx
@@ -27,7 +27,7 @@ class NotebookTerminalComponentAdapter implements ReactAdapter {
     private getNotebookServerInfo: () => DataModels.NotebookWorkspaceConnectionInfo,
     private getDatabaseAccount: () => DataModels.DatabaseAccount,
     private getTabId: () => string
-  ) { }
+  ) {}
 
   public renderComponent(): JSX.Element {
     return this.parameters() ? (

--- a/src/Explorer/Tabs/TerminalTab.tsx
+++ b/src/Explorer/Tabs/TerminalTab.tsx
@@ -25,14 +25,16 @@ class NotebookTerminalComponentAdapter implements ReactAdapter {
   public parameters: ko.Computed<boolean>;
   constructor(
     private getNotebookServerInfo: () => DataModels.NotebookWorkspaceConnectionInfo,
-    private getDatabaseAccount: () => DataModels.DatabaseAccount
-  ) {}
+    private getDatabaseAccount: () => DataModels.DatabaseAccount,
+    private getTabId: () => string
+  ) { }
 
   public renderComponent(): JSX.Element {
     return this.parameters() ? (
       <NotebookTerminalComponent
         notebookServerInfo={this.getNotebookServerInfo()}
         databaseAccount={this.getDatabaseAccount()}
+        tabId={this.getTabId()}
       />
     ) : (
       <Spinner styles={{ root: { marginTop: 10 } }} size={SpinnerSize.large}></Spinner>
@@ -50,7 +52,8 @@ export default class TerminalTab extends TabsBase {
     this.container = options.container;
     this.notebookTerminalComponentAdapter = new NotebookTerminalComponentAdapter(
       () => this.getNotebookServerInfo(options),
-      () => userContext?.databaseAccount
+      () => userContext?.databaseAccount,
+      () => this.tabId
     );
     this.notebookTerminalComponentAdapter.parameters = ko.computed<boolean>(() => {
       if (

--- a/src/Terminal/JupyterLabAppFactory.ts
+++ b/src/Terminal/JupyterLabAppFactory.ts
@@ -2,15 +2,23 @@
  * JupyterLab applications based on jupyterLab components
  */
 import { ServerConnection, TerminalManager } from "@jupyterlab/services";
+import { IMessage, ITerminalConnection } from "@jupyterlab/services/lib/terminal/terminal";
 import { Terminal } from "@jupyterlab/terminal";
 import { Panel, Widget } from "@phosphor/widgets";
 
 export class JupyterLabAppFactory {
-  public static async createTerminalApp(serverSettings: ServerConnection.ISettings) {
+  public static async createTerminalApp(serverSettings: ServerConnection.ISettings, closeTab: () => void) {
     const manager = new TerminalManager({
       serverSettings: serverSettings,
     });
     const session = await manager.startNew();
+    session.messageReceived.connect(async (terminalConnection: ITerminalConnection, message: IMessage) => {
+      var content = message.content[0].toString();
+      if (message.type == "stdout" && content.indexOf("bye") != -1) {
+        closeTab();
+      }
+    }, this)
+
     const term = new Terminal(session, { theme: "dark", shutdownOnClose: true });
 
     if (!term) {

--- a/src/Terminal/TerminalProps.ts
+++ b/src/Terminal/TerminalProps.ts
@@ -10,4 +10,5 @@ export interface TerminalProps {
   authType: AuthType;
   apiType: ApiType;
   subscriptionId: string;
+  tabId: string;
 }

--- a/src/Terminal/index.ts
+++ b/src/Terminal/index.ts
@@ -1,5 +1,6 @@
 import { ServerConnection } from "@jupyterlab/services";
 import "@jupyterlab/terminal/style/index.css";
+import { MessageTypes } from "Contracts/ExplorerContracts";
 import postRobot from "post-robot";
 import { HttpHeaders } from "../Common/Constants";
 import { Action } from "../Shared/Telemetry/TelemetryConstants";
@@ -54,12 +55,16 @@ const initTerminal = async (props: TerminalProps) => {
   const startTime = TelemetryProcessor.traceStart(Action.OpenTerminal, data);
 
   try {
-    await JupyterLabAppFactory.createTerminalApp(serverSettings);
+    await JupyterLabAppFactory.createTerminalApp(serverSettings, () => closeTab(props.tabId));
     TelemetryProcessor.traceSuccess(Action.OpenTerminal, data, startTime);
   } catch (error) {
     TelemetryProcessor.traceFailure(Action.OpenTerminal, data, startTime);
   }
 };
+
+const closeTab = (tabId: string): void => {
+  window.parent.postMessage({ type: MessageTypes.CloseTab, data: { tabId: tabId }, signature: "pcIframe" })
+}
 
 const main = async (): Promise<void> => {
   postRobot.on(

--- a/src/Terminal/index.ts
+++ b/src/Terminal/index.ts
@@ -63,8 +63,8 @@ const initTerminal = async (props: TerminalProps) => {
 };
 
 const closeTab = (tabId: string): void => {
-  window.parent.postMessage({ type: MessageTypes.CloseTab, data: { tabId: tabId }, signature: "pcIframe" })
-}
+  window.parent.postMessage({ type: MessageTypes.CloseTab, data: { tabId: tabId }, signature: "pcIframe" });
+};
 
 const main = async (): Promise<void> => {
   postRobot.on(

--- a/src/Terminal/index.ts
+++ b/src/Terminal/index.ts
@@ -55,7 +55,7 @@ const initTerminal = async (props: TerminalProps) => {
   const startTime = TelemetryProcessor.traceStart(Action.OpenTerminal, data);
 
   try {
-    await JupyterLabAppFactory.createTerminalApp(serverSettings, () => closeTab(props.tabId));
+    await new JupyterLabAppFactory(() => closeTab(props.tabId)).createTerminalApp(serverSettings);
     TelemetryProcessor.traceSuccess(Action.OpenTerminal, data, startTime);
   } catch (error) {
     TelemetryProcessor.traceFailure(Action.OpenTerminal, data, startTime);

--- a/src/Terminal/index.ts
+++ b/src/Terminal/index.ts
@@ -63,7 +63,10 @@ const initTerminal = async (props: TerminalProps) => {
 };
 
 const closeTab = (tabId: string): void => {
-  window.parent.postMessage({ type: MessageTypes.CloseTab, data: { tabId: tabId }, signature: "pcIframe" });
+  window.parent.postMessage(
+    { type: MessageTypes.CloseTab, data: { tabId: tabId }, signature: "pcIframe" },
+    window.document.referrer
+  );
 };
 
 const main = async (): Promise<void> => {

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -95,7 +95,7 @@ async function configureHosted(): Promise<Explorer> {
       }
 
       if (event.data?.type === MessageTypes.CloseTab) {
-        useTabs.getState().closeTabsByComparator((tab) => tab.tabId === event.data.data.tabId);
+        useTabs.getState().closeTabsByComparator((tab) => tab.tabId === event.data?.data?.tabId);
       }
     },
     false
@@ -285,7 +285,7 @@ async function configurePortal(): Promise<Explorer> {
         } else if (shouldForwardMessage(message, event.origin)) {
           sendMessage(message);
         } else if (event.data?.type === MessageTypes.CloseTab) {
-          useTabs.getState().closeTabsByComparator((tab) => tab.tabId === event.data.data.tabId);
+          useTabs.getState().closeTabsByComparator((tab) => tab.tabId === event.data?.data?.tabId);
         }
       },
       false

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -1,3 +1,4 @@
+import { useTabs } from "hooks/useTabs";
 import { useEffect, useState } from "react";
 import { applyExplorerBindings } from "../applyExplorerBindings";
 import { AuthType } from "../AuthType";
@@ -16,14 +17,14 @@ import {
   ConnectionString,
   EncryptedToken,
   HostedExplorerChildFrame,
-  ResourceToken,
+  ResourceToken
 } from "../HostedExplorerChildFrame";
 import { emulatorAccount } from "../Platform/Emulator/emulatorAccount";
 import { extractFeatures } from "../Platform/Hosted/extractFeatures";
 import { parseResourceTokenConnectionString } from "../Platform/Hosted/Helpers/ResourceTokenUtils";
 import {
   getDatabaseAccountKindFromExperience,
-  getDatabaseAccountPropertiesFromMetadata,
+  getDatabaseAccountPropertiesFromMetadata
 } from "../Platform/Hosted/HostedUtils";
 import { CollectionCreation } from "../Shared/Constants";
 import { DefaultExperienceUtility } from "../Shared/DefaultExperienceUtility";
@@ -261,6 +262,8 @@ async function configurePortal(): Promise<Explorer> {
           }
         } else if (shouldForwardMessage(message, event.origin)) {
           sendMessage(message);
+        } else if (event.data?.type === MessageTypes.CloseTab) {
+          useTabs.getState().closeTabsByComparator(tab => tab.tabId == event.data.data.tabId)
         }
       },
       false


### PR DESCRIPTION
This PR
- Adds logic to check the terminal output messages to see if the mongo or cassandra shells are closed
- If closed, a "closetab" message is sent from terminal iframe to cosmos-explorer (the parent)
- This is read and handled by the cosmos explorer which closes the tab with the correspondign tabId
- Also fixes a bug with tab numbering
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1183)
