### PR TITLE
Added separate flag for shells and schema analyzer

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -96,7 +96,8 @@ export class Flights {
   public static readonly AutoscaleTest = "autoscaletest";
   public static readonly PartitionKeyTest = "partitionkeytest";
   public static readonly PKPartitionKeyTest = "pkpartitionkeytest";
-  public static readonly Phoenix = "phoenix";
+  public static readonly PhoenixNotebooks = "phoenixnotebooks";
+  public static readonly PhoenixFeatures = "phoenixfeatures";
   public static readonly NotebooksDownBanner = "notebooksdownbanner";
 }
 

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -439,7 +439,7 @@ export default class Explorer {
       );
       return;
     }
-    const dialogContent = useNotebook.getState().isPhoenix
+    const dialogContent = useNotebook.getState().isPhoenixNotebooks
       ? "Notebooks saved in the temporary workspace will be deleted. Do you want to proceed?"
       : "This lets you keep your notebook files and the workspace will be restored to default. Proceed anyway?";
 
@@ -516,7 +516,7 @@ export default class Explorer {
       TelemetryProcessor.traceStart(Action.PhoenixResetWorkspace, {
         dataExplorerArea: Areas.Notebook,
       });
-      if (useNotebook.getState().isPhoenix) {
+      if (useNotebook.getState().isPhoenixNotebooks) {
         useTabs.getState().closeAllNotebookTabs(true);
         connectionStatus = {
           status: ConnectionStatusType.Connecting,
@@ -530,7 +530,7 @@ export default class Explorer {
       if (!connectionInfo?.data?.notebookServerUrl) {
         throw new Error(`Reset Workspace: NotebookServerUrl is invalid!`);
       }
-      if (useNotebook.getState().isPhoenix) {
+      if (useNotebook.getState().isPhoenixNotebooks) {
         await this.setNotebookInfo(connectionInfo, connectionStatus);
         useNotebook.getState().setIsRefreshed(!useNotebook.getState().isRefreshed);
       }
@@ -545,7 +545,7 @@ export default class Explorer {
         error: getErrorMessage(error),
         errorStack: getErrorStack(error),
       });
-      if (useNotebook.getState().isPhoenix) {
+      if (useNotebook.getState().isPhoenixNotebooks) {
         connectionStatus = {
           status: ConnectionStatusType.Failed,
         };
@@ -743,7 +743,7 @@ export default class Explorer {
     if (!notebookContentItem || !notebookContentItem.path) {
       throw new Error(`Invalid notebookContentItem: ${notebookContentItem}`);
     }
-    if (notebookContentItem.type === NotebookContentItemType.Notebook && useNotebook.getState().isPhoenix) {
+    if (notebookContentItem.type === NotebookContentItemType.Notebook && useNotebook.getState().isPhoenixNotebooks) {
       await this.allocateContainer();
     }
 
@@ -967,7 +967,7 @@ export default class Explorer {
       handleError(error, "Explorer/onNewNotebookClicked");
       throw new Error(error);
     }
-    if (useNotebook.getState().isPhoenix) {
+    if (useNotebook.getState().isPhoenixNotebooks) {
       if (isGithubTree) {
         await this.allocateContainer();
         parent = parent || this.resourceTree.myNotebooksContentRoot;
@@ -1056,7 +1056,7 @@ export default class Explorer {
   }
 
   public async openNotebookTerminal(kind: ViewModels.TerminalKind): Promise<void> {
-    if (useNotebook.getState().isPhoenix) {
+    if (useNotebook.getState().isPhoenixFeatures) {
       await this.allocateContainer();
       const notebookServerInfo = useNotebook.getState().notebookServerInfo;
       if (notebookServerInfo && notebookServerInfo.notebookServerEndpoint !== undefined) {
@@ -1197,7 +1197,7 @@ export default class Explorer {
   }
 
   public async handleOpenFileAction(path: string): Promise<void> {
-    if (useNotebook.getState().isPhoenix) {
+    if (useNotebook.getState().isPhoenixNotebooks) {
       await this.allocateContainer();
     } else if (!(await this._containsDefaultNotebookWorkspace(userContext.databaseAccount))) {
       this._openSetupNotebooksPaneForQuickstart();
@@ -1231,7 +1231,7 @@ export default class Explorer {
   }
 
   public openUploadFilePanel(parent?: NotebookContentItem): void {
-    if (useNotebook.getState().isPhoenix) {
+    if (useNotebook.getState().isPhoenixNotebooks) {
       useDialog.getState().showOkCancelModalDialog(
         Notebook.newNotebookUploadModalTitle,
         undefined,
@@ -1261,7 +1261,7 @@ export default class Explorer {
   }
 
   public getDownloadModalConent(fileName: string): JSX.Element {
-    if (useNotebook.getState().isPhoenix) {
+    if (useNotebook.getState().isPhoenixNotebooks) {
       return (
         <>
           <p>{Notebook.galleryNotebookDownloadContent1}</p>
@@ -1285,16 +1285,18 @@ export default class Explorer {
     await useNotebook.getState().refreshNotebooksEnabledStateForAccount();
 
     // TODO: remove reference to isNotebookEnabled and isNotebooksEnabledForAccount
-    const isNotebookEnabled = userContext.features.notebooksDownBanner || useNotebook.getState().isPhoenix;
+    const isNotebookEnabled = userContext.features.notebooksDownBanner || useNotebook.getState().isPhoenixNotebooks;
     useNotebook.getState().setIsNotebookEnabled(isNotebookEnabled);
-    useNotebook.getState().setIsShellEnabled(useNotebook.getState().isPhoenix && isPublicInternetAccessAllowed());
+    useNotebook
+      .getState()
+      .setIsShellEnabled(useNotebook.getState().isPhoenixFeatures && isPublicInternetAccessAllowed());
 
     TelemetryProcessor.trace(Action.NotebookEnabled, ActionModifiers.Mark, {
       isNotebookEnabled,
       dataExplorerArea: Constants.Areas.Notebook,
     });
 
-    if (useNotebook.getState().isPhoenix) {
+    if (useNotebook.getState().isPhoenixNotebooks) {
       await this.initNotebooks(userContext.databaseAccount);
     }
   }

--- a/src/Explorer/Menus/CommandBar/CommandBarComponentAdapter.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarComponentAdapter.tsx
@@ -53,7 +53,7 @@ export const CommandBar: React.FC<Props> = ({ container }: Props) => {
   const uiFabricControlButtons = CommandBarUtil.convertButton(controlButtons, backgroundColor);
   uiFabricControlButtons.forEach((btn: ICommandBarItemProps) => (btn.iconOnly = true));
 
-  if (useNotebook.getState().isPhoenix) {
+  if (useNotebook.getState().isPhoenixNotebooks || useNotebook.getState().isPhoenixFeatures) {
     uiFabricControlButtons.unshift(CommandBarUtil.createConnectionStatus(container, "connectionStatus"));
   }
 

--- a/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
@@ -78,10 +78,10 @@ export function createStaticCommandBarButtons(
     if (container.notebookManager?.gitHubOAuthService) {
       notebookButtons.push(createManageGitHubAccountButton(container));
     }
-    if (useNotebook.getState().isPhoenix && configContext.isTerminalEnabled) {
+    if (useNotebook.getState().isPhoenixFeatures && configContext.isTerminalEnabled) {
       notebookButtons.push(createOpenTerminalButton(container));
     }
-    if (selectedNodeState.isConnectedToContainer()) {
+    if (useNotebook.getState().isPhoenixNotebooks && selectedNodeState.isConnectedToContainer()) {
       notebookButtons.push(createNotebookWorkspaceResetButton(container));
     }
     if (
@@ -99,19 +99,21 @@ export function createStaticCommandBarButtons(
     }
 
     notebookButtons.forEach((btn) => {
-      if (!useNotebook.getState().isPhoenix) {
-        if (btn.commandButtonLabel.indexOf("Cassandra") !== -1) {
+      if (btn.commandButtonLabel.indexOf("Cassandra") !== -1) {
+        if (!useNotebook.getState().isPhoenixFeatures) {
           applyNotebooksTemporarilyDownStyle(btn, Constants.Notebook.cassandraShellTemporarilyDownMsg);
-        } else if (btn.commandButtonLabel.indexOf("Mongo") !== -1) {
-          applyNotebooksTemporarilyDownStyle(btn, Constants.Notebook.mongoShellTemporarilyDownMsg);
-        } else {
-          applyNotebooksTemporarilyDownStyle(btn, Constants.Notebook.temporarilyDownMsg);
         }
+      } else if (btn.commandButtonLabel.indexOf("Mongo") !== -1) {
+        if (!useNotebook.getState().isPhoenixFeatures) {
+          applyNotebooksTemporarilyDownStyle(btn, Constants.Notebook.mongoShellTemporarilyDownMsg);
+        }
+      } else if (!useNotebook.getState().isPhoenixNotebooks) {
+        applyNotebooksTemporarilyDownStyle(btn, Constants.Notebook.temporarilyDownMsg);
       }
       buttons.push(btn);
     });
   } else {
-    if (!isRunningOnNationalCloud() && useNotebook.getState().isPhoenix) {
+    if (!isRunningOnNationalCloud() && useNotebook.getState().isPhoenixNotebooks) {
       buttons.push(createDivider());
       buttons.push(createEnableNotebooksButton(container));
     }

--- a/src/Explorer/Notebook/NotebookContainerClient.ts
+++ b/src/Explorer/Notebook/NotebookContainerClient.ts
@@ -149,7 +149,7 @@ export class NotebookContainerClient {
     }
 
     try {
-      if (useNotebook.getState().isPhoenix) {
+      if (useNotebook.getState().isPhoenixNotebooks) {
         const provisionData: IProvisionData = {
           cosmosEndpoint: userContext.databaseAccount.properties.documentEndpoint,
         };

--- a/src/Explorer/Notebook/useNotebook.ts
+++ b/src/Explorer/Notebook/useNotebook.ts
@@ -38,7 +38,8 @@ interface NotebookState {
   isAllocating: boolean;
   isRefreshed: boolean;
   containerStatus: ContainerInfo;
-  isPhoenix: boolean;
+  isPhoenixNotebooks: boolean;
+  isPhoenixFeatures: boolean;
   setIsNotebookEnabled: (isNotebookEnabled: boolean) => void;
   setIsNotebooksEnabledForAccount: (isNotebooksEnabledForAccount: boolean) => void;
   setNotebookServerInfo: (notebookServerInfo: DataModels.NotebookWorkspaceConnectionInfo) => void;
@@ -61,7 +62,8 @@ interface NotebookState {
   setIsRefreshed: (isAllocating: boolean) => void;
   setContainerStatus: (containerStatus: ContainerInfo) => void;
   getPhoenixStatus: () => Promise<void>;
-  setIsPhoenix: (isPhoenix: boolean) => void;
+  setIsPhoenixNotebooks: (isPhoenixNotebooks: boolean) => void;
+  setIsPhoenixFeatures: (isPhoenixFeatures: boolean) => void;
 }
 
 export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
@@ -96,7 +98,8 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
     durationLeftInMinutes: undefined,
     notebookServerInfo: undefined,
   },
-  isPhoenix: undefined,
+  isPhoenixNotebooks: undefined,
+  isPhoenixFeatures: undefined,
   setIsNotebookEnabled: (isNotebookEnabled: boolean) => set({ isNotebookEnabled }),
   setIsNotebooksEnabledForAccount: (isNotebooksEnabledForAccount: boolean) => set({ isNotebooksEnabledForAccount }),
   setNotebookServerInfo: (notebookServerInfo: DataModels.NotebookWorkspaceConnectionInfo) =>
@@ -202,7 +205,7 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
     isGithubTree ? set({ gitHubNotebooksContentRoot: root }) : set({ myNotebooksContentRoot: root });
   },
   initializeNotebooksTree: async (notebookManager: NotebookManager): Promise<void> => {
-    const notebookFolderName = get().isPhoenix ? "Temporary Notebooks" : "My Notebooks";
+    const notebookFolderName = get().isPhoenixNotebooks ? "Temporary Notebooks" : "My Notebooks";
     set({ notebookFolderName });
     const myNotebooksContentRoot = {
       name: get().notebookFolderName,
@@ -299,14 +302,20 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
   setIsRefreshed: (isRefreshed: boolean) => set({ isRefreshed }),
   setContainerStatus: (containerStatus: ContainerInfo) => set({ containerStatus }),
   getPhoenixStatus: async () => {
-    if (get().isPhoenix === undefined) {
+    if (get().isPhoenixNotebooks === undefined || get().isPhoenixFeatures === undefined) {
       let isPhoenix = false;
-      if (userContext.features.phoenix) {
+      if (userContext.features.phoenixNotebooks || userContext.features.phoenixFeatures) {
         const phoenixClient = new PhoenixClient();
         isPhoenix = isPublicInternetAccessAllowed() && (await phoenixClient.isDbAcountWhitelisted());
       }
-      set({ isPhoenix });
+
+      const isPhoenixNotebooks = userContext.features.phoenixNotebooks && isPhoenix;
+      const isPhoenixFeatures = userContext.features.phoenixFeatures && isPhoenix;
+
+      set({ isPhoenixNotebooks: isPhoenixNotebooks });
+      set({ isPhoenixFeatures: isPhoenixFeatures });
     }
   },
-  setIsPhoenix: (isPhoenix: boolean) => set({ isPhoenix }),
+  setIsPhoenixNotebooks: (isPhoenixNotebooks: boolean) => set({ isPhoenixNotebooks: isPhoenixNotebooks }),
+  setIsPhoenixFeatures: (isPhoenixFeatures: boolean) => set({ isPhoenixFeatures: isPhoenixFeatures }),
 }));

--- a/src/Explorer/Panes/CopyNotebookPane/CopyNotebookPane.tsx
+++ b/src/Explorer/Panes/CopyNotebookPane/CopyNotebookPane.tsx
@@ -75,7 +75,7 @@ export const CopyNotebookPane: FunctionComponent<CopyNotebookPanelProps> = ({
           selectedLocation.owner,
           selectedLocation.repo
         )} - ${selectedLocation.branch}`;
-      } else if (selectedLocation.type === "MyNotebooks" && useNotebook.getState().isPhoenix) {
+      } else if (selectedLocation.type === "MyNotebooks" && useNotebook.getState().isPhoenixNotebooks) {
         destination = useNotebook.getState().notebookFolderName;
       }
 

--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -221,7 +221,7 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
       });
     }
 
-    if (useNotebook.getState().isPhoenix) {
+    if (useNotebook.getState().isPhoenixNotebooks) {
       heroes.push({
         iconSrc: NewNotebookIcon,
         title: "New Notebook",

--- a/src/Explorer/Tree/Collection.ts
+++ b/src/Explorer/Tree/Collection.ts
@@ -529,7 +529,7 @@ export default class Collection implements ViewModels.Collection {
   };
 
   public onSchemaAnalyzerClick = async () => {
-    if (useNotebook.getState().isPhoenix) {
+    if (useNotebook.getState().isPhoenixFeatures) {
       await this.container.allocateContainer();
     }
     useSelectedNode.getState().setSelectedNode(this);

--- a/src/Explorer/Tree/ResourceTree.tsx
+++ b/src/Explorer/Tree/ResourceTree.tsx
@@ -121,7 +121,7 @@ export const ResourceTree: React.FC<ResourceTreeProps> = ({ container }: Resourc
       children: [],
     };
 
-    if (!useNotebook.getState().isPhoenix) {
+    if (!useNotebook.getState().isPhoenixNotebooks) {
       notebooksTree.children.push(buildNotebooksTemporarilyDownTree());
     } else {
       if (galleryContentRoot) {
@@ -130,7 +130,7 @@ export const ResourceTree: React.FC<ResourceTreeProps> = ({ container }: Resourc
 
       if (
         myNotebooksContentRoot &&
-        useNotebook.getState().isPhoenix &&
+        useNotebook.getState().isPhoenixNotebooks &&
         useNotebook.getState().connectionInfo.status === ConnectionStatusType.Connected
       ) {
         notebooksTree.children.push(buildMyNotebooksTree());
@@ -516,7 +516,7 @@ export const ResourceTree: React.FC<ResourceTreeProps> = ({ container }: Resourc
       isNotebookEnabled &&
       userContext.apiType === "Mongo" &&
       isPublicInternetAccessAllowed() &&
-      useNotebook.getState().isPhoenix
+      useNotebook.getState().isPhoenixFeatures
     ) {
       children.push({
         label: "Schema (Preview)",

--- a/src/Platform/Hosted/extractFeatures.ts
+++ b/src/Platform/Hosted/extractFeatures.ts
@@ -11,7 +11,8 @@ export type Features = {
   autoscaleDefault: boolean;
   partitionKeyDefault: boolean;
   partitionKeyDefault2: boolean;
-  phoenix: boolean;
+  phoenixNotebooks: boolean;
+  phoenixFeatures: boolean;
   notebooksDownBanner: boolean;
   readonly enableSDKoperations: boolean;
   readonly enableSpark: boolean;
@@ -83,7 +84,8 @@ export function extractFeatures(given = new URLSearchParams(window.location.sear
     autoscaleDefault: "true" === get("autoscaledefault"),
     partitionKeyDefault: "true" === get("partitionkeytest"),
     partitionKeyDefault2: "true" === get("pkpartitionkeytest"),
-    phoenix: "true" === get("phoenix"),
+    phoenixNotebooks: "true" === get("phoenixnotebooks"),
+    phoenixFeatures: "true" === get("phoenixfeatures"),
     notebooksDownBanner: "true" === get("notebooksDownBanner"),
     enableThroughputCap: "true" === get("enablethroughputcap"),
   };

--- a/src/Utils/GalleryUtils.ts
+++ b/src/Utils/GalleryUtils.ts
@@ -228,7 +228,7 @@ export function downloadItem(
     undefined,
     "Download",
     async () => {
-      if (useNotebook.getState().isPhoenix) {
+      if (useNotebook.getState().isPhoenixNotebooks) {
         await container.allocateContainer();
       }
       const notebookServerInfo = useNotebook.getState().notebookServerInfo;

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -339,8 +339,11 @@ function updateContextsFromPortalMessage(inputs: DataExplorerInputsFrame) {
     if (inputs.flights.indexOf(Flights.PKPartitionKeyTest) !== -1) {
       userContext.features.partitionKeyDefault2 = true;
     }
-    if (inputs.flights.indexOf(Flights.Phoenix) !== -1) {
-      userContext.features.phoenix = true;
+    if (inputs.flights.indexOf(Flights.PhoenixNotebooks) !== -1) {
+      userContext.features.phoenixNotebooks = true;
+    }
+    if (inputs.flights.indexOf(Flights.PhoenixFeatures) !== -1) {
+      userContext.features.phoenixFeatures = true;
     }
     if (inputs.flights.indexOf(Flights.NotebooksDownBanner) !== -1) {
       userContext.features.notebooksDownBanner = true;


### PR DESCRIPTION
This PR
- Renames phoenix feature flag to "phoenixnotebooks". This is used for all notebook related checks
- Adds a seaprate phoenixfeatures flag for schema analyzer, mongo terminal and cassandra terminal

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1184?feature.phoeixfeatures=true&feature.phoeixnotebooks=true)
