### PR TITLE
Fix 1582396 : WCAG 4.1.2: Ensures ARIA attributes are allowed for an element's role (span[aria-label="pkDescription"])

### DIFF
--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -419,9 +419,9 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                 </TooltipHost>
               </Stack>
 
-              <Text variant="small" aria-label="pkDescription">
+              <label aria-label="pkDescription" style={{ padding: "0" }}>
                 {this.getPartitionKeySubtext()}
-              </Text>
+              </label>
 
               <input
                 type="text"


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Issue: https://msdata.visualstudio.com/CosmosDB/_workitems/edit/1582396

Issue is fixed as below,
![Screenshot_1582396](https://user-images.githubusercontent.com/81285216/150487378-79f6c147-739f-4635-a439-6e58322241b9.png)

