### PR TITLE
Fix 1586471 : WCAG 4.1.2: Ensures every ARIA input field has an accessible name (#Dropdown745)

### DIFF
--- a/src/Explorer/Panes/ExecuteSprocParamsPane/InputParameter.tsx
+++ b/src/Explorer/Panes/ExecuteSprocParamsPane/InputParameter.tsx
@@ -60,6 +60,7 @@ export const InputParameter: FunctionComponent<InputParameterProps> = ({
           options={options}
           styles={dropdownStyles}
           tabIndex={0}
+          ariaLabel="Key"
         />
         <TextField
           label={inputLabel && inputLabel}

--- a/src/Explorer/Panes/ExecuteSprocParamsPane/__snapshots__/ExecuteSprocParamsPane.test.tsx.snap
+++ b/src/Explorer/Panes/ExecuteSprocParamsPane/__snapshots__/ExecuteSprocParamsPane.test.tsx.snap
@@ -319,6 +319,7 @@ exports[`Excute Sproc Param Pane should render Default properly 1`] = `
               className="ms-Stack css-54"
             >
               <Dropdown
+                ariaLabel="Key"
                 defaultSelectedKey="string"
                 key=".0:$.0"
                 label="Key"
@@ -345,6 +346,7 @@ exports[`Excute Sproc Param Pane should render Default properly 1`] = `
                 tabIndex={0}
               >
                 <DropdownBase
+                  ariaLabel="Key"
                   defaultSelectedKey="string"
                   label="Key"
                   onChange={[Function]}
@@ -637,6 +639,7 @@ exports[`Excute Sproc Param Pane should render Default properly 1`] = `
                   }
                 >
                   <DropdownInternal
+                    ariaLabel="Key"
                     defaultSelectedKey="string"
                     hoisted={
                       Object {
@@ -1235,7 +1238,7 @@ exports[`Excute Sproc Param Pane should render Default properly 1`] = `
                       <div
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        aria-labelledby="Dropdown0-label Dropdown0-option"
+                        aria-label="Key"
                         className="ms-Dropdown dropdown-55"
                         data-is-focusable={true}
                         data-ktp-target={true}
@@ -2477,6 +2480,7 @@ exports[`Excute Sproc Param Pane should render Default properly 1`] = `
               className="ms-Stack css-54"
             >
               <Dropdown
+                ariaLabel="Key"
                 defaultSelectedKey="string"
                 key=".0:$.0"
                 label="Key"
@@ -2503,6 +2507,7 @@ exports[`Excute Sproc Param Pane should render Default properly 1`] = `
                 tabIndex={0}
               >
                 <DropdownBase
+                  ariaLabel="Key"
                   defaultSelectedKey="string"
                   label="Key"
                   onChange={[Function]}
@@ -2795,6 +2800,7 @@ exports[`Excute Sproc Param Pane should render Default properly 1`] = `
                   }
                 >
                   <DropdownInternal
+                    ariaLabel="Key"
                     defaultSelectedKey="string"
                     hoisted={
                       Object {
@@ -3393,7 +3399,7 @@ exports[`Excute Sproc Param Pane should render Default properly 1`] = `
                       <div
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        aria-labelledby="Dropdown4-label Dropdown4-option"
+                        aria-label="Key"
                         className="ms-Dropdown dropdown-55"
                         data-is-focusable={true}
                         data-ktp-target={true}


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Issue: https://msdata.visualstudio.com/CosmosDB/_workitems/edit/1586471

Issue is fixed as below,
![Screenshot_1586471](https://user-images.githubusercontent.com/81285216/150804350-94ca1144-741a-4f51-9c96-23df94f18ff0.png)

