### PR TITLE
Fix 1586681 : WCAG 4.1.2: Ensures attributes that begin with aria- are valid ARIA attributes (.graphExpandCollapseBtn)

### DIFF
--- a/src/Explorer/Graph/GraphExplorerComponent/MiddlePaneComponent.tsx
+++ b/src/Explorer/Graph/GraphExplorerComponent/MiddlePaneComponent.tsx
@@ -22,7 +22,7 @@ export class MiddlePaneComponent extends React.Component<MiddlePaneComponentProp
             onClick={this.props.toggleExpandGraph}
             role="button"
             aria-expanded={this.props.isTabsContentExpanded}
-            aria-name="View graph in full screen"
+            aria-label="View graph in full screen"
             tabIndex={0}
           >
             <img


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Issue: https://msdata.visualstudio.com/CosmosDB/_workitems/edit/1586681

Issue is fixed as below, 
![Screenshot_1586681](https://user-images.githubusercontent.com/81285216/151312074-4e801492-d214-425c-8996-951cd43f2492.png)

