### PR TITLE
Fix 1586697 : WCAG 4.1.2: Ensures every ARIA input field has an accessible name (#Dropdown516)

### DIFF
--- a/src/Explorer/Graph/NewVertexComponent/NewVertexComponent.test.tsx
+++ b/src/Explorer/Graph/NewVertexComponent/NewVertexComponent.test.tsx
@@ -107,11 +107,11 @@ describe("New Vertex Component", () => {
   it("should call onTypeChange method on type dropdown change", () => {
     const DOWN_ARROW = { keyCode: 40 };
     const onTypeChange = jest.fn();
-    const dropdown = screen.getByRole("listbox");
+    const dropdown = screen.getByRole("combobox");
     dropdown.onclick = onTypeChange();
     dropdown.onkeydown = onTypeChange();
 
-    fireEvent.keyDown(screen.getByRole("listbox"), DOWN_ARROW);
+    fireEvent.keyDown(screen.getByRole("combobox"), DOWN_ARROW);
     fireEvent.click(screen.getByText(/number/));
     expect(onTypeChange).toHaveBeenCalled();
   });

--- a/src/Explorer/Graph/NewVertexComponent/NewVertexComponent.tsx
+++ b/src/Explorer/Graph/NewVertexComponent/NewVertexComponent.tsx
@@ -165,7 +165,6 @@ export const NewVertexComponent: FunctionComponent<INewVertexComponentProps> = (
                 </div>
                 <div>
                   <Dropdown
-                    role="listbox"
                     placeholder="Select an option"
                     defaultSelectedKey={data.values[0].type}
                     style={{ width: 100 }}
@@ -174,6 +173,7 @@ export const NewVertexComponent: FunctionComponent<INewVertexComponentProps> = (
                       text: type,
                     }))}
                     onChange={(_, options: IDropdownOption) => onTypeChange(options.key.toString(), index)}
+                    ariaLabel="Select an option"
                   />
                 </div>
                 <div className="actionCol">


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Issue: https://msdata.visualstudio.com/CosmosDB/_workitems/edit/1586697

Issue is fixed as below,
![Screenshot_1586697](https://user-images.githubusercontent.com/81285216/151509068-0b668590-c513-4aaa-9edc-6a62160fc7d2.png)

