### PR TITLE
Fix some metric labels are missing in the query stats tab

### DIFF
--- a/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
@@ -215,13 +215,13 @@ export default class QueryTabComponent extends React.Component<IQueryTabComponen
       {
         metric: "Request Charge",
         value: this.state.requestChargeDisplayText,
-        toolTip: "",
+        toolTip: "Request Charge",
         isQueryMetricsEnabled: true,
       },
       {
         metric: "Showing Results",
         value: this.state.showingDocumentsDisplayText,
-        toolTip: "",
+        toolTip: "Showing Results",
         isQueryMetricsEnabled: true,
       },
       {


### PR DESCRIPTION
Set `toolTip` value for "Request Charge" and "Showing Results" metrics
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
