### PR TITLE
Fix 1586708 : WCAG 1.3.1,WCAG 4.1.2: Ensures select element has an accessible name (select)

### DIFF
--- a/src/Explorer/Graph/GraphExplorerComponent/EditorNodePropertiesComponent.tsx
+++ b/src/Explorer/Graph/GraphExplorerComponent/EditorNodePropertiesComponent.tsx
@@ -222,6 +222,7 @@ export class EditorNodePropertiesComponent extends React.Component<EditorNodePro
                     this.props.onUpdateProperties(this.props.editedProperties);
                   }}
                   required
+                  aria-label="Select Type"
                 >
                   {EditorNodePropertiesComponent.VERTEX_PROPERTY_TYPES.map((type: string) => (
                     <option value={type} key={type}>


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Issue: https://msdata.visualstudio.com/CosmosDB/_workitems/edit/1586708

Issue is fixed as below,
![Screenshot_1586708](https://user-images.githubusercontent.com/81285216/151784443-55e6cb79-ccdc-49f2-bb2e-43103619895b.png)

