### PR TITLE
Fix 1586701 : WCAG 4.1.2: Ensures ARIA attributes are allowed for an element's role (.iconContainer)

### DIFF
--- a/src/Explorer/Graph/GraphExplorerComponent/D3ForceGraph.ts
+++ b/src/Explorer/Graph/GraphExplorerComponent/D3ForceGraph.ts
@@ -730,9 +730,6 @@ export class D3ForceGraph implements GraphRenderer {
       .append("g")
       .attr("class", "iconContainer")
       .attr("tabindex", 0)
-      .attr("aria-label", (d: D3Node) => {
-        return this.retrieveNodeCaption(d);
-      })
       .on("dblclick", function (this: Element, _: MouseEvent, d: D3Node) {
         // https://stackoverflow.com/a/41945742 ('this' implicitly has type 'any' because it does not have a type annotation)
         // this is the <g> element


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Issue: https://msdata.visualstudio.com/CosmosDB/_workitems/edit/1586701

Issue is fixed as below,
![Screenshot_1586701](https://user-images.githubusercontent.com/81285216/151788097-fa6fb6f0-a1fb-410b-971b-58c42e9818e0.png)

