### PR TITLE
Fix 1586688 : WCAG 1.1.1: Ensures svg elements with an img, graphics-document or graphics-symbol role have an accessible text (#Layer_1)

### DIFF
--- a/src/Explorer/Graph/GraphExplorerComponent/GraphVizComponent.tsx
+++ b/src/Explorer/Graph/GraphExplorerComponent/GraphVizComponent.tsx
@@ -54,7 +54,9 @@ export class GraphVizComponent extends React.Component<GraphVizComponentProps> {
                 }
               }
               xmlSpace="preserve"
+              aria-label="Load more icon"
             >
+              <title>Load More Icon</title>
               <g style={{ opacity: 1 }}>
                 <g>
                   <g style={{ opacity: 0.4 }}>
@@ -151,6 +153,7 @@ export class GraphVizComponent extends React.Component<GraphVizComponentProps> {
               width="20px"
               height="20px"
             >
+              <title>Triangle Right</title>
               <polygon points="0.5,10 0.5,0 5.2,5 " />
             </svg>
             {/*<!-- Make whole area clickable instead of the shape -->*/}


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Issue : https://msdata.visualstudio.com/CosmosDB/_workitems/edit/1586688

Issue is fixed as below,
![Screenshot_1586688](https://user-images.githubusercontent.com/81285216/151926617-8dfe9821-ea93-4848-b649-3d0e49b76d06.png)

