### PR TITLE
Fix 1586748 : WCAG 4.1.2: Ensures attributes that begin with aria- are valid ARIA attributes (.collapsibleSection.css-152[aria-name="Advanced"])

### DIFF
--- a/src/Explorer/Controls/CollapsiblePanel/CollapsibleSectionComponent.tsx
+++ b/src/Explorer/Controls/CollapsiblePanel/CollapsibleSectionComponent.tsx
@@ -49,7 +49,6 @@ export class CollapsibleSectionComponent extends React.Component<CollapsibleSect
           onClick={this.toggleCollapsed}
           onKeyPress={this.onKeyPress}
           tabIndex={0}
-          aria-name="Advanced"
           role="button"
           aria-expanded={this.state.isExpanded}
         >

--- a/src/Explorer/Controls/CollapsiblePanel/__snapshots__/CollapsibleSectionComponent.test.tsx.snap
+++ b/src/Explorer/Controls/CollapsiblePanel/__snapshots__/CollapsibleSectionComponent.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`CollapsibleSectionComponent renders 1`] = `
 <Fragment>
   <Stack
     aria-expanded={true}
-    aria-name="Advanced"
     className="collapsibleSection"
     horizontal={true}
     onClick={[Function]}


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Issue: https://msdata.visualstudio.com/CosmosDB/_workitems/edit/1586748

Issue is fixed as below,
![Screenshot_1586748](https://user-images.githubusercontent.com/81285216/152293658-787a44bb-c0c9-4c68-84e0-f50338075153.png)

