### PR TITLE
Fix 1586537 : WCAG 1.3.1: Ensures elements with an ARIA role that require parent roles are contained by them (.databaseHeader.main1.nodeItem:nth-child(1))

### DIFF
--- a/src/Explorer/Controls/TreeComponent/TreeComponent.tsx
+++ b/src/Explorer/Controls/TreeComponent/TreeComponent.tsx
@@ -194,7 +194,7 @@ export class TreeNodeComponent extends React.Component<TreeNodeComponentProps, T
         </div>
         {node.children && (
           <AnimateHeight duration={TreeNodeComponent.transitionDurationMS} height={this.state.isExpanded ? "auto" : 0}>
-            <div className="nodeChildren" data-test={node.label}>
+            <div className="nodeChildren" data-test={node.label} role="tree">
               {TreeNodeComponent.getSortedChildren(node).map((childNode: TreeNode) => (
                 <TreeNodeComponent
                   key={`${childNode.label}-${generation + 1}-${childNode.timestamp}`}

--- a/src/Explorer/Controls/TreeComponent/__snapshots__/TreeComponent.test.tsx.snap
+++ b/src/Explorer/Controls/TreeComponent/__snapshots__/TreeComponent.test.tsx.snap
@@ -100,6 +100,7 @@ exports[`TreeNodeComponent does not render children by default 1`] = `
     <div
       className="nodeChildren"
       data-test="label"
+      role="tree"
     >
       <TreeNodeComponent
         generation={3}
@@ -250,6 +251,7 @@ exports[`TreeNodeComponent renders a simple node (sorted children, expanded) 1`]
     <div
       className="nodeChildren"
       data-test="label"
+      role="tree"
     >
       <TreeNodeComponent
         generation={13}
@@ -351,6 +353,7 @@ exports[`TreeNodeComponent renders loading icon 1`] = `
     <div
       className="nodeChildren"
       data-test="label"
+      role="tree"
     />
   </AnimateHeight>
 </div>
@@ -463,6 +466,7 @@ exports[`TreeNodeComponent renders sorted children, expanded, leaves and parents
     <div
       className="nodeChildren"
       data-test="label"
+      role="tree"
     >
       <TreeNodeComponent
         generation={13}
@@ -592,6 +596,7 @@ exports[`TreeNodeComponent renders unsorted children by default 1`] = `
     <div
       className="nodeChildren"
       data-test="label"
+      role="tree"
     >
       <TreeNodeComponent
         generation={3}


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Issue: https://msdata.visualstudio.com/CosmosDB/_workitems/edit/1586537

Issue is fixed as below,
![Screenshot_1586537](https://user-images.githubusercontent.com/81285216/152294430-ff1160c4-8503-4179-8a6a-cf170a310bfc.png)

