### PR TITLE
Fixe 1586279 : WCAG 4.1.2: Nested interactive controls are not announced by screen readers (.refreshColHeader)

### DIFF
--- a/less/documentDB.less
+++ b/less/documentDB.less
@@ -2245,7 +2245,8 @@ a:link {
 }
 
 .refreshColHeader {
-  padding: 3px 6px 10px 0px !important;
+  padding: 3px 0px 10px 0px !important;
+  width: 15px;
 }
 
 .refreshColHeader:hover {

--- a/src/Explorer/Tabs/DocumentsTab.html
+++ b/src/Explorer/Tabs/DocumentsTab.html
@@ -158,13 +158,13 @@
                   role="button"
                   aria-label="Refresh documents"
                   data-bind="event: { keydown: onRefreshButtonKeyDown }"
+                  tabindex="0"
                 >
                   <img
                     class="refreshcol"
                     src="/refresh-cosmos.svg"
                     data-bind="click: refreshDocumentsGrid"
                     alt="Refresh documents"
-                    tabindex="0"
                   />
                 </th>
               </tr>


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Issue: https://msdata.visualstudio.com/CosmosDB/_workitems/edit/1586279

Issue is fixed as below,
![Screenshot_1586279](https://user-images.githubusercontent.com/81285216/152467192-56469e07-6e81-4dd3-9745-55d8d3d3a4e1.png)

