### PR TITLE
Fix 1582593 : WCAG 4.1.2: Ensures ARIA attributes are allowed for an element's role (#header250-costType)

### DIFF
--- a/src/Explorer/Controls/Settings/SettingsRenderUtils.tsx
+++ b/src/Explorer/Controls/Settings/SettingsRenderUtils.tsx
@@ -141,6 +141,19 @@ export const transparentDetailsHeaderStyle: Partial<IDetailsColumnStyles> = {
   },
 };
 
+export const transparentDetailsCostHeaderStyle: Partial<IDetailsColumnStyles> = {
+  root: {
+    selectors: {
+      ":hover": {
+        background: "transparent",
+      },
+      ".ms-DetailsHeader-cellTitle": {
+        visibility: "hidden",
+      },
+    },
+  },
+};
+
 export const customDetailsListStyles: Partial<IDetailsListStyles> = {
   root: {
     selectors: {

--- a/src/Explorer/Controls/Settings/SettingsSubComponents/ThroughputInputComponents/ThroughputInputAutoPilotV3Component.tsx
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/ThroughputInputComponents/ThroughputInputAutoPilotV3Component.tsx
@@ -38,6 +38,7 @@ import {
   PriceBreakdown,
   saveThroughputWarningMessage,
   titleAndInputStackProps,
+  transparentDetailsCostHeaderStyle,
   transparentDetailsHeaderStyle,
 } from "../../SettingsRenderUtils";
 import { getSanitizedInputValue, IsComponentDirtyResult, isDirty } from "../../SettingsUtils";
@@ -219,12 +220,12 @@ export class ThroughputInputAutoPilotV3Component extends React.Component<
     const estimatedSpendingColumns: IColumn[] = [
       {
         key: "costType",
-        name: "",
+        name: "Cost Type",
         fieldName: "costType",
         minWidth: 100,
         maxWidth: 200,
         isResizable: true,
-        styles: transparentDetailsHeaderStyle,
+        styles: transparentDetailsCostHeaderStyle,
       },
       {
         key: "minPerMonth",


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Issue: https://msdata.visualstudio.com/CosmosDB/_workitems/edit/1582593

Issue is fixed as below,
![Screenshot_1582593](https://user-images.githubusercontent.com/81285216/152746928-74f08022-9d87-4a03-bdf0-e0a27b0e4dad.png)

