### PR TITLE
Update autoscale throughput limits

### DIFF
--- a/src/Explorer/Controls/ThroughputInput/ThroughputInput.tsx
+++ b/src/Explorer/Controls/ThroughputInput/ThroughputInput.tsx
@@ -14,6 +14,7 @@ import "./ThroughputInput.less";
 export interface ThroughputInputProps {
   isDatabase: boolean;
   isSharded: boolean;
+  isFreeTier: boolean;
   showFreeTierExceedThroughputTooltip: boolean;
   setThroughputValue: (throughput: number) => void;
   setIsAutoscale: (isAutoscale: boolean) => void;
@@ -23,15 +24,18 @@ export interface ThroughputInputProps {
 
 export const ThroughputInput: FunctionComponent<ThroughputInputProps> = ({
   isDatabase,
+  isSharded,
+  isFreeTier,
   showFreeTierExceedThroughputTooltip,
   setThroughputValue,
   setIsAutoscale,
   setIsThroughputCapExceeded,
-  isSharded,
   onCostAcknowledgeChange,
 }: ThroughputInputProps) => {
   const [isAutoscaleSelected, setIsAutoScaleSelected] = useState<boolean>(true);
-  const [throughput, setThroughput] = useState<number>(AutoPilotUtils.minAutoPilotThroughput);
+  const [throughput, setThroughput] = useState<number>(
+    isFreeTier ? AutoPilotUtils.minAutoPilotThroughput : AutoPilotUtils.autoPilotDefaultThroughput
+  );
   const [isCostAcknowledged, setIsCostAcknowledged] = useState<boolean>(false);
   const [throughputError, setThroughputError] = useState<string>("");
   const [totalThroughputUsed, setTotalThroughputUsed] = useState<number>(0);
@@ -151,11 +155,14 @@ export const ThroughputInput: FunctionComponent<ThroughputInputProps> = ({
 
   const handleOnChangeMode = (event: React.ChangeEvent<HTMLInputElement>, mode: string): void => {
     if (mode === "Autoscale") {
-      setThroughput(AutoPilotUtils.minAutoPilotThroughput);
+      const defaultThroughput = isFreeTier
+        ? AutoPilotUtils.minAutoPilotThroughput
+        : AutoPilotUtils.autoPilotDefaultThroughput;
+      setThroughput(defaultThroughput);
       setIsAutoScaleSelected(true);
-      setThroughputValue(AutoPilotUtils.minAutoPilotThroughput);
+      setThroughputValue(defaultThroughput);
       setIsAutoscale(true);
-      checkThroughputCap(AutoPilotUtils.minAutoPilotThroughput);
+      checkThroughputCap(defaultThroughput);
     } else {
       setThroughput(SharedConstants.CollectionCreation.DefaultCollectionRUs400);
       setIsAutoScaleSelected(false);

--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -249,6 +249,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                     showFreeTierExceedThroughputTooltip={this.isFreeTierAccount() && !isFirstResourceCreated}
                     isDatabase={true}
                     isSharded={this.state.isSharded}
+                    isFreeTier={this.isFreeTierAccount()}
                     setThroughputValue={(throughput: number) => (this.newDatabaseThroughput = throughput)}
                     setIsAutoscale={(isAutoscale: boolean) => (this.isNewDatabaseAutoscale = isAutoscale)}
                     setIsThroughputCapExceeded={(isThroughputCapExceeded: boolean) =>
@@ -483,6 +484,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
               showFreeTierExceedThroughputTooltip={this.isFreeTierAccount() && !isFirstResourceCreated}
               isDatabase={false}
               isSharded={this.state.isSharded}
+              isFreeTier={this.isFreeTierAccount()}
               setThroughputValue={(throughput: number) => (this.collectionThroughput = throughput)}
               setIsAutoscale={(isAutoscale: boolean) => (this.isCollectionAutoscale = isAutoscale)}
               setIsThroughputCapExceeded={(isThroughputCapExceeded: boolean) =>

--- a/src/Explorer/Panes/AddDatabasePanel/AddDatabasePanel.tsx
+++ b/src/Explorer/Panes/AddDatabasePanel/AddDatabasePanel.tsx
@@ -241,6 +241,7 @@ export const AddDatabasePanel: FunctionComponent<AddDatabasePaneProps> = ({
             showFreeTierExceedThroughputTooltip={isFreeTierAccount && !useDatabases.getState().isFirstResourceCreated()}
             isDatabase={true}
             isSharded={databaseCreateNewShared}
+            isFreeTier={isFreeTierAccount}
             setThroughputValue={(newThroughput: number) => (throughput = newThroughput)}
             setIsAutoscale={(isAutoscale: boolean) => (isAutoscaleSelected = isAutoscale)}
             setIsThroughputCapExceeded={(isCapExceeded: boolean) => setIsThroughputCapExceeded(isCapExceeded)}

--- a/src/Utils/AutoPilotUtils.ts
+++ b/src/Utils/AutoPilotUtils.ts
@@ -1,6 +1,6 @@
-export const minAutoPilotThroughput = 4000;
-
+export const minAutoPilotThroughput = 1000;
 export const autoPilotIncrementStep = 1000;
+export const autoPilotDefaultThroughput = 4000;
 
 export function isValidAutoPilotThroughput(maxThroughput: number): boolean {
   if (!maxThroughput) {


### PR DESCRIPTION
- changed minimum autoscale throughput value from 4000 to 1000
- changed default autoscale throughput value for free tier account from 4000 to 1000

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
