### PR TITLE
Enable phoenix for MPAC by default, and for PROD will enable phoenix only based on flight

### DIFF
--- a/configs/mpac.json
+++ b/configs/mpac.json
@@ -1,4 +1,5 @@
 {
   "JUNO_ENDPOINT": "https://tools-staging.cosmos.azure.com",
-  "isTerminalEnabled" : true
+  "isTerminalEnabled" : true,
+  "isMPAC" : true
 }

--- a/configs/mpac.json
+++ b/configs/mpac.json
@@ -1,5 +1,5 @@
 {
   "JUNO_ENDPOINT": "https://tools-staging.cosmos.azure.com",
   "isTerminalEnabled" : true,
-  "isMPAC" : true
+  "isPhoenixFlightDefault" : true
 }

--- a/configs/prod.json
+++ b/configs/prod.json
@@ -1,4 +1,5 @@
 {
  "JUNO_ENDPOINT": "https://tools.cosmos.azure.com",
- "isTerminalEnabled" : false
+ "isTerminalEnabled" : false,
+ "isMPAC" : false
 }

--- a/configs/prod.json
+++ b/configs/prod.json
@@ -1,5 +1,5 @@
 {
  "JUNO_ENDPOINT": "https://tools.cosmos.azure.com",
  "isTerminalEnabled" : false,
- "isMPAC" : false
+ "isPhoenixFlightDefault" : false
 }

--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -40,6 +40,7 @@ export interface ConfigContext {
   GITHUB_TEST_ENV_CLIENT_ID: string;
   GITHUB_CLIENT_SECRET?: string; // No need to inject secret for prod. Juno already knows it.
   isTerminalEnabled: boolean;
+  isMPAC: boolean;
   hostedExplorerURL: string;
   armAPIVersion?: string;
   msalRedirectURI?: string;
@@ -71,6 +72,7 @@ let configContext: Readonly<ConfigContext> = {
   JUNO_ENDPOINT: "https://tools.cosmos.azure.com",
   BACKEND_ENDPOINT: "https://main.documentdb.ext.azure.com",
   isTerminalEnabled: false,
+  isMPAC: false,
 };
 
 export function resetConfigContext(): void {

--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -40,7 +40,7 @@ export interface ConfigContext {
   GITHUB_TEST_ENV_CLIENT_ID: string;
   GITHUB_CLIENT_SECRET?: string; // No need to inject secret for prod. Juno already knows it.
   isTerminalEnabled: boolean;
-  isMPAC: boolean;
+  isPhoenixFlightDefault: boolean;
   hostedExplorerURL: string;
   armAPIVersion?: string;
   msalRedirectURI?: string;
@@ -72,7 +72,7 @@ let configContext: Readonly<ConfigContext> = {
   JUNO_ENDPOINT: "https://tools.cosmos.azure.com",
   BACKEND_ENDPOINT: "https://main.documentdb.ext.azure.com",
   isTerminalEnabled: false,
-  isMPAC: false,
+  isPhoenixFlightDefault: false,
 };
 
 export function resetConfigContext(): void {

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -364,7 +364,7 @@ function updateContextsFromPortalMessage(inputs: DataExplorerInputsFrame) {
     if (inputs.flights.indexOf(Flights.PKPartitionKeyTest) !== -1) {
       userContext.features.partitionKeyDefault2 = true;
     }
-    if (configContext.isMPAC === true) {
+    if (configContext.isPhoenixFlightDefault === true) {
       userContext.features.phoenixNotebooks = true;
       userContext.features.phoenixFeatures = true;
     } else {

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -364,11 +364,16 @@ function updateContextsFromPortalMessage(inputs: DataExplorerInputsFrame) {
     if (inputs.flights.indexOf(Flights.PKPartitionKeyTest) !== -1) {
       userContext.features.partitionKeyDefault2 = true;
     }
-    if (inputs.flights.indexOf(Flights.PhoenixNotebooks) !== -1) {
+    if (configContext.isMPAC === true) {
       userContext.features.phoenixNotebooks = true;
-    }
-    if (inputs.flights.indexOf(Flights.PhoenixFeatures) !== -1) {
       userContext.features.phoenixFeatures = true;
+    } else {
+      if (inputs.flights.indexOf(Flights.PhoenixNotebooks) !== -1) {
+        userContext.features.phoenixNotebooks = true;
+      }
+      if (inputs.flights.indexOf(Flights.PhoenixFeatures) !== -1) {
+        userContext.features.phoenixFeatures = true;
+      }
     }
     if (inputs.flights.indexOf(Flights.NotebooksDownBanner) !== -1) {
       userContext.features.notebooksDownBanner = true;


### PR DESCRIPTION
This PR:

- Adds a flag 'isPhoenixFlightDefault' in configuration files. For MPAC both phoenix feature flags will be enabled irrespective of flight and for prod will enable based on flight control tower.
