### PR TITLE
Update Tab title from 'Items' to id + ' - Items' to make it easier to differentiate them

### DIFF
--- a/src/Explorer/Tree/Collection.ts
+++ b/src/Explorer/Tree/Collection.ts
@@ -308,7 +308,7 @@ export default class Collection implements ViewModels.Collection {
         collectionName: this.id(),
 
         dataExplorerArea: Constants.Areas.Tab,
-        tabTitle: "Items",
+        tabTitle: this.rawDataModel.id + " - Items",
       });
       this.documentIds([]);
 
@@ -316,7 +316,7 @@ export default class Collection implements ViewModels.Collection {
         partitionKey: this.partitionKey,
         documentIds: ko.observableArray<DocumentId>([]),
         tabKind: ViewModels.CollectionTabKind.Documents,
-        title: "Items",
+        title: this.rawDataModel.id + " - Items",
         collection: this,
         node: this,
         tabPath: `${this.databaseId}>${this.id()}>Documents`,


### PR DESCRIPTION
# Why is this change being made?
It's hard to know which tab has the data of which container today since they are all named "Items". This makes it easier to differentiate them.

# What changed?
Added the container id to the tab name so instead of all reading "Items" they read as "Planet - Items", "Books - Items", etc. 

# How was this validated?
Ran the cosmos explorer locally, used the feature flag on portal to point it to my local cosmos explorer and validated that the tab name now had the id. 

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1233)
