### PR TITLE
Fix settings tab shows no selected value

### DIFF
--- a/src/Explorer/Controls/Settings/SettingsComponent.tsx
+++ b/src/Explorer/Controls/Settings/SettingsComponent.tsx
@@ -149,7 +149,7 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
       this.offer = this.database?.offer();
     }
 
-    this.state = {
+    const initialState: SettingsComponentState = {
       throughput: undefined,
       throughputBaseline: undefined,
       autoPilotThroughput: undefined,
@@ -197,6 +197,11 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
 
       initialNotification: undefined,
       selectedTab: SettingsV2TabTypes.ScaleTab,
+    };
+
+    this.state = {
+      ...initialState,
+      ...this.getBaselineValues(),
     };
 
     this.saveSettingsButton = {
@@ -561,21 +566,24 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
   };
 
   public setBaseline = (): void => {
+    const baselineValues = this.getBaselineValues();
+    this.setState(baselineValues as SettingsComponentState);
+  };
+
+  private getBaselineValues = (): Partial<SettingsComponentState> => {
     const offerThroughput = this.offer?.manualThroughput;
 
     if (!this.isCollectionSettingsTab) {
-      this.setState({
+      return {
         throughput: offerThroughput,
         throughputBaseline: offerThroughput,
-      });
-
-      return;
+      };
     }
 
     const defaultTtl = this.collection.defaultTtl();
 
-    let timeToLive: TtlType = this.state.timeToLive;
-    let timeToLiveSeconds = this.state.timeToLiveSeconds;
+    let timeToLive: TtlType;
+    let timeToLiveSeconds: number;
     switch (defaultTtl) {
       case undefined:
       case 0:
@@ -620,7 +628,7 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
       (this.collection.geospatialConfig && this.collection.geospatialConfig()?.type) || GeospatialConfigType.Geometry;
     const geoSpatialConfigType = GeospatialConfigType[geospatialConfigTypeString as keyof typeof GeospatialConfigType];
 
-    this.setState({
+    return {
       throughput: offerThroughput,
       throughputBaseline: offerThroughput,
       changeFeedPolicy: changeFeedPolicy,
@@ -643,7 +651,7 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
       conflictResolutionPolicyProcedureBaseline: conflictResolutionPolicyProcedure,
       geospatialConfigType: geoSpatialConfigType,
       geospatialConfigTypeBaseline: geoSpatialConfigType,
-    });
+    };
   };
 
   private getTabsButtons = (): CommandButtonComponentProps[] => {


### PR DESCRIPTION
In the constructor of the settings component, the states are initialized with `undefined` so when the settings tab is rendered the first time, it will have no selected value. The actual values of the states are only populated when the component is mounted. Normally when we call `setState` in settings component, it should also trigger a re-render for the inner tabs/pivots (e.g. scale, settings, indexing policy), updating the selected values. However, it looks like there's some special logic for the fluent UI pivot/pivot items which causes the inner tabs to not update while it's the active tab.

This fix sets the proper initial value for the states in the constructor which fixes the issue. However, a better fix would be to move the actual content of the tabs outside of the pivot. This way we are only using the pivot for showing the tab headers and controlling the logic for switching tabs while having the freedom to freely update the tab content.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1237?feature.someFeatureFlagYouMightNeed=true)
