### PR TITLE
Make Phoenix enabled based of config context

### DIFF
--- a/src/Phoenix/PhoenixClient.ts
+++ b/src/Phoenix/PhoenixClient.ts
@@ -160,10 +160,10 @@ export class PhoenixClient {
   }
 
   public async isDbAcountWhitelisted(): Promise<boolean> {
+    const startKey = TelemetryProcessor.traceStart(Action.PhoenixDBAccountAllowed, {
+      dataExplorerArea: Areas.Notebook,
+    });
     try {
-      TelemetryProcessor.traceStart(Action.PhoenixDBAccountAllowed, {
-        dataExplorerArea: Areas.Notebook,
-      });
       const response = await window.fetch(`${this.getPhoenixControlPlanePathPrefix()}`, {
         method: "GET",
         headers: PhoenixClient.getHeaders(),
@@ -171,16 +171,24 @@ export class PhoenixClient {
       if (response.status !== HttpStatusCodes.OK) {
         throw new Error(`Received status code: ${response?.status}`);
       }
-      TelemetryProcessor.traceSuccess(Action.PhoenixDBAccountAllowed, {
-        dataExplorerArea: Areas.Notebook,
-      });
+      TelemetryProcessor.traceSuccess(
+        Action.PhoenixDBAccountAllowed,
+        {
+          dataExplorerArea: Areas.Notebook,
+        },
+        startKey
+      );
       return response.status === HttpStatusCodes.OK;
     } catch (error) {
-      TelemetryProcessor.traceFailure(Action.PhoenixDBAccountAllowed, {
-        dataExplorerArea: Areas.Notebook,
-        error: getErrorMessage(error),
-        errorStack: getErrorStack(error),
-      });
+      TelemetryProcessor.traceFailure(
+        Action.PhoenixDBAccountAllowed,
+        {
+          dataExplorerArea: Areas.Notebook,
+          error: getErrorMessage(error),
+          errorStack: getErrorStack(error),
+        },
+        startKey
+      );
       Logger.logError(getErrorMessage(error), "PhoenixClient/IsDbAcountWhitelisted");
       return false;
     }

--- a/src/Phoenix/PhoenixClient.ts
+++ b/src/Phoenix/PhoenixClient.ts
@@ -161,9 +161,15 @@ export class PhoenixClient {
 
   public async isDbAcountWhitelisted(): Promise<boolean> {
     try {
+      TelemetryProcessor.traceStart(Action.PhoenixDBAccountAllowed, {
+        dataExplorerArea: Areas.Notebook,
+      });
       const response = await window.fetch(`${this.getPhoenixControlPlanePathPrefix()}`, {
         method: "GET",
         headers: PhoenixClient.getHeaders(),
+      });
+      TelemetryProcessor.traceSuccess(Action.PhoenixDBAccountAllowed, {
+        dataExplorerArea: Areas.Notebook,
       });
       return response.status === HttpStatusCodes.OK;
     } catch (error) {

--- a/src/Phoenix/PhoenixClient.ts
+++ b/src/Phoenix/PhoenixClient.ts
@@ -10,7 +10,7 @@ import {
   HttpStatusCodes,
   Notebook,
 } from "../Common/Constants";
-import { getErrorMessage } from "../Common/ErrorHandlingUtils";
+import { getErrorMessage, getErrorStack } from "../Common/ErrorHandlingUtils";
 import * as Logger from "../Common/Logger";
 import { configContext } from "../ConfigContext";
 import {
@@ -168,6 +168,9 @@ export class PhoenixClient {
         method: "GET",
         headers: PhoenixClient.getHeaders(),
       });
+      if (response.status !== HttpStatusCodes.OK) {
+        throw new Error(`Received status code: ${response?.status}`);
+      }
       TelemetryProcessor.traceSuccess(Action.PhoenixDBAccountAllowed, {
         dataExplorerArea: Areas.Notebook,
       });
@@ -175,6 +178,8 @@ export class PhoenixClient {
     } catch (error) {
       TelemetryProcessor.traceFailure(Action.PhoenixDBAccountAllowed, {
         dataExplorerArea: Areas.Notebook,
+        error: getErrorMessage(error),
+        errorStack: getErrorStack(error),
       });
       Logger.logError(getErrorMessage(error), "PhoenixClient/IsDbAcountWhitelisted");
       return false;

--- a/src/Phoenix/PhoenixClient.ts
+++ b/src/Phoenix/PhoenixClient.ts
@@ -167,6 +167,9 @@ export class PhoenixClient {
       });
       return response.status === HttpStatusCodes.OK;
     } catch (error) {
+      TelemetryProcessor.traceFailure(Action.PhoenixDBAccountAllowed, {
+        dataExplorerArea: Areas.Notebook,
+      });
       Logger.logError(getErrorMessage(error), "PhoenixClient/IsDbAcountWhitelisted");
       return false;
     }

--- a/src/Shared/Telemetry/TelemetryConstants.ts
+++ b/src/Shared/Telemetry/TelemetryConstants.ts
@@ -84,6 +84,7 @@ export enum Action {
   PhoenixConnection,
   PhoenixHeartBeat,
   PhoenixResetWorkspace,
+  PhoenixDBAccountAllowed,
   DeleteCellFromMenu,
   OpenTerminal,
   CreateMongoCollectionWithWildcardIndex,

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -44,6 +44,11 @@ export function useKnockoutExplorer(platform: Platform): Explorer {
   useEffect(() => {
     const effect = async () => {
       if (platform) {
+        //Updating phoenix feature flags for MPAC based of config context
+        if (configContext.isPhoenixEnabled === true) {
+          userContext.features.phoenixNotebooks = true;
+          userContext.features.phoenixFeatures = true;
+        }
         if (platform === Platform.Hosted) {
           const explorer = await configureHosted();
           setExplorer(explorer);
@@ -350,11 +355,6 @@ function updateContextsFromPortalMessage(inputs: DataExplorerInputsFrame) {
   });
   if (inputs.features) {
     Object.assign(userContext.features, extractFeatures(new URLSearchParams(inputs.features)));
-  }
-  //Updating phoenix feature flags for MPAC based of config context
-  if (configContext.isPhoenixEnabled === true) {
-    userContext.features.phoenixNotebooks = true;
-    userContext.features.phoenixFeatures = true;
   }
   if (inputs.flights) {
     if (inputs.flights.indexOf(Flights.AutoscaleTest) !== -1) {


### PR DESCRIPTION
This PR:

> Making phoenix enabled irrespective ofDE launched from portal or hosted explorer.

> Add telemetry for IsDBAccountWhitelisted Call