### PR TITLE
Change Headers meant to unblock merge private preview customers

### DIFF
--- a/src/Common/CosmosClient.ts
+++ b/src/Common/CosmosClient.ts
@@ -90,7 +90,7 @@ export function client(): Cosmos.CosmosClient {
   if (_client) return _client;
 
   let _defaultHeaders: CosmosHeaders = {};
-  _defaultHeaders["x-ms-cosmos-sdk-supported-capabilities"] =
+  _defaultHeaders["x-ms-cosmos-sdk-supportedcapabilities"] =
     SDKSupportedCapabilities.None | SDKSupportedCapabilities.PartitionMerge;
 
   const options: Cosmos.CosmosClientOptions = {


### PR DESCRIPTION
We discovered recently that v2 SDks which are not merge proof are sending the header "x-ms-cosmos-sdk-supported-capabilities" so changing it to "x-ms-cosmos-sdk-supportedcapabilities" to ensure non supported sdks are blocked when customer opts into merge

This is a follow up for https://github.com/Azure/cosmos-explorer/pull/1190