### PR TITLE
Add support for multi-partition key

### DIFF
--- a/src/Common/MongoProxyClient.test.ts
+++ b/src/Common/MongoProxyClient.test.ts
@@ -25,12 +25,12 @@ const fetchMock = () => {
   });
 };
 
-const partitionKeyProperty = "pk";
+const partitionKeyProperties = ["pk"];
 
 const collection = {
   id: () => "testCollection",
   rid: "testCollectionrid",
-  partitionKeyProperty,
+  partitionKeyProperties,
   partitionKey: {
     paths: ["/pk"],
     kind: "Hash",
@@ -41,7 +41,7 @@ const collection = {
 const documentId = ({
   partitionKeyHeader: () => "[]",
   self: "db/testDB/db/testCollection/docs/testId",
-  partitionKeyProperty,
+  partitionKeyProperties,
   partitionKey: {
     paths: ["/pk"],
     kind: "Hash",

--- a/src/Common/MongoProxyClient.ts
+++ b/src/Common/MongoProxyClient.ts
@@ -76,7 +76,7 @@ export function queryDocuments(
     dba: databaseAccount.name,
     pk:
       collection && collection.partitionKey && !collection.partitionKey.systemKey
-        ? collection.partitionKeyProperty
+        ? collection.partitionKeyProperties?.[0]
         : "",
   };
 
@@ -139,7 +139,7 @@ export function readDocument(
     dba: databaseAccount.name,
     pk:
       documentId && documentId.partitionKey && !documentId.partitionKey.systemKey
-        ? documentId.partitionKeyProperty
+        ? documentId.partitionKeyProperties?.[0]
         : "",
   };
 
@@ -225,7 +225,7 @@ export function updateDocument(
     dba: databaseAccount.name,
     pk:
       documentId && documentId.partitionKey && !documentId.partitionKey.systemKey
-        ? documentId.partitionKeyProperty
+        ? documentId.partitionKeyProperties?.[0]
         : "",
   };
   const endpoint = getFeatureEndpointOrDefault("updateDocument");
@@ -266,7 +266,7 @@ export function deleteDocument(databaseId: string, collection: Collection, docum
     dba: databaseAccount.name,
     pk:
       documentId && documentId.partitionKey && !documentId.partitionKey.systemKey
-        ? documentId.partitionKeyProperty
+        ? documentId.partitionKeyProperties?.[0]
         : "",
   };
   const endpoint = getFeatureEndpointOrDefault("deleteDocument");

--- a/src/Common/QueriesClient.ts
+++ b/src/Common/QueriesClient.ts
@@ -149,10 +149,10 @@ export class QueriesClient {
     const documentId = new DocumentId(
       {
         partitionKey: QueriesClient.PartitionKey,
-        partitionKeyProperty: "id",
+        partitionKeyProperties: ["id"],
       } as DocumentsTab,
       query,
-      query.queryName
+      [query.queryName]
     ); // TODO: Remove DocumentId's dependency on DocumentsTab
     const options: any = { partitionKey: query.resourceId };
     return deleteDocument(queriesCollection, documentId)

--- a/src/Common/dataAccess/readDocument.ts
+++ b/src/Common/dataAccess/readDocument.ts
@@ -1,21 +1,28 @@
-import { Item } from "@azure/cosmos";
+import { Item, RequestOptions } from "@azure/cosmos";
 import { CollectionBase } from "../../Contracts/ViewModels";
+import DocumentId from "../../Explorer/Tree/DocumentId";
+import { logConsoleProgress } from "../../Utils/NotificationConsoleUtils";
+import { HttpHeaders } from "../Constants";
 import { client } from "../CosmosClient";
 import { getEntityName } from "../DocumentUtility";
 import { handleError } from "../ErrorHandlingUtils";
-import { logConsoleProgress } from "../../Utils/NotificationConsoleUtils";
-import DocumentId from "../../Explorer/Tree/DocumentId";
 
 export const readDocument = async (collection: CollectionBase, documentId: DocumentId): Promise<Item> => {
   const entityName = getEntityName();
   const clearMessage = logConsoleProgress(`Reading ${entityName} ${documentId.id()}`);
 
   try {
+    const options: RequestOptions =
+      documentId.partitionKey.kind === "MultiHash"
+        ? {
+            [HttpHeaders.partitionKey]: documentId.partitionKeyValue,
+          }
+        : {};
     const response = await client()
       .database(collection.databaseId)
       .container(collection.id())
       .item(documentId.id(), documentId.partitionKeyValue)
-      .read();
+      .read(options);
 
     return response?.resource;
   } catch (error) {

--- a/src/Contracts/ViewModels.ts
+++ b/src/Contracts/ViewModels.ts
@@ -106,8 +106,8 @@ export interface CollectionBase extends TreeNode {
   self: string;
   rawDataModel: DataModels.Collection;
   partitionKey: DataModels.PartitionKey;
-  partitionKeyProperty: string;
-  partitionKeyPropertyHeader: string;
+  partitionKeyProperties: string[];
+  partitionKeyPropertyHeaders: string[];
   id: ko.Observable<string>;
   selectedSubnodeKind: ko.Observable<CollectionTabKind>;
   children: ko.ObservableArray<TreeNode>;

--- a/src/Explorer/Controls/Settings/SettingsSubComponents/SubSettingsComponent.tsx
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/SubSettingsComponent.tsx
@@ -65,8 +65,8 @@ export class SubSettingsComponent extends React.Component<SubSettingsComponentPr
   constructor(props: SubSettingsComponentProps) {
     super(props);
     this.geospatialVisible = userContext.apiType === "SQL";
-    this.partitionKeyValue = "/" + this.props.collection.partitionKeyProperty;
     this.partitionKeyName = userContext.apiType === "Mongo" ? "Shard key" : "Partition key";
+    this.partitionKeyValue = this.getPartitionKeyValue();
   }
 
   componentDidMount(): void {
@@ -250,6 +250,23 @@ export class SubSettingsComponent extends React.Component<SubSettingsComponentPr
     </Stack>
   );
 
+  private getPartitionKeyValue = (): string => {
+    const partitionKeyValueProperties = this.props.collection.partitionKeyProperties;
+    if (!partitionKeyValueProperties || partitionKeyValueProperties.length === 0) {
+      return "";
+    }
+
+    let partitionKeyValue = "/" + partitionKeyValueProperties[0];
+
+    if (partitionKeyValueProperties.length > 1) {
+      for (let i = 1; i < partitionKeyValueProperties.length; i++) {
+        partitionKeyValue += ", /" + partitionKeyValueProperties[i];
+      }
+    }
+
+    return partitionKeyValue;
+  };
+
   private geoSpatialConfigTypeChoiceGroupOptions: IChoiceGroupOption[] = [
     { key: GeospatialConfigType.Geography, text: "Geography" },
     { key: GeospatialConfigType.Geometry, text: "Geometry" },
@@ -310,7 +327,8 @@ export class SubSettingsComponent extends React.Component<SubSettingsComponentPr
     if (
       userContext.apiType === "Cassandra" ||
       userContext.apiType === "Tables" ||
-      !this.props.collection.partitionKeyProperty ||
+      !this.props.collection.partitionKeyProperties ||
+      this.props.collection.partitionKeyProperties.length === 0 ||
       (userContext.apiType === "Mongo" && this.props.collection.partitionKey.systemKey)
     ) {
       return false;

--- a/src/Explorer/Controls/Settings/SettingsSubComponents/SubSettingsComponent.tsx
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/SubSettingsComponent.tsx
@@ -66,9 +66,7 @@ export class SubSettingsComponent extends React.Component<SubSettingsComponentPr
     super(props);
     this.geospatialVisible = userContext.apiType === "SQL";
     this.partitionKeyName = userContext.apiType === "Mongo" ? "Shard key" : "Partition key";
-    this.partitionKeyValue = (this.props.collection.partitionKeyProperties || [])
-      .map((property) => "/" + property)
-      .join(", ");
+    this.partitionKeyValue = this.getPartitionKeyValue();
   }
 
   componentDidMount(): void {
@@ -291,6 +289,14 @@ export class SubSettingsComponent extends React.Component<SubSettingsComponentPr
         />
       </Stack>
     );
+  };
+
+  private getPartitionKeyValue = (): string => {
+    if (userContext.apiType === "Mongo") {
+      return this.props.collection.partitionKeyProperties?.[0] || "";
+    }
+
+    return (this.props.collection.partitionKeyProperties || []).map((property) => "/" + property).join(", ");
   };
 
   private getPartitionKeyComponent = (): JSX.Element => (

--- a/src/Explorer/Controls/Settings/SettingsSubComponents/SubSettingsComponent.tsx
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/SubSettingsComponent.tsx
@@ -66,7 +66,9 @@ export class SubSettingsComponent extends React.Component<SubSettingsComponentPr
     super(props);
     this.geospatialVisible = userContext.apiType === "SQL";
     this.partitionKeyName = userContext.apiType === "Mongo" ? "Shard key" : "Partition key";
-    this.partitionKeyValue = this.getPartitionKeyValue();
+    this.partitionKeyValue = (this.props.collection.partitionKeyProperties || [])
+      .map((property) => "/" + property)
+      .join(", ");
   }
 
   componentDidMount(): void {
@@ -249,16 +251,6 @@ export class SubSettingsComponent extends React.Component<SubSettingsComponentPr
       )}
     </Stack>
   );
-
-  private getPartitionKeyValue = (): string => {
-    const partitionKeyValueProperties = this.props.collection.partitionKeyProperties;
-    if (!partitionKeyValueProperties || partitionKeyValueProperties.length === 0) {
-      return "";
-    }
-
-    // e.g. "/pk1, /pk2, /pk3"
-    return partitionKeyValueProperties.map((property) => "/" + property).join(", ");
-  };
 
   private geoSpatialConfigTypeChoiceGroupOptions: IChoiceGroupOption[] = [
     { key: GeospatialConfigType.Geography, text: "Geography" },

--- a/src/Explorer/Controls/Settings/SettingsSubComponents/SubSettingsComponent.tsx
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/SubSettingsComponent.tsx
@@ -256,15 +256,8 @@ export class SubSettingsComponent extends React.Component<SubSettingsComponentPr
       return "";
     }
 
-    let partitionKeyValue = "/" + partitionKeyValueProperties[0];
-
-    if (partitionKeyValueProperties.length > 1) {
-      for (let i = 1; i < partitionKeyValueProperties.length; i++) {
-        partitionKeyValue += ", /" + partitionKeyValueProperties[i];
-      }
-    }
-
-    return partitionKeyValue;
+    // e.g. "/pk1, /pk2, /pk3"
+    return partitionKeyValueProperties.map((property) => "/" + property).join(", ");
   };
 
   private geoSpatialConfigTypeChoiceGroupOptions: IChoiceGroupOption[] = [

--- a/src/Explorer/Controls/Settings/TestUtils.tsx
+++ b/src/Explorer/Controls/Settings/TestUtils.tsx
@@ -39,7 +39,7 @@ export const collection = ({
     kind: "hash",
     version: 2,
   },
-  partitionKeyProperty: "partitionKey",
+  partitionKeyProperties: ["partitionKey"],
   readSettings: () => {
     return;
   },

--- a/src/Explorer/Controls/Settings/__snapshots__/SettingsComponent.test.tsx.snap
+++ b/src/Explorer/Controls/Settings/__snapshots__/SettingsComponent.test.tsx.snap
@@ -1669,7 +1669,9 @@ exports[`SettingsComponent renders 1`] = `
                 "paths": Array [],
                 "version": 2,
               },
-              "partitionKeyProperty": "partitionKey",
+              "partitionKeyProperties": Array [
+                "partitionKey",
+              ],
               "readSettings": [Function],
               "uniqueKeyPolicy": Object {},
               "usageSizeInKB": [Function],
@@ -3348,7 +3350,9 @@ exports[`SettingsComponent renders 1`] = `
                 "paths": Array [],
                 "version": 2,
               },
-              "partitionKeyProperty": "partitionKey",
+              "partitionKeyProperties": Array [
+                "partitionKey",
+              ],
               "readSettings": [Function],
               "uniqueKeyPolicy": Object {},
               "usageSizeInKB": [Function],

--- a/src/Explorer/OpenActions/OpenActions.tsx
+++ b/src/Explorer/OpenActions/OpenActions.tsx
@@ -8,23 +8,23 @@ import { CassandraAddCollectionPane } from "../Panes/CassandraAddCollectionPane/
 import { SettingsPane } from "../Panes/SettingsPane/SettingsPane";
 import { CassandraAPIDataClient } from "../Tables/TableDataClient";
 
-function generateQueryText(action: ActionContracts.OpenQueryTab, partitionKeyProperty: string): string {
+function generateQueryText(action: ActionContracts.OpenQueryTab, partitionKeyProperties: string[]): string {
   if (!action.query) {
     return "SELECT * FROM c";
   } else if (action.query.text) {
     return action.query.text;
-  } else if (!!action.query.partitionKeys && action.query.partitionKeys.length > 0) {
+  } else if (action.query.partitionKeys?.length > 0 && partitionKeyProperties?.length > 0) {
     let query = "SELECT * FROM c WHERE";
     for (let i = 0; i < action.query.partitionKeys.length; i++) {
       const partitionKey = action.query.partitionKeys[i];
       if (!partitionKey) {
         // null partition key case
-        query = query.concat(` c.${partitionKeyProperty} = ${action.query.partitionKeys[i]}`);
+        query = query.concat(` c.${partitionKeyProperties[i]} = ${action.query.partitionKeys[i]}`);
       } else if (typeof partitionKey !== "string") {
         // Undefined partition key case
-        query = query.concat(` NOT IS_DEFINED(c.${partitionKeyProperty})`);
+        query = query.concat(` NOT IS_DEFINED(c.${partitionKeyProperties[i]})`);
       } else {
-        query = query.concat(` c.${partitionKeyProperty} = "${action.query.partitionKeys[i]}"`);
+        query = query.concat(` c.${partitionKeyProperties[i]} = "${action.query.partitionKeys[i]}"`);
       }
       if (i !== action.query.partitionKeys.length - 1) {
         query = query.concat(" OR");
@@ -109,7 +109,7 @@ function openCollectionTab(
           collection.onNewQueryClick(
             collection,
             undefined,
-            generateQueryText(action as ActionContracts.OpenQueryTab, collection.partitionKeyProperty)
+            generateQueryText(action as ActionContracts.OpenQueryTab, collection.partitionKeyProperties)
           );
           break;
         }

--- a/src/Explorer/Tables/TableEntityProcessor.ts
+++ b/src/Explorer/Tables/TableEntityProcessor.ts
@@ -126,7 +126,7 @@ export function convertEntitiesToDocuments(
       };
       if (collection.partitionKey) {
         document["partitionKey"] = collection.partitionKey;
-        document[collection.partitionKeyProperty] = entity.PartitionKey._;
+        document[collection.partitionKeyProperties[0]] = entity.PartitionKey._;
         document["partitionKeyValue"] = entity.PartitionKey._;
       }
       for (var property in entity) {

--- a/src/Explorer/Tabs/ConflictsTab.ts
+++ b/src/Explorer/Tabs/ConflictsTab.ts
@@ -50,8 +50,8 @@ export default class ConflictsTab extends TabsBase {
   public splitter: Splitter;
 
   public partitionKey: DataModels.PartitionKey;
-  public partitionKeyPropertyHeaders: string[];
-  public partitionKeyProperties: string[];
+  public partitionKeyPropertyHeader: string;
+  public partitionKeyProperty: string;
   public conflictOperation: ko.Observable<string> = ko.observable<string>();
   public conflictIds: ko.ObservableArray<ConflictId>;
 
@@ -73,10 +73,11 @@ export default class ConflictsTab extends TabsBase {
     this.selectedConflictCurrent = editable.observable<any>("");
     this.partitionKey = options.partitionKey || (this.collection && this.collection.partitionKey);
     this.conflictIds = options.conflictIds;
-    this.partitionKeyPropertyHeaders = this.collection?.partitionKeyPropertyHeaders || this.partitionKey?.paths;
-    this.partitionKeyProperties = this.partitionKeyPropertyHeaders.map((partitionKeyPropertyHeader) =>
-      partitionKeyPropertyHeader.replace(/[/]+/g, ".").substring(1).replace(/[']+/g, "")
-    );
+    this.partitionKeyPropertyHeader =
+      this.collection?.partitionKeyPropertyHeaders?.[0] || this._getPartitionKeyPropertyHeader();
+    this.partitionKeyProperty = !!this.partitionKeyPropertyHeader
+      ? this.partitionKeyPropertyHeader.replace(/[/]+/g, ".").substr(1).replace(/[']+/g, "")
+      : null;
 
     this.dataContentsGridScrollHeight = ko.observable<string>(null);
 
@@ -673,5 +674,15 @@ export default class ConflictsTab extends TabsBase {
     delete jsonObject["_attachments"];
 
     return jsonObject;
+  }
+
+  private _getPartitionKeyPropertyHeader(): string {
+    return (
+      (this.partitionKey &&
+        this.partitionKey.paths &&
+        this.partitionKey.paths.length > 0 &&
+        this.partitionKey.paths[0]) ||
+      null
+    );
   }
 }

--- a/src/Explorer/Tabs/ConflictsTab.ts
+++ b/src/Explorer/Tabs/ConflictsTab.ts
@@ -50,8 +50,8 @@ export default class ConflictsTab extends TabsBase {
   public splitter: Splitter;
 
   public partitionKey: DataModels.PartitionKey;
-  public partitionKeyPropertyHeader: string;
-  public partitionKeyProperty: string;
+  public partitionKeyPropertyHeaders: string[];
+  public partitionKeyProperties: string[];
   public conflictOperation: ko.Observable<string> = ko.observable<string>();
   public conflictIds: ko.ObservableArray<ConflictId>;
 
@@ -73,11 +73,10 @@ export default class ConflictsTab extends TabsBase {
     this.selectedConflictCurrent = editable.observable<any>("");
     this.partitionKey = options.partitionKey || (this.collection && this.collection.partitionKey);
     this.conflictIds = options.conflictIds;
-    this.partitionKeyPropertyHeader =
-      (this.collection && this.collection.partitionKeyPropertyHeader) || this._getPartitionKeyPropertyHeader();
-    this.partitionKeyProperty = !!this.partitionKeyPropertyHeader
-      ? this.partitionKeyPropertyHeader.replace(/[/]+/g, ".").substr(1).replace(/[']+/g, "")
-      : null;
+    this.partitionKeyPropertyHeaders = this.collection?.partitionKeyPropertyHeaders || this.partitionKey?.paths;
+    this.partitionKeyProperties = this.partitionKeyPropertyHeaders.map((partitionKeyPropertyHeader) =>
+      partitionKeyPropertyHeader.replace(/[/]+/g, ".").substring(1).replace(/[']+/g, "")
+    );
 
     this.dataContentsGridScrollHeight = ko.observable<string>(null);
 
@@ -674,15 +673,5 @@ export default class ConflictsTab extends TabsBase {
     delete jsonObject["_attachments"];
 
     return jsonObject;
-  }
-
-  private _getPartitionKeyPropertyHeader(): string {
-    return (
-      (this.partitionKey &&
-        this.partitionKey.paths &&
-        this.partitionKey.paths.length > 0 &&
-        this.partitionKey.paths[0]) ||
-      null
-    );
   }
 }

--- a/src/Explorer/Tabs/DocumentsTab.html
+++ b/src/Explorer/Tabs/DocumentsTab.html
@@ -143,15 +143,17 @@
               <tr>
                 <th class="documentsGridHeader" data-bind="text: idHeader" tabindex="0"></th>
                 <!-- ko if: showPartitionKey -->
+                <!-- ko foreach: partitionKeyPropertyHeaders -->
                 <th
                   class="documentsGridHeader documentsGridPartition evenlySpacedHeader"
                   data-bind="
                                               attr: {
-                                                  title: partitionKeyPropertyHeader
+                                                  title: $data
                                               },
-                                              text: partitionKeyPropertyHeader"
+                                              text: $data"
                   tabindex="0"
                 ></th>
+                <!-- /ko -->
                 <!-- /ko -->
                 <th
                   class="refreshColHeader"
@@ -182,12 +184,12 @@
                 tabindex="0"
               >
                 <td class="tabdocumentsGridElement"><a data-bind="text: $data.id, attr: { title: $data.id }"></a></td>
-                <!-- ko if: $data.partitionKeyProperty -->
-                <td class="tabdocumentsGridElement" colspan="2">
-                  <a
-                    data-bind="text: $data.stringPartitionKeyValue, attr: { title: $data.stringPartitionKeyValue }"
-                  ></a>
+                <!-- ko if: $data.partitionKeyProperties -->
+                <!-- ko foreach: $data.stringPartitionKeyValues -->
+                <td class="tabdocumentsGridElement" data-bind="colspan: $parent.stringPartitionKeyValues.length + 1">
+                  <a data-bind="text: $data, attr: { title: $data }"></a>
                 </td>
+                <!-- /ko -->
                 <!-- /ko -->
               </tr>
               <!-- /ko -->

--- a/src/Explorer/Tabs/DocumentsTab.ts
+++ b/src/Explorer/Tabs/DocumentsTab.ts
@@ -91,7 +91,7 @@ export default class DocumentsTab extends TabsBase {
     this.documentIds = options.documentIds;
 
     this.partitionKeyPropertyHeaders = this.collection?.partitionKeyPropertyHeaders || this.partitionKey?.paths;
-    this.partitionKeyProperties = this.partitionKeyPropertyHeaders.map((partitionKeyPropertyHeader) =>
+    this.partitionKeyProperties = this.partitionKeyPropertyHeaders?.map((partitionKeyPropertyHeader) =>
       partitionKeyPropertyHeader.replace(/[/]+/g, ".").substring(1).replace(/[']+/g, "")
     );
 

--- a/src/Explorer/Tabs/DocumentsTab.ts
+++ b/src/Explorer/Tabs/DocumentsTab.ts
@@ -906,16 +906,6 @@ export default class DocumentsTab extends TabsBase {
     this.updateNavbarWithTabsButtons();
   }
 
-  private _getPartitionKeyPropertyHeader(): string {
-    return (
-      (this.partitionKey &&
-        this.partitionKey.paths &&
-        this.partitionKey.paths.length > 0 &&
-        this.partitionKey.paths[0]) ||
-      null
-    );
-  }
-
   public static _createUploadButton(container: Explorer): CommandButtonComponentProps {
     const label = "Upload Item";
     return {

--- a/src/Explorer/Tree/Collection.test.ts
+++ b/src/Explorer/Tree/Collection.test.ts
@@ -37,7 +37,8 @@ describe("Collection", () => {
         version: 2,
       });
       collection = generateMockCollectionWithDataModel(collectionsDataModel);
-      expect(collection.partitionKeyProperties).toBe(["somePartitionKey.anotherPartitionKey"]);
+      expect(collection.partitionKeyProperties.length).toBe(1);
+      expect(collection.partitionKeyProperties[0]).toBe("somePartitionKey.anotherPartitionKey");
     });
 
     it("should strip out forward slashes from single partition key paths", () => {
@@ -47,7 +48,8 @@ describe("Collection", () => {
         version: 2,
       });
       collection = generateMockCollectionWithDataModel(collectionsDataModel);
-      expect(collection.partitionKeyProperties).toBe(["somePartitionKey"]);
+      expect(collection.partitionKeyProperties.length).toBe(1);
+      expect(collection.partitionKeyProperties[0]).toBe("somePartitionKey");
     });
   });
 
@@ -61,7 +63,8 @@ describe("Collection", () => {
         version: 2,
       });
       collection = generateMockCollectionWithDataModel(collectionsDataModel);
-      expect(collection.partitionKeyPropertyHeaders).toBe(["/somePartitionKey/anotherPartitionKey"]);
+      expect(collection.partitionKeyPropertyHeaders.length).toBe(1);
+      expect(collection.partitionKeyPropertyHeaders[0]).toBe("/somePartitionKey/anotherPartitionKey");
     });
 
     it("should preserve forward slash on a single partition key", () => {
@@ -71,7 +74,8 @@ describe("Collection", () => {
         version: 2,
       });
       collection = generateMockCollectionWithDataModel(collectionsDataModel);
-      expect(collection.partitionKeyPropertyHeaders).toBe(["/somePartitionKey"]);
+      expect(collection.partitionKeyPropertyHeaders.length).toBe(1);
+      expect(collection.partitionKeyPropertyHeaders[0]).toBe("/somePartitionKey");
     });
 
     it("should be null if there is no partition key", () => {
@@ -81,7 +85,7 @@ describe("Collection", () => {
         kind: "Hash",
       });
       collection = generateMockCollectionWithDataModel(collectionsDataModel);
-      expect(collection.partitionKeyPropertyHeaders).toBeNull();
+      expect(collection.partitionKeyPropertyHeaders.length).toBe(0);
     });
   });
 });

--- a/src/Explorer/Tree/Collection.test.ts
+++ b/src/Explorer/Tree/Collection.test.ts
@@ -37,7 +37,7 @@ describe("Collection", () => {
         version: 2,
       });
       collection = generateMockCollectionWithDataModel(collectionsDataModel);
-      expect(collection.partitionKeyProperty).toBe("somePartitionKey.anotherPartitionKey");
+      expect(collection.partitionKeyProperties).toBe(["somePartitionKey.anotherPartitionKey"]);
     });
 
     it("should strip out forward slashes from single partition key paths", () => {
@@ -47,7 +47,7 @@ describe("Collection", () => {
         version: 2,
       });
       collection = generateMockCollectionWithDataModel(collectionsDataModel);
-      expect(collection.partitionKeyProperty).toBe("somePartitionKey");
+      expect(collection.partitionKeyProperties).toBe(["somePartitionKey"]);
     });
   });
 
@@ -61,7 +61,7 @@ describe("Collection", () => {
         version: 2,
       });
       collection = generateMockCollectionWithDataModel(collectionsDataModel);
-      expect(collection.partitionKeyPropertyHeader).toBe("/somePartitionKey/anotherPartitionKey");
+      expect(collection.partitionKeyPropertyHeaders).toBe(["/somePartitionKey/anotherPartitionKey"]);
     });
 
     it("should preserve forward slash on a single partition key", () => {
@@ -71,7 +71,7 @@ describe("Collection", () => {
         version: 2,
       });
       collection = generateMockCollectionWithDataModel(collectionsDataModel);
-      expect(collection.partitionKeyPropertyHeader).toBe("/somePartitionKey");
+      expect(collection.partitionKeyPropertyHeaders).toBe(["/somePartitionKey"]);
     });
 
     it("should be null if there is no partition key", () => {
@@ -81,7 +81,7 @@ describe("Collection", () => {
         kind: "Hash",
       });
       collection = generateMockCollectionWithDataModel(collectionsDataModel);
-      expect(collection.partitionKeyPropertyHeader).toBeNull();
+      expect(collection.partitionKeyPropertyHeaders).toBeNull();
     });
   });
 });

--- a/src/Explorer/Tree/Collection.ts
+++ b/src/Explorer/Tree/Collection.ts
@@ -135,8 +135,6 @@ export default class Collection implements ViewModels.Collection {
           partitionKeyProperty = partitionKeyProperty.replace(/.\$v/g, "").replace(/\$v./g, "");
           this.partitionKeyPropertyHeaders[i] = partitionKeyProperty;
         }
-      } else {
-        this.partitionKeyPropertyHeaders[i] = "/" + partitionKeyProperty;
       }
 
       return partitionKeyProperty;

--- a/src/Explorer/Tree/Collection.ts
+++ b/src/Explorer/Tree/Collection.ts
@@ -133,8 +133,10 @@ export default class Collection implements ViewModels.Collection {
         if (partitionKeyProperty.indexOf("$v") > -1) {
           // From $v.shard.$v.key.$v > shard.key
           partitionKeyProperty = partitionKeyProperty.replace(/.\$v/g, "").replace(/\$v./g, "");
-          this.partitionKeyPropertyHeaders[i] = "/" + partitionKeyProperty;
+          this.partitionKeyPropertyHeaders[i] = partitionKeyProperty;
         }
+      } else {
+        this.partitionKeyPropertyHeaders[i] = "/" + partitionKeyProperty;
       }
 
       return partitionKeyProperty;

--- a/src/Explorer/Tree/Collection.ts
+++ b/src/Explorer/Tree/Collection.ts
@@ -50,8 +50,8 @@ export default class Collection implements ViewModels.Collection {
   public rid: string;
   public databaseId: string;
   public partitionKey: DataModels.PartitionKey;
-  public partitionKeyPropertyHeader: string;
-  public partitionKeyProperty: string;
+  public partitionKeyPropertyHeaders: string[];
+  public partitionKeyProperties: string[];
   public id: ko.Observable<string>;
   public defaultTtl: ko.Observable<number>;
   public indexingPolicy: ko.Observable<DataModels.IndexingPolicy>;
@@ -120,31 +120,25 @@ export default class Collection implements ViewModels.Collection {
     this.requestSchema = data.requestSchema;
     this.geospatialConfig = ko.observable(data.geospatialConfig);
 
-    // TODO fix this to only replace non-excaped single quotes
-    this.partitionKeyProperty =
-      (this.partitionKey &&
-        this.partitionKey.paths &&
-        this.partitionKey.paths.length &&
-        this.partitionKey.paths.length > 0 &&
-        this.partitionKey.paths[0].replace(/[/]+/g, ".").substr(1).replace(/[']+/g, "")) ||
-      null;
-    this.partitionKeyPropertyHeader =
-      (this.partitionKey &&
-        this.partitionKey.paths &&
-        this.partitionKey.paths.length > 0 &&
-        this.partitionKey.paths[0]) ||
-      null;
+    this.partitionKeyPropertyHeaders = this.partitionKey?.paths;
+    this.partitionKeyProperties = this.partitionKeyPropertyHeaders?.map((partitionKeyPropertyHeader, i) => {
+      // TODO fix this to only replace non-excaped single quotes
+      let partitionKeyProperty = partitionKeyPropertyHeader.replace(/[/]+/g, ".").substring(1).replace(/[']+/g, "");
 
-    if (userContext.apiType === "Mongo" && this.partitionKeyProperty && ~this.partitionKeyProperty.indexOf(`"`)) {
-      this.partitionKeyProperty = this.partitionKeyProperty.replace(/["]+/g, "");
-    }
+      if (userContext.apiType === "Mongo" && partitionKeyProperty) {
+        if (~partitionKeyProperty.indexOf(`"`)) {
+          partitionKeyProperty = partitionKeyProperty.replace(/["]+/g, "");
+        }
+        // TODO #10738269 : Add this logic in a derived class for Mongo
+        if (partitionKeyProperty.indexOf("$v") > -1) {
+          // From $v.shard.$v.key.$v > shard.key
+          partitionKeyProperty = partitionKeyProperty.replace(/.\$v/g, "").replace(/\$v./g, "");
+          this.partitionKeyPropertyHeaders[i] = "/" + partitionKeyProperty;
+        }
+      }
 
-    // TODO #10738269 : Add this logic in a derived class for Mongo
-    if (userContext.apiType === "Mongo" && this.partitionKeyProperty && this.partitionKeyProperty.indexOf("$v") > -1) {
-      // From $v.shard.$v.key.$v > shard.key
-      this.partitionKeyProperty = this.partitionKeyProperty.replace(/.\$v/g, "").replace(/\$v./g, "");
-      this.partitionKeyPropertyHeader = "/" + this.partitionKeyProperty;
-    }
+      return partitionKeyProperty;
+    });
 
     this.documentIds = ko.observableArray<DocumentId>([]);
     this.isCollectionExpanded = ko.observable<boolean>(false);
@@ -471,7 +465,7 @@ export default class Collection implements ViewModels.Collection {
 
         collection: this,
         masterKey: userContext.masterKey || "",
-        collectionPartitionKeyProperty: this.partitionKeyProperty,
+        collectionPartitionKeyProperty: this.partitionKeyProperties?.[0],
         collectionId: this.id(),
         databaseId: this.databaseId,
         isTabsContentExpanded: this.container.isTabsContentExpanded,
@@ -710,7 +704,7 @@ export default class Collection implements ViewModels.Collection {
       tabPath: "",
       collection: this,
       masterKey: userContext.masterKey || "",
-      collectionPartitionKeyProperty: this.partitionKeyProperty,
+      collectionPartitionKeyProperty: this.partitionKeyProperties?.[0],
       collectionId: this.id(),
       databaseId: this.databaseId,
       isTabsContentExpanded: this.container.isTabsContentExpanded,

--- a/src/Explorer/Tree/ConflictId.ts
+++ b/src/Explorer/Tree/ConflictId.ts
@@ -150,7 +150,7 @@ export default class ConflictId {
       partitionKeyValueResolved
     );
 
-    documentId.partitionKeyProperty = this.partitionKeyProperty;
+    documentId.partitionKeyProperties = [this.partitionKeyProperty];
     documentId.partitionKey = this.partitionKey;
 
     return documentId;

--- a/src/Explorer/Tree/DocumentId.ts
+++ b/src/Explorer/Tree/DocumentId.ts
@@ -9,21 +9,21 @@ export default class DocumentId {
   public self: string;
   public ts: string;
   public id: ko.Observable<string>;
-  public partitionKeyProperty: string;
+  public partitionKeyProperties: string[];
   public partitionKey: DataModels.PartitionKey;
-  public partitionKeyValue: any;
-  public stringPartitionKeyValue: string;
+  public partitionKeyValue: any[];
+  public stringPartitionKeyValues: string[];
   public isDirty: ko.Observable<boolean>;
 
-  constructor(container: DocumentsTab, data: any, partitionKeyValue: any) {
+  constructor(container: DocumentsTab, data: any, partitionKeyValue: any[]) {
     this.container = container;
     this.self = data._self;
     this.rid = data._rid;
     this.ts = data._ts;
     this.partitionKeyValue = partitionKeyValue;
-    this.partitionKeyProperty = container && container.partitionKeyProperty;
+    this.partitionKeyProperties = container?.partitionKeyProperties;
     this.partitionKey = container && container.partitionKey;
-    this.stringPartitionKeyValue = this.getPartitionKeyValueAsString();
+    this.stringPartitionKeyValues = this.getPartitionKeyValueAsString();
     this.id = ko.observable(data.id);
     this.isDirty = ko.observable(false);
   }
@@ -46,34 +46,35 @@ export default class DocumentId {
   }
 
   public partitionKeyHeader(): Object {
-    if (!this.partitionKeyProperty) {
+    if (!this.partitionKeyProperties || this.partitionKeyProperties.length === 0) {
       return undefined;
     }
 
-    if (this.partitionKeyValue === undefined) {
+    if (!this.partitionKeyValue || this.partitionKeyValue.length === 0) {
       return [{}];
     }
 
     return [this.partitionKeyValue];
   }
 
-  public getPartitionKeyValueAsString(): string {
-    const partitionKeyValue: any = this.partitionKeyValue;
-    const typeOfPartitionKeyValue: string = typeof partitionKeyValue;
+  public getPartitionKeyValueAsString(): string[] {
+    return this.partitionKeyValue?.map((partitionKeyValue) => {
+      const typeOfPartitionKeyValue: string = typeof partitionKeyValue;
 
-    if (
-      typeOfPartitionKeyValue === "undefined" ||
-      typeOfPartitionKeyValue === "null" ||
-      typeOfPartitionKeyValue === "object"
-    ) {
-      return "";
-    }
+      if (
+        typeOfPartitionKeyValue === "undefined" ||
+        typeOfPartitionKeyValue === "null" ||
+        typeOfPartitionKeyValue === "object"
+      ) {
+        return "";
+      }
 
-    if (typeOfPartitionKeyValue === "string") {
-      return partitionKeyValue;
-    }
+      if (typeOfPartitionKeyValue === "string") {
+        return partitionKeyValue;
+      }
 
-    return JSON.stringify(partitionKeyValue);
+      return JSON.stringify(partitionKeyValue);
+    });
   }
 
   public async loadDocument(): Promise<void> {

--- a/src/Explorer/Tree/ResourceTokenCollection.ts
+++ b/src/Explorer/Tree/ResourceTokenCollection.ts
@@ -22,8 +22,8 @@ export default class ResourceTokenCollection implements ViewModels.CollectionBas
   public rid: string;
   public rawDataModel: DataModels.Collection;
   public partitionKey: DataModels.PartitionKey;
-  public partitionKeyProperty: string;
-  public partitionKeyPropertyHeader: string;
+  public partitionKeyProperties: string[];
+  public partitionKeyPropertyHeaders: string[];
   public id: ko.Observable<string>;
   public children: ko.ObservableArray<ViewModels.TreeNode>;
   public selectedSubnodeKind: ko.Observable<ViewModels.CollectionTabKind>;

--- a/src/Utils/QueryUtils.ts
+++ b/src/Utils/QueryUtils.ts
@@ -3,15 +3,16 @@ import * as ViewModels from "../Contracts/ViewModels";
 
 export function buildDocumentsQuery(
   filter: string,
-  partitionKeyProperty: string,
+  partitionKeyProperties: string[],
   partitionKey: DataModels.PartitionKey
 ): string {
-  let query = partitionKeyProperty
-    ? `select c.id, c._self, c._rid, c._ts, ${buildDocumentsQueryPartitionProjections(
-        "c",
-        partitionKey
-      )} as _partitionKeyValue from c`
-    : `select c.id, c._self, c._rid, c._ts from c`;
+  let query =
+    partitionKeyProperties && partitionKeyProperties.length > 0
+      ? `select c.id, c._self, c._rid, c._ts, [${buildDocumentsQueryPartitionProjections(
+          "c",
+          partitionKey
+        )}] as _partitionKeyValue from c`
+      : `select c.id, c._self, c._rid, c._ts from c`;
 
   if (filter) {
     query += " " + filter;


### PR DESCRIPTION
- store partition keys and values as array in `DocumentId`
- add support in documents tab to display multiple partition keys in the grid
- add `x-ms-documentdb-partitionkey` header in the request options when doing a read or update operation on documents with multiple partition key
	- **this requires the SDK to upgrade the current version to "2020-07-15"**
- for Mongo, assume the length of partition key array is 1 if it's defined

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1252?feature.someFeatureFlagYouMightNeed=true)
