### PR TITLE
Fix error when reading document with no partition key

### DIFF
--- a/src/Common/dataAccess/readDocument.ts
+++ b/src/Common/dataAccess/readDocument.ts
@@ -21,7 +21,8 @@ export const readDocument = async (collection: CollectionBase, documentId: Docum
     const response = await client()
       .database(collection.databaseId)
       .container(collection.id())
-      .item(documentId.id(), documentId.partitionKeyValue)
+      // use undefined if the partitionKeyValue is empty
+      .item(documentId.id(), documentId.partitionKeyValue?.length === 0 ? undefined : documentId.partitionKeyValue)
       .read(options);
 
     return response?.resource;


### PR DESCRIPTION
If a document has no partition key value defined, use `undefined` instead of `[]`.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1256?feature.someFeatureFlagYouMightNeed=true)
