### PR TITLE
Added support for multi line descriptions in self serve framework

### DIFF
--- a/src/Explorer/Controls/SmartUi/SmartUiComponent.tsx
+++ b/src/Explorer/Controls/SmartUi/SmartUiComponent.tsx
@@ -181,7 +181,7 @@ export class SmartUiComponent extends React.Component<SmartUiComponentProps, Sma
     const descriptionElement = (
       <Stack>
         {labelElement}
-        <Text id={`${dataFieldName}-text-display`} aria-labelledby={labelId}>
+        <Text id={`${dataFieldName}-text-display`} aria-labelledby={labelId} style={{ whiteSpace: "pre" }}>
           {this.props.getTranslation(description.textTKey)}{" "}
           {description.link && (
             <Link target="_blank" href={description.link.href}>

--- a/src/Localization/en/SelfServeExample.json
+++ b/src/Localization/en/SelfServeExample.json
@@ -7,7 +7,7 @@
     "RegionsAndAccountNameValidationError": "Regions and account name should not be empty.",
     "DbThroughputValidationError": "Please update throughput for database.",
     "DescriptionLabel": "Description",
-    "DescriptionText": "This class sets collection and database throughput.",
+    "DescriptionText": "This class sets collection and database throughput.\nTo know more -",
     "DecriptionLinkText": "Click here for more information",
     "Regions": "Regions",
     "RegionsPlaceholder": "Select a region",

--- a/src/SelfServe/Example/SelfServeExample.tsx
+++ b/src/SelfServe/Example/SelfServeExample.tsx
@@ -180,6 +180,15 @@ export default class SelfServeExample extends SelfServeBaseClass {
   description: string;
 
   @Values({
+    description: {
+      textTKey: `This UI can be used to dynamically change the throughput.
+This is an alternative to updating the throughput from the 'scale & settings' tab.`,
+      type: DescriptionType.Text,
+    },
+  })
+  multiLineDescription: string;
+
+  @Values({
     labelTKey: "Current Region",
     isDynamicDescription: true,
   })


### PR DESCRIPTION
This PR 
- adds the "pre" style to text descriptions 
- Updates the SelfServeExample to ilustrate different ways to render multiline text descriptions
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
