### PR TITLE
Fix issue with reading and saving mongo documents with shard key

### DIFF
--- a/src/Explorer/Tree/Collection.ts
+++ b/src/Explorer/Tree/Collection.ts
@@ -133,7 +133,7 @@ export default class Collection implements ViewModels.Collection {
         if (partitionKeyProperty.indexOf("$v") > -1) {
           // From $v.shard.$v.key.$v > shard.key
           partitionKeyProperty = partitionKeyProperty.replace(/.\$v/g, "").replace(/\$v./g, "");
-          this.partitionKeyPropertyHeaders[i] = partitionKeyProperty;
+          this.partitionKeyPropertyHeaders[i] = "/" + partitionKeyProperty;
         }
       }
 


### PR DESCRIPTION
We removed the "/" prefix for Mongo shard keys in this change: https://github.com/Azure/cosmos-explorer/pull/1252. This has caused some issues because other functions still assume the "/" exists. I am adding the "/" back in this PR and will work on removing it completely in a later PR.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1269?feature.someFeatureFlagYouMightNeed=true)
