### PR TITLE
ValidationErrors renamed to PhoenixErrors

### DIFF
--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -450,21 +450,21 @@ export interface IResponse<T> {
   data: T;
 }
 
-export interface IValidationError {
+export interface IPhoenixError {
   message: string;
   type: string;
 }
 
-export interface IMaxAllocationTimeExceeded extends IValidationError {
+export interface IMaxAllocationTimeExceeded extends IPhoenixError {
   earliestAllocationTimestamp: string;
   maxAllocationTimePerDayPerUserInMinutes: string;
 }
 
-export interface IMaxDbAccountsPerUserExceeded extends IValidationError {
+export interface IMaxDbAccountsPerUserExceeded extends IPhoenixError {
   maxSimultaneousConnectionsPerUser: string;
 }
 
-export interface IMaxUsersPerDbAccountExceeded extends IValidationError {
+export interface IMaxUsersPerDbAccountExceeded extends IPhoenixError {
   maxSimultaneousUsersPerDbAccount: string;
 }
 
@@ -557,4 +557,5 @@ export enum PhoenixErrorType {
   AllocationValidationResult = "AllocationValidationResult",
   RegionNotServicable = "RegionNotServicable",
   SubscriptionNotAllowed = "SubscriptionNotAllowed",
+  UnknownError = "UnknownError",
 }

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -369,9 +369,6 @@ export default class Explorer {
         });
         useNotebook.getState().setIsAllocating(true);
         connectionInfo = await this.phoenixClient.allocateContainer(provisionData);
-        if (connectionInfo.status !== HttpStatusCodes.OK) {
-          throw new Error(`Received status code: ${connectionInfo?.status}`);
-        }
         if (!connectionInfo?.data?.notebookServerUrl) {
           throw new Error(`NotebookServerUrl is invalid!`);
         }
@@ -382,6 +379,7 @@ export default class Explorer {
       } catch (error) {
         TelemetryProcessor.traceFailure(Action.PhoenixConnection, {
           dataExplorerArea: Areas.Notebook,
+          status: error.status,
           error: getErrorMessage(error),
           errorStack: getErrorStack(error),
         });


### PR DESCRIPTION
This PR
- Renames Validation error -> phoenix error
- Refactors the allocate container flow in phoenix client to better handle errors which are now all json type

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1272)
