### PR TITLE
Add another error type for user missing permissions

### DIFF
--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -563,6 +563,7 @@ export interface ContainerConnectionInfo {
 }
 
 export enum PhoenixErrorType {
+  UserMissingPermissionsError = "UserMissingPermissionsError",
   MaxAllocationTimeExceeded = "MaxAllocationTimeExceeded",
   MaxDbAccountsPerUserExceeded = "MaxDbAccountsPerUserExceeded",
   MaxUsersPerDbAccountExceeded = "MaxUsersPerDbAccountExceeded",

--- a/src/Phoenix/PhoenixClient.ts
+++ b/src/Phoenix/PhoenixClient.ts
@@ -266,6 +266,7 @@ export class PhoenixClient {
           "."
         );
       }
+      case PhoenixErrorType.UserMissingPermissionsError:
       case PhoenixErrorType.AllocationValidationResult:
       case PhoenixErrorType.RegionNotServicable:
       case PhoenixErrorType.SubscriptionNotAllowed: {


### PR DESCRIPTION
# Why is this change being made?
A new error is added in the backend for when the user doesn't have permissions to do a listkeys call. We need to handle that error in the frontend.

# What changed?
Added the error type.

# How was this validated? 
- [ ] Running locally to check that the error shows up correctly.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
