### PR TITLE
Updating SDK to 3.16.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@azure/arm-cosmosdb": "9.1.0",
-        "@azure/cosmos": "3.16.2",
+        "@azure/cosmos": "3.16.3",
         "@azure/cosmos-language-service": "0.0.5",
         "@azure/identity": "1.2.1",
         "@azure/ms-rest-nodeauth": "3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -396,12 +396,13 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@azure/cosmos": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-3.16.2.tgz",
-      "integrity": "sha512-sceY5LWj0BHGj8PSyaVCfDRQLVZyoCfIY78kyIROJVEw0k+p9XFs8fhpykN8JklkCftL0WlaVY+X25SQwnhZsw==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-3.16.3.tgz",
+      "integrity": "sha512-c+znFMHB03QjvLwUfFhASXJn02Ucg0T+sZ4iAC6y7jfjb4SEzxOt3YjvSKAdFzAQa3TMa/Yg9NJEHlRxPSk0/Q==",
       "dependencies": {
         "@azure/core-auth": "^1.3.0",
         "@azure/core-rest-pipeline": "^1.2.0",
+        "@azure/core-tracing": "^1.0.0",
         "debug": "^4.1.1",
         "fast-json-stable-stringify": "^2.1.0",
         "jsbi": "^3.1.3",
@@ -439,6 +440,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@azure/cosmos/node_modules/@azure/core-tracing": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
+      "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@azure/cosmos/node_modules/tslib": {
@@ -31458,12 +31470,13 @@
       }
     },
     "@azure/cosmos": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-3.16.2.tgz",
-      "integrity": "sha512-sceY5LWj0BHGj8PSyaVCfDRQLVZyoCfIY78kyIROJVEw0k+p9XFs8fhpykN8JklkCftL0WlaVY+X25SQwnhZsw==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-3.16.3.tgz",
+      "integrity": "sha512-c+znFMHB03QjvLwUfFhASXJn02Ucg0T+sZ4iAC6y7jfjb4SEzxOt3YjvSKAdFzAQa3TMa/Yg9NJEHlRxPSk0/Q==",
       "requires": {
         "@azure/core-auth": "^1.3.0",
         "@azure/core-rest-pipeline": "^1.2.0",
+        "@azure/core-tracing": "^1.0.0",
         "debug": "^4.1.1",
         "fast-json-stable-stringify": "^2.1.0",
         "jsbi": "^3.1.3",
@@ -31475,6 +31488,14 @@
         "uuid": "^8.3.0"
       },
       "dependencies": {
+        "@azure/core-tracing": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
+          "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
+          "requires": {
+            "tslib": "^2.2.0"
+          }
+        },
         "tslib": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "@azure/arm-cosmosdb": "9.1.0",
-    "@azure/cosmos": "3.16.2",
+    "@azure/cosmos": "3.16.3",
     "@azure/cosmos-language-service": "0.0.5",
     "@azure/identity": "1.2.1",
     "@azure/ms-rest-nodeauth": "3.0.7",


### PR DESCRIPTION
Updating Cosmos DB SDK to 3.16.3 to accommodate hotfix for allowing trailing white space in keys
