### PR TITLE
Update params for creating collection via mongo proxy

### DIFF
--- a/src/Common/MongoProxyClient.ts
+++ b/src/Common/MongoProxyClient.ts
@@ -2,7 +2,6 @@ import { Constants as CosmosSDKConstants } from "@azure/cosmos";
 import queryString from "querystring";
 import { allowedMongoProxyEndpoints, validateEndpoint } from "Utils/EndpointValidation";
 import { AuthType } from "../AuthType";
-import { configContext } from "../ConfigContext";
 import * as DataModels from "../Contracts/DataModels";
 import { MessageTypes } from "../Contracts/ExplorerContracts";
 import { Collection } from "../Contracts/ViewModels";
@@ -299,7 +298,7 @@ export function createMongoCollectionWithProxy(
     db: params.databaseId,
     coll: params.collectionId,
     pk: shardKey,
-    offerThroughput: params.offerThroughput,
+    offerThroughput: params.autoPilotMaxThroughput || params.offerThroughput,
     cd: params.createNewDatabase,
     st: params.databaseLevelThroughput,
     is: !!shardKey,
@@ -309,7 +308,6 @@ export function createMongoCollectionWithProxy(
     rg: userContext.resourceGroup,
     dba: databaseAccount.name,
     isAutoPilot: !!params.autoPilotMaxThroughput,
-    autoPilotThroughput: params.autoPilotMaxThroughput?.toString(),
   };
 
   const endpoint = getFeatureEndpointOrDefault("createCollectionWithProxy");


### PR DESCRIPTION
Due to changes in mongo proxy, we need to update the params when we try to create a mongo collection via mongo proxy. Instead of passing the autoscale max throughput as a separate param, we pass it via the `offerThroughput` param. This is safe because only one of `autoPilotMaxThroughput` and `offerThroughput` can be defined (i.e. `offerThroughput` will be undefined if autoscale is selected and vice versa).

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
