### PR TITLE
Reverting cosmos sdk to 3.16.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@azure/arm-cosmosdb": "9.1.0",
-        "@azure/cosmos": "3.16.3",
+        "@azure/cosmos": "3.16.2",
         "@azure/cosmos-language-service": "0.0.5",
         "@azure/identity": "1.2.1",
         "@azure/ms-rest-nodeauth": "3.0.7",
@@ -396,9 +396,9 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@azure/cosmos": {
-      "version": "3.16.3",
-      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-3.16.3.tgz",
-      "integrity": "sha512-c+znFMHB03QjvLwUfFhASXJn02Ucg0T+sZ4iAC6y7jfjb4SEzxOt3YjvSKAdFzAQa3TMa/Yg9NJEHlRxPSk0/Q==",
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-3.16.2.tgz",
+      "integrity": "sha512-sceY5LWj0BHGj8PSyaVCfDRQLVZyoCfIY78kyIROJVEw0k+p9XFs8fhpykN8JklkCftL0WlaVY+X25SQwnhZsw==",
       "dependencies": {
         "@azure/core-auth": "^1.3.0",
         "@azure/core-rest-pipeline": "^1.2.0",
@@ -31470,9 +31470,9 @@
       }
     },
     "@azure/cosmos": {
-      "version": "3.16.3",
-      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-3.16.3.tgz",
-      "integrity": "sha512-c+znFMHB03QjvLwUfFhASXJn02Ucg0T+sZ4iAC6y7jfjb4SEzxOt3YjvSKAdFzAQa3TMa/Yg9NJEHlRxPSk0/Q==",
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-3.16.2.tgz",
+      "integrity": "sha512-sceY5LWj0BHGj8PSyaVCfDRQLVZyoCfIY78kyIROJVEw0k+p9XFs8fhpykN8JklkCftL0WlaVY+X25SQwnhZsw==",
       "requires": {
         "@azure/core-auth": "^1.3.0",
         "@azure/core-rest-pipeline": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "@azure/arm-cosmosdb": "9.1.0",
-    "@azure/cosmos": "3.16.3",
+    "@azure/cosmos": "3.16.2",
     "@azure/cosmos-language-service": "0.0.5",
     "@azure/identity": "1.2.1",
     "@azure/ms-rest-nodeauth": "3.0.7",


### PR DESCRIPTION
Reverting cosmos sdk to 3.16.2
