### PR TITLE
Add teaching bubbles for mongo quickstart

### DIFF
--- a/src/Explorer/Controls/ThroughputInput/ThroughputInput.tsx
+++ b/src/Explorer/Controls/ThroughputInput/ThroughputInput.tsx
@@ -28,6 +28,7 @@ export const ThroughputInput: FunctionComponent<ThroughputInputProps> = ({
   isSharded,
   isFreeTier,
   showFreeTierExceedThroughputTooltip,
+  isQuickstart,
   setThroughputValue,
   setIsAutoscale,
   setIsThroughputCapExceeded,
@@ -35,7 +36,7 @@ export const ThroughputInput: FunctionComponent<ThroughputInputProps> = ({
 }: ThroughputInputProps) => {
   const [isAutoscaleSelected, setIsAutoScaleSelected] = useState<boolean>(true);
   const [throughput, setThroughput] = useState<number>(
-    isFreeTier ? AutoPilotUtils.autoPilotThroughput1K : AutoPilotUtils.autoPilotThroughput4K
+    isFreeTier || isQuickstart ? AutoPilotUtils.autoPilotThroughput1K : AutoPilotUtils.autoPilotThroughput4K
   );
   const [isCostAcknowledged, setIsCostAcknowledged] = useState<boolean>(false);
   const [throughputError, setThroughputError] = useState<string>("");

--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -346,6 +346,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                     isDatabase={true}
                     isSharded={this.state.isSharded}
                     isFreeTier={this.isFreeTierAccount()}
+                    isQuickstart={this.props.isQuickstart}
                     setThroughputValue={(throughput: number) => (this.newDatabaseThroughput = throughput)}
                     setIsAutoscale={(isAutoscale: boolean) => (this.isNewDatabaseAutoscale = isAutoscale)}
                     setIsThroughputCapExceeded={(isThroughputCapExceeded: boolean) =>
@@ -581,6 +582,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
               isDatabase={false}
               isSharded={this.state.isSharded}
               isFreeTier={this.isFreeTierAccount()}
+              isQuickstart={this.props.isQuickstart}
               setThroughputValue={(throughput: number) => (this.collectionThroughput = throughput)}
               setIsAutoscale={(isAutoscale: boolean) => (this.isCollectionAutoscale = isAutoscale)}
               setIsThroughputCapExceeded={(isThroughputCapExceeded: boolean) =>
@@ -1249,7 +1251,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
           collection.isSampleCollection = true;
           useTeachingBubble.getState().setSampleCollection(collection);
           const sampleGenerator = await ContainerSampleGenerator.createSampleGeneratorAsync(this.props.explorer);
-          await sampleGenerator.populateContainerAsync(collection);
+          await sampleGenerator.populateContainerAsync(collection, partitionKeyString);
           // auto-expand sample database + container and show teaching bubble
           await database.expandDatabase();
           collection.expandCollection();

--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -190,11 +190,8 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
         iconSrc: QuickStartIcon,
         title: "Launch quick start",
         description: "Launch a quick start tutorial to get started with sample data",
-        showLinkIcon: userContext.apiType === "Mongo",
         onClick: () => {
-          userContext.apiType === "Mongo"
-            ? window.open("http://aka.ms/mongodbquickstart", "_blank")
-            : this.container.onNewCollectionClicked({ isQuickstart: true });
+          this.container.onNewCollectionClicked({ isQuickstart: true });
           traceOpen(Action.LaunchQuickstart, { apiType: userContext.apiType });
         },
       };

--- a/src/Explorer/Tabs/DocumentsTab.ts
+++ b/src/Explorer/Tabs/DocumentsTab.ts
@@ -811,6 +811,7 @@ export default class DocumentsTab extends TabsBase {
         ariaLabel: label,
         hasPopup: false,
         disabled: !this.newDocumentButton.enabled(),
+        id: "mongoNewDocumentBtn",
       });
     }
 

--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -120,7 +120,10 @@ const CloseButton = ({
     role="button"
     aria-label="Close Tab"
     className="cancelButton"
-    onClick={() => (tab ? tab.onCloseTabButtonClick() : useTabs.getState().closeReactTab(tabKind))}
+    onClick={(event: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
+      event.stopPropagation();
+      tab ? tab.onCloseTabButtonClick() : useTabs.getState().closeReactTab(tabKind);
+    }}
     tabIndex={active ? 0 : undefined}
     onKeyPress={({ nativeEvent: e }) => tab.onKeyPressClose(undefined, e)}
   >

--- a/src/Explorer/Tree/ResourceTree.tsx
+++ b/src/Explorer/Tree/ResourceTree.tsx
@@ -531,8 +531,13 @@ export const ResourceTree: React.FC<ResourceTreeProps> = ({ container }: Resourc
     }
 
     if (userContext.apiType !== "Cassandra" || !isServerlessAccount()) {
+      let id = "";
+      if (collection.isSampleCollection) {
+        id = database.isDatabaseShared() ? "sampleSettings" : "sampleScaleSettings";
+      }
+
       children.push({
-        id: collection.isSampleCollection && !database.isDatabaseShared() ? "sampleScaleSettings" : "",
+        id,
         label: database.isDatabaseShared() || isServerlessAccount() ? "Settings" : "Scale & Settings",
         onClick: collection.onSettingsClick.bind(collection),
         isSelected: () =>

--- a/src/Explorer/Tutorials/MongoQuickstartTutorial.tsx
+++ b/src/Explorer/Tutorials/MongoQuickstartTutorial.tsx
@@ -6,7 +6,7 @@ import { Action } from "Shared/Telemetry/TelemetryConstants";
 import { traceCancel, traceSuccess } from "Shared/Telemetry/TelemetryProcessor";
 import { userContext } from "UserContext";
 
-export const QuickstartTutorial: React.FC = (): JSX.Element => {
+export const MongoQuickstartTutorial: React.FC = (): JSX.Element => {
   const { step, isSampleDBExpanded, isDocumentsTabOpened, sampleCollection, setStep } = useTeachingBubble();
 
   const onDimissTeachingBubble = (): void => {
@@ -14,7 +14,7 @@ export const QuickstartTutorial: React.FC = (): JSX.Element => {
     traceCancel(Action.CancelUITour, { step });
   };
 
-  if (userContext.apiType !== "SQL") {
+  if (userContext.apiType !== "Mongo") {
     return <></>;
   }
 
@@ -33,9 +33,9 @@ export const QuickstartTutorial: React.FC = (): JSX.Element => {
             },
           }}
           onDismiss={() => onDimissTeachingBubble()}
-          footerContent="Step 1 of 7"
+          footerContent="Step 1 of 8"
         >
-          Start viewing and working with your data by opening Items under Data
+          Start viewing and working with your data by opening Documents under Data
         </TeachingBubble>
       ) : (
         <></>
@@ -43,8 +43,8 @@ export const QuickstartTutorial: React.FC = (): JSX.Element => {
     case 2:
       return isDocumentsTabOpened ? (
         <TeachingBubble
-          headline="View item"
-          target={".queryButton"}
+          headline="View Documents"
+          target={".documentsGridHeaderContainer"}
           hasCloseButton
           primaryButtonProps={{
             text: "Next",
@@ -55,10 +55,10 @@ export const QuickstartTutorial: React.FC = (): JSX.Element => {
             onClick: () => setStep(1),
           }}
           onDismiss={() => onDimissTeachingBubble()}
-          footerContent="Step 2 of 7"
+          footerContent="Step 2 of 8"
         >
-          View item here using the items window. Additionally you can also filter items to be reviewed with the filter
-          function
+          View documents here using the documents window. You can also use your favorite MongoDB tools and drivers to do
+          so.
         </TeachingBubble>
       ) : (
         <></>
@@ -66,8 +66,8 @@ export const QuickstartTutorial: React.FC = (): JSX.Element => {
     case 3:
       return (
         <TeachingBubble
-          headline="Add new item"
-          target={"#uploadItemBtn"}
+          headline="Add new document"
+          target={"#mongoNewDocumentBtn"}
           hasCloseButton
           primaryButtonProps={{
             text: "Next",
@@ -78,16 +78,17 @@ export const QuickstartTutorial: React.FC = (): JSX.Element => {
             onClick: () => setStep(2),
           }}
           onDismiss={() => onDimissTeachingBubble()}
-          footerContent="Step 3 of 7"
+          footerContent="Step 3 of 8"
         >
-          Add new item by copy / pasting JSON; or uploading a JSON
+          Add new document by copy / pasting JSON or uploading a JSON. You can also use your favorite MongoDB tools and
+          drivers to do so.
         </TeachingBubble>
       );
     case 4:
       return (
         <TeachingBubble
           headline="Run a query"
-          target={"#newQueryBtn"}
+          target={".querydropdown"}
           hasCloseButton
           primaryButtonProps={{
             text: "Next",
@@ -98,9 +99,10 @@ export const QuickstartTutorial: React.FC = (): JSX.Element => {
             onClick: () => setStep(3),
           }}
           onDismiss={() => onDimissTeachingBubble()}
-          footerContent="Step 4 of 7"
+          footerContent="Step 4 of 8"
         >
-          Query your data using either the filter function or new query.
+          Query your data using the filter function. Azure Cosmos DB API for MongoDB provides comprehensive support for
+          MongoDB query language constructs. You can also use your favorite MongoDB tools and drivers to do so.
         </TeachingBubble>
       );
     case 5:
@@ -118,16 +120,16 @@ export const QuickstartTutorial: React.FC = (): JSX.Element => {
             onClick: () => setStep(4),
           }}
           onDismiss={() => onDimissTeachingBubble()}
-          footerContent="Step 5 of 7"
+          footerContent="Step 5 of 8"
         >
-          Change throughput provisioned to your container according to your needs
+          Change throughput provisioned to your collection according to your needs
         </TeachingBubble>
       );
     case 6:
       return (
         <TeachingBubble
-          headline="Create notebook"
-          target={"#newNotebookBtn"}
+          headline="Indexing Policy"
+          target={"#sampleSettings"}
           hasCloseButton
           primaryButtonProps={{
             text: "Next",
@@ -138,12 +140,32 @@ export const QuickstartTutorial: React.FC = (): JSX.Element => {
             onClick: () => setStep(5),
           }}
           onDismiss={() => onDimissTeachingBubble()}
-          footerContent="Step 6 of 7"
+          footerContent="Step 6 of 8"
+        >
+          Use the indexing policy editor to create and edit your indexes.
+        </TeachingBubble>
+      );
+    case 7:
+      return (
+        <TeachingBubble
+          headline="Create notebook"
+          target={"#newNotebookBtn"}
+          hasCloseButton
+          primaryButtonProps={{
+            text: "Next",
+            onClick: () => setStep(8),
+          }}
+          secondaryButtonProps={{
+            text: "Previous",
+            onClick: () => setStep(6),
+          }}
+          onDismiss={() => onDimissTeachingBubble()}
+          footerContent="Step 7 of 8"
         >
           Visualize your data, store queries in an interactive document
         </TeachingBubble>
       );
-    case 7:
+    case 8:
       return (
         <TeachingBubble
           headline="Congratulations!"
@@ -158,10 +180,10 @@ export const QuickstartTutorial: React.FC = (): JSX.Element => {
           }}
           secondaryButtonProps={{
             text: "Previous",
-            onClick: () => setStep(6),
+            onClick: () => setStep(7),
           }}
           onDismiss={() => onDimissTeachingBubble()}
-          footerContent="Step 7 of 7"
+          footerContent="Step 8 of 8"
         >
           <Stack>
             <Text style={{ color: "white" }}>

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,6 +1,7 @@
 // CSS Dependencies
 import { initializeIcons } from "@fluentui/react";
 import "bootstrap/dist/css/bootstrap.css";
+import { MongoQuickstartTutorial } from "Explorer/Tutorials/MongoQuickstartTutorial";
 import { QuickstartCarousel } from "Explorer/Tutorials/QuickstartCarousel";
 import { QuickstartTutorial } from "Explorer/Tutorials/QuickstartTutorial";
 import { useCarousel } from "hooks/useCarousel";
@@ -116,6 +117,7 @@ const App: React.FunctionComponent = () => {
       <Dialog />
       {<QuickstartCarousel isOpen={isCarouselOpen} />}
       {<QuickstartTutorial />}
+      {<MongoQuickstartTutorial />}
     </div>
   );
 };

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -42,9 +42,7 @@ export const useTabs: UseStore<TabsState> = create((set, get) => ({
     set((state) => ({ openedTabs: [...state.openedTabs, tab], activeTab: tab, activeReactTab: undefined }));
     tab.onActivate();
   },
-  activateReactTab: (tabKind: ReactTabKind): void => {
-    set({ activeTab: undefined, activeReactTab: tabKind });
-  },
+  activateReactTab: (tabKind: ReactTabKind): void => set({ activeTab: undefined, activeReactTab: tabKind }),
   updateTab: (tab: TabsBase) => {
     if (get().activeTab?.tabId === tab.tabId) {
       set({ activeTab: tab });

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -42,7 +42,9 @@ export const useTabs: UseStore<TabsState> = create((set, get) => ({
     set((state) => ({ openedTabs: [...state.openedTabs, tab], activeTab: tab, activeReactTab: undefined }));
     tab.onActivate();
   },
-  activateReactTab: (tabKind: ReactTabKind): void => set({ activeTab: undefined, activeReactTab: tabKind }),
+  activateReactTab: (tabKind: ReactTabKind): void => {
+    set({ activeTab: undefined, activeReactTab: tabKind });
+  },
   updateTab: (tab: TabsBase) => {
     if (get().activeTab?.tabId === tab.tabId) {
       set({ activeTab: tab });
@@ -132,12 +134,13 @@ export const useTabs: UseStore<TabsState> = create((set, get) => ({
   },
   closeReactTab: (tabKind: ReactTabKind) => {
     const { activeReactTab, openedTabs, openedReactTabs } = get();
+    const updatedOpenedReactTabs = openedReactTabs.filter((tab: ReactTabKind) => tabKind !== tab);
     if (activeReactTab === tabKind) {
       openedTabs?.length > 0
         ? set({ activeTab: openedTabs[0], activeReactTab: undefined })
-        : set({ activeTab: undefined, activeReactTab: openedReactTabs[0] });
+        : set({ activeTab: undefined, activeReactTab: updatedOpenedReactTabs[0] });
     }
 
-    set({ openedReactTabs: openedReactTabs.filter((tab: ReactTabKind) => tabKind !== tab) });
+    set({ openedReactTabs: updatedOpenedReactTabs });
   },
 }));


### PR DESCRIPTION
- changed the "Launch quickstart" button to open add collection panel with pre-filled values
- made the SampleGenerator work with Mongo API
- changed the autoscale throughput value for SampleDB from 4000 to 1000
- added set of teaching bubbles after the SampleDB is created
- fixed a bug where closing the Connect tab does not automatically activates the Home tab

Figma: https://www.figma.com/file/m6MTakDdn9hhZWmAN9H4mG/COSP-5x5?node-id=1533%3A195809

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1313?feature.someFeatureFlagYouMightNeed=true)
