### PR TITLE
Whitelist AGC endpoint in data explorer

### DIFF
--- a/src/Utils/EndpointValidation.ts
+++ b/src/Utils/EndpointValidation.ts
@@ -50,6 +50,7 @@ export const allowedBackendEndpoints: ReadonlyArray<string> = [
   "https://main.documentdb.ext.azure.com",
   "https://main.documentdb.ext.azure.cn",
   "https://main.documentdb.ext.azure.us",
+  "https://main.cosmos.ext.azure",
   "https://localhost:12901",
   "https://localhost:1234",
 ];
@@ -58,6 +59,7 @@ export const allowedMongoProxyEndpoints: ReadonlyArray<string> = [
   "https://main.documentdb.ext.azure.com",
   "https://main.documentdb.ext.azure.cn",
   "https://main.documentdb.ext.azure.us",
+  "https://main.cosmos.ext.azure",
   "https://localhost:12901",
 ];
 


### PR DESCRIPTION
Add AGC endpoint "https://main.cosmos.ext.azure" to the allowed endpoints list

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
