### PR TITLE
Moved notebooks to latest API version

### DIFF
--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -481,6 +481,10 @@ export interface IMaxUsersPerDbAccountExceeded extends IPhoenixError {
 }
 
 export interface IPhoenixConnectionInfoResult {
+  readonly phoenixServiceInfo?: IPhoenixServiceInfo;
+}
+
+export interface IPhoenixServiceInfo {
   readonly authToken?: string;
   readonly phoenixServiceUrl?: string;
   readonly forwardingId?: string;

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -16,12 +16,7 @@ import { getErrorMessage, getErrorStack, handleError } from "../Common/ErrorHand
 import * as Logger from "../Common/Logger";
 import { QueriesClient } from "../Common/QueriesClient";
 import * as DataModels from "../Contracts/DataModels";
-import {
-  ContainerConnectionInfo,
-  IPhoenixConnectionInfoResult,
-  IProvisionData,
-  IResponse,
-} from "../Contracts/DataModels";
+import { ContainerConnectionInfo, IPhoenixServiceInfo, IProvisionData, IResponse } from "../Contracts/DataModels";
 import * as ViewModels from "../Contracts/ViewModels";
 import { GitHubOAuthService } from "../GitHub/GitHubOAuthService";
 import { useSidePanel } from "../hooks/useSidePanel";
@@ -407,7 +402,7 @@ export default class Explorer {
   }
 
   private async setNotebookInfo(
-    connectionInfo: IResponse<IPhoenixConnectionInfoResult>,
+    connectionInfo: IResponse<IPhoenixServiceInfo>,
     connectionStatus: DataModels.ContainerConnectionInfo
   ) {
     const containerData = {

--- a/src/Explorer/Notebook/NotebookContainerClient.ts
+++ b/src/Explorer/Notebook/NotebookContainerClient.ts
@@ -9,7 +9,7 @@ import { ConnectionStatusType, HttpHeaders, HttpStatusCodes, Notebook, PoolIdTyp
 import { getErrorMessage } from "../../Common/ErrorHandlingUtils";
 import * as Logger from "../../Common/Logger";
 import * as DataModels from "../../Contracts/DataModels";
-import { IPhoenixConnectionInfoResult, IProvisionData, IResponse } from "../../Contracts/DataModels";
+import { IPhoenixServiceInfo, IProvisionData, IResponse } from "../../Contracts/DataModels";
 import { userContext } from "../../UserContext";
 import { getAuthorizationHeader } from "../../Utils/AuthorizationUtils";
 import { logConsoleProgress } from "../../Utils/NotificationConsoleUtils";
@@ -129,9 +129,9 @@ export class NotebookContainerClient {
     );
   }
 
-  public async resetWorkspace(): Promise<IResponse<IPhoenixConnectionInfoResult>> {
+  public async resetWorkspace(): Promise<IResponse<IPhoenixServiceInfo>> {
     this.isResettingWorkspace = true;
-    let response: IResponse<IPhoenixConnectionInfoResult>;
+    let response: IResponse<IPhoenixServiceInfo>;
     try {
       response = await this._resetWorkspace();
     } catch (error) {
@@ -142,7 +142,7 @@ export class NotebookContainerClient {
     return response;
   }
 
-  private async _resetWorkspace(): Promise<IResponse<IPhoenixConnectionInfoResult>> {
+  private async _resetWorkspace(): Promise<IResponse<IPhoenixServiceInfo>> {
     const notebookServerInfo = useNotebook.getState().notebookServerInfo;
     if (!notebookServerInfo || !notebookServerInfo.notebookServerEndpoint) {
       const error = "No server endpoint detected";

--- a/src/Phoenix/PhoenixClient.ts
+++ b/src/Phoenix/PhoenixClient.ts
@@ -60,10 +60,10 @@ export class PhoenixClient {
       });
       const responseJson = await response?.json();
       if (response.ok) {
-        let phoenixConnectionInfoResult = responseJson as IPhoenixConnectionInfoResult[];
+        const phoenixConnectionInfoResult = responseJson as IPhoenixConnectionInfoResult[];
         if (
           !phoenixConnectionInfoResult ||
-          phoenixConnectionInfoResult.length == 0 ||
+          phoenixConnectionInfoResult.length === 0 ||
           !phoenixConnectionInfoResult[0]
         ) {
           throw new Error("Received invalid phoenix connection response.");

--- a/src/Phoenix/PhoenixClient.ts
+++ b/src/Phoenix/PhoenixClient.ts
@@ -21,6 +21,7 @@ import {
   IMaxAllocationTimeExceeded,
   IPhoenixConnectionInfoResult,
   IPhoenixError,
+  IPhoenixServiceInfo,
   IProvisionData,
   IResponse,
   PhoenixErrorType,
@@ -38,30 +39,38 @@ export class PhoenixClient {
     minTimeout: Notebook.retryAttemptDelayMs,
   };
 
-  public async allocateContainer(provisionData: IProvisionData): Promise<IResponse<IPhoenixConnectionInfoResult>> {
+  public async allocateContainer(provisionData: IProvisionData): Promise<IResponse<IPhoenixServiceInfo>> {
     return this.executeContainerAssignmentOperation(provisionData, "allocate");
   }
 
-  public async resetContainer(provisionData: IProvisionData): Promise<IResponse<IPhoenixConnectionInfoResult>> {
+  public async resetContainer(provisionData: IProvisionData): Promise<IResponse<IPhoenixServiceInfo>> {
     return this.executeContainerAssignmentOperation(provisionData, "reset");
   }
 
   private async executeContainerAssignmentOperation(
     provisionData: IProvisionData,
     operation: string
-  ): Promise<IResponse<IPhoenixConnectionInfoResult>> {
+  ): Promise<IResponse<IPhoenixServiceInfo>> {
     let response;
     try {
-      response = await fetch(`${this.getPhoenixControlPlanePathPrefix()}/containerconnections`, {
+      response = await fetch(`${this.getPhoenixControlPlanePathPrefix()}/containerconnections/multicontainer`, {
         method: operation === "allocate" ? "POST" : "PATCH",
         headers: PhoenixClient.getHeaders(),
         body: JSON.stringify(provisionData),
       });
       const responseJson = await response?.json();
       if (response.ok) {
+        let phoenixConnectionInfoResult = responseJson as IPhoenixConnectionInfoResult[];
+        if (
+          !phoenixConnectionInfoResult ||
+          phoenixConnectionInfoResult.length == 0 ||
+          !phoenixConnectionInfoResult[0]
+        ) {
+          throw new Error("Received invalid phoenix connection response.");
+        }
         return {
           status: response.status,
-          data: responseJson,
+          data: phoenixConnectionInfoResult[0].phoenixServiceInfo,
         };
       }
       const phoenixError = responseJson as IPhoenixError;


### PR DESCRIPTION
For graphql, we changed the create and reset workspace APIs to return an array of allocated servers instead of just one.
This PR migrates Notebooks also to this new API response.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1320)
