### PR TITLE
Properly load a postgres account in data explorer

### DIFF
--- a/src/Contracts/ViewModels.ts
+++ b/src/Contracts/ViewModels.ts
@@ -395,6 +395,7 @@ export interface DataExplorerInputsFrame {
   sharedThroughputDefault?: number;
   dataExplorerVersion?: string;
   defaultCollectionThroughput?: CollectionCreationDefaults;
+  isPostgresAccount?: boolean;
   flights?: readonly string[];
   features?: {
     [key: string]: string;

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -185,7 +185,7 @@ export default class Explorer {
       useNotebook.getState().setNotebookBasePath(userContext.features.notebookBasePath);
     }
 
-    if (!userContext.features.enablePGQuickstart || userContext.apiType !== "Postgres") {
+    if (userContext.apiType !== "Postgres") {
       this.refreshExplorer();
     }
   }

--- a/src/Explorer/Menus/CommandBar/CommandBarComponentAdapter.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarComponentAdapter.tsx
@@ -34,7 +34,7 @@ export const CommandBar: React.FC<Props> = ({ container }: Props) => {
   const buttons = useCommandBar((state) => state.contextButtons);
   const backgroundColor = StyleConstants.BaseLight;
 
-  if (userContext.features.enablePGQuickstart && userContext.apiType === "Postgres") {
+  if (userContext.apiType === "Postgres") {
     const buttons = CommandBarComponentButtonFactory.createPostgreButtons(container);
     return (
       <div className="commandBarContainer">

--- a/src/Platform/Hosted/extractFeatures.ts
+++ b/src/Platform/Hosted/extractFeatures.ts
@@ -29,7 +29,6 @@ export type Features = {
   readonly mongoProxyEndpoint?: string;
   readonly mongoProxyAPIs?: string;
   readonly enableThroughputCap: boolean;
-  readonly enablePGQuickstart: boolean;
 
   // can be set via both flight and feature flag
   autoscaleDefault: boolean;
@@ -91,7 +90,6 @@ export function extractFeatures(given = new URLSearchParams(window.location.sear
     partitionKeyDefault2: "true" === get("pkpartitionkeytest"),
     notebooksDownBanner: "true" === get("notebooksDownBanner"),
     enableThroughputCap: "true" === get("enablethroughputcap"),
-    enablePGQuickstart: "true" === get("enablepgquickstart"),
   };
 }
 

--- a/src/UserContext.ts
+++ b/src/UserContext.ts
@@ -112,10 +112,6 @@ function apiType(account: DatabaseAccount | undefined): ApiType {
     return "SQL";
   }
 
-  if (features.enablePGQuickstart) {
-    return "Postgres";
-  }
-
   const capabilities = account.properties?.capabilities;
   if (capabilities) {
     if (capabilities.find((c) => c.name === "EnableCassandra")) {
@@ -138,3 +134,4 @@ function apiType(account: DatabaseAccount | undefined): ApiType {
 }
 
 export { userContext, updateUserContext };
+

--- a/src/UserContext.ts
+++ b/src/UserContext.ts
@@ -134,4 +134,3 @@ function apiType(account: DatabaseAccount | undefined): ApiType {
 }
 
 export { userContext, updateUserContext };
-

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -354,9 +354,15 @@ function updateContextsFromPortalMessage(inputs: DataExplorerInputsFrame) {
     collectionCreationDefaults: inputs.defaultCollectionThroughput,
     isTryCosmosDBSubscription: inputs.isTryCosmosDBSubscription,
   });
+
+  if (inputs.isPostgresAccount) {
+    updateUserContext({ apiType: "Postgres" });
+  }
+
   if (inputs.features) {
     Object.assign(userContext.features, extractFeatures(new URLSearchParams(inputs.features)));
   }
+
   if (inputs.flights) {
     if (inputs.flights.indexOf(Flights.AutoscaleTest) !== -1) {
       userContext.features.autoscaleDefault;


### PR DESCRIPTION
- set the API type to "Postgres" if `inputs.isPostgresAccount` is true
- remove `enablePGQuickstart` feature flag and replace it by checking if the APIType === "Postgres"

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1323?feature.someFeatureFlagYouMightNeed=true)
