### PR TITLE
Add retries when checking if account is allowed to access phoenix

### DIFF
--- a/src/Explorer/Notebook/useNotebook.ts
+++ b/src/Explorer/Notebook/useNotebook.ts
@@ -1,6 +1,5 @@
 import { isPublicInternetAccessAllowed } from "Common/DatabaseAccountUtility";
 import { cloneDeep } from "lodash";
-import promiseRetry from "p-retry";
 import { PhoenixClient } from "Phoenix/PhoenixClient";
 import create, { UseStore } from "zustand";
 import { AuthType } from "../../AuthType";
@@ -310,11 +309,7 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
 
       const isPublicInternetAllowed = isPublicInternetAccessAllowed();
       const phoenixClient = new PhoenixClient(userContext?.databaseAccount?.id);
-      const dbAccountAllowedInfo = await promiseRetry(() => phoenixClient.getDbAccountAllowedStatus(), {
-        retries: 10,
-        maxTimeout: 5000,
-        minTimeout: 5000,
-      });
+      const dbAccountAllowedInfo = await phoenixClient.getDbAccountAllowedStatus();
 
       if (dbAccountAllowedInfo.status === HttpStatusCodes.OK) {
         if (dbAccountAllowedInfo?.type === PhoenixErrorType.PhoenixFlightFallback) {

--- a/src/Explorer/Notebook/useNotebook.ts
+++ b/src/Explorer/Notebook/useNotebook.ts
@@ -1,5 +1,6 @@
 import { isPublicInternetAccessAllowed } from "Common/DatabaseAccountUtility";
 import { cloneDeep } from "lodash";
+import promiseRetry from "p-retry";
 import { PhoenixClient } from "Phoenix/PhoenixClient";
 import create, { UseStore } from "zustand";
 import { AuthType } from "../../AuthType";
@@ -309,7 +310,11 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
 
       const isPublicInternetAllowed = isPublicInternetAccessAllowed();
       const phoenixClient = new PhoenixClient(userContext?.databaseAccount?.id);
-      const dbAccountAllowedInfo = await phoenixClient.getDbAccountAllowedStatus();
+      const dbAccountAllowedInfo = await promiseRetry(() => phoenixClient.getDbAccountAllowedStatus(), {
+        retries: 10,
+        maxTimeout: 5000,
+        minTimeout: 5000,
+      });
 
       if (dbAccountAllowedInfo.status === HttpStatusCodes.OK) {
         if (dbAccountAllowedInfo?.type === PhoenixErrorType.PhoenixFlightFallback) {

--- a/src/Explorer/Quickstart/QuickstartGuide.tsx
+++ b/src/Explorer/Quickstart/QuickstartGuide.tsx
@@ -96,12 +96,18 @@ export const QuickstartGuide: React.FC = (): JSX.Element => {
       <Stack style={{ flexGrow: 1, padding: "0 20px", overflow: "auto" }}>
         <Text variant="xxLarge">Quick start guide</Text>
         {currentStep < 5 && (
-          <Pivot style={{ marginTop: 10, width: "100%" }} selectedKey={GuideSteps[currentStep]}>
+          <Pivot
+            style={{ marginTop: 10, width: "100%" }}
+            selectedKey={GuideSteps[currentStep]}
+            onLinkClick={(item?: PivotItem) => setCurrentStep(Object.values(GuideSteps).indexOf(item.props.itemKey))}
+          >
             <PivotItem
               headerText="Login"
               onRenderItemLink={(props, defaultRenderer) => customPivotHeaderRenderer(props, defaultRenderer, 0)}
               itemKey={GuideSteps[0]}
-              onClick={() => setCurrentStep(0)}
+              onClick={() => {
+                setCurrentStep(0);
+              }}
             >
               <Stack style={{ marginTop: 20 }}>
                 <Text>

--- a/src/Explorer/Tabs/QuickstartTab.tsx
+++ b/src/Explorer/Tabs/QuickstartTab.tsx
@@ -1,4 +1,4 @@
-import { Spinner, SpinnerSize, Stack } from "@fluentui/react";
+import { Spinner, SpinnerSize, Stack, Text } from "@fluentui/react";
 import { configContext } from "ConfigContext";
 import { NotebookWorkspaceConnectionInfo, PostgresFirewallRule } from "Contracts/DataModels";
 import { NotebookTerminalComponent } from "Explorer/Controls/Notebook/NotebookTerminalComponent";
@@ -69,7 +69,15 @@ export const QuickstartTab: React.FC<QuickstartTabProps> = ({ explorer }: Quicks
           />
         )}
         {isAllPublicIPAddressEnabled && !notebookServerInfo?.notebookServerEndpoint && (
-          <Spinner styles={{ root: { marginTop: 10 } }} size={SpinnerSize.large}></Spinner>
+          <Stack style={{ margin: "auto 0" }}>
+            <Text block style={{ margin: "auto" }}>
+              Connecting to the PostgreSQL shell.
+            </Text>
+            <Text block style={{ margin: "auto" }}>
+              If the cluster was just created, this could take up to a minute.
+            </Text>
+            <Spinner styles={{ root: { marginTop: 16 } }} size={SpinnerSize.large}></Spinner>
+          </Stack>
         )}
       </Stack>
     </Stack>

--- a/src/Terminal/JupyterLabAppFactory.ts
+++ b/src/Terminal/JupyterLabAppFactory.ts
@@ -81,6 +81,9 @@ export class JupyterLabAppFactory {
     // Attach the widget to the dom.
     Widget.attach(panel, document.body);
 
+    // Switch focus to the terminal
+    term.activate();
+
     // Handle resize events.
     window.addEventListener("resize", () => {
       panel.update();


### PR DESCRIPTION
When a free tier account is just created, it's possible that the permissions have not been propogated, causing the `getDbAccountAllowedStatus` call to fail. This fix adds a retry logic to the request with a maximum retry count of 10 and a 5 seconds retry interval.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1342?feature.someFeatureFlagYouMightNeed=true)
