### PR TITLE
Hide launch quick start button and postgres teaching bubbles if account is a replica

### DIFF
--- a/src/Contracts/ViewModels.ts
+++ b/src/Contracts/ViewModels.ts
@@ -397,6 +397,7 @@ export interface DataExplorerInputsFrame {
   dataExplorerVersion?: string;
   defaultCollectionThroughput?: CollectionCreationDefaults;
   isPostgresAccount?: boolean;
+  isReplica?: boolean;
   // TODO: Update this param in the OSS extension to remove isFreeTier, isMarlinServerGroup, and make nodes a flat array instead of an nested array
   connectionStringParams?: any;
   flights?: readonly string[];

--- a/src/Explorer/SplashScreen/SplashScreen.less
+++ b/src/Explorer/SplashScreen/SplashScreen.less
@@ -14,10 +14,6 @@
     padding-right: 16px;
     max-width: 1168px;
 
-    > * {
-      justify-content: space-between;
-    }
-
     > .title {
       position: relative; // To attach FeaturePanelLauncher as absolute
       color: @BaseHigh;

--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -304,7 +304,11 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
   public createMainItems(): SplashScreenItem[] {
     const heroes: SplashScreenItem[] = [];
 
-    if (userContext.apiType === "SQL" || userContext.apiType === "Mongo" || userContext.apiType === "Postgres") {
+    if (
+      userContext.apiType === "SQL" ||
+      userContext.apiType === "Mongo" ||
+      (userContext.apiType === "Postgres" && !userContext.isReplica)
+    ) {
       const launchQuickstartBtn = {
         id: "quickstartDescription",
         iconSrc: QuickStartIcon,

--- a/src/UserContext.ts
+++ b/src/UserContext.ts
@@ -67,6 +67,7 @@ interface UserContext {
     partitionKey?: string;
   };
   readonly postgresConnectionStrParams?: PostgresConnectionStrParams;
+  readonly isReplica?: boolean;
   collectionCreationDefaults: CollectionCreationDefaults;
 }
 
@@ -110,7 +111,7 @@ function updateUserContext(newContext: Partial<UserContext>): void {
 
     if (!localStorage.getItem(newContext.databaseAccount.id)) {
       if (newContext.isTryCosmosDBSubscription || isNewAccount) {
-        if (newContext.apiType === "Postgres") {
+        if (newContext.apiType === "Postgres" && !newContext.isReplica) {
           usePostgres.getState().setShowResetPasswordBubble(true);
           usePostgres.getState().setShowPostgreTeachingBubble(true);
         } else {

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -364,7 +364,7 @@ function updateContextsFromPortalMessage(inputs: DataExplorerInputsFrame) {
   });
 
   if (inputs.isPostgresAccount) {
-    updateUserContext({ apiType: "Postgres" });
+    updateUserContext({ apiType: "Postgres", isReplica: !!inputs.isReplica });
 
     if (inputs.connectionStringParams) {
       // TODO: Remove after the nodes param has been updated to be a flat array in the OSS extension


### PR DESCRIPTION
Hide launch quick start button and postgres teaching bubbles if account is a replica
![image](https://user-images.githubusercontent.com/56978073/196313662-033959a9-8226-4e32-a6a3-8cd0bbb69d59.png)

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1344)
