### PR TITLE
Support new auth token format

### DIFF
--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -78,8 +78,19 @@ export enum ApiKind {
 }
 
 export interface GenerateTokenResponse {
+  readWritePrimary: string;
+  readWriteSecondary: string;
+}
+
+export interface GenerateTokenResponse2 {
   readWrite: string;
   read: string;
+}
+
+export interface EncryptedAccessToken {
+  version: 1 | 2;
+  primaryToken: string;
+  secondaryToken: string;
 }
 
 export interface Subscription {

--- a/src/HostedExplorer.tsx
+++ b/src/HostedExplorer.tsx
@@ -5,7 +5,7 @@ import { render } from "react-dom";
 import ChevronRight from "../images/chevron-right.svg";
 import "../less/hostedexplorer.less";
 import { AuthType } from "./AuthType";
-import { DatabaseAccount } from "./Contracts/DataModels";
+import { DatabaseAccount, EncryptedAccessToken } from "./Contracts/DataModels";
 import "./Explorer/Menus/NavBar/MeControlComponent.less";
 import { useAADAuth } from "./hooks/useAADAuth";
 import { useConfig } from "./hooks/useConfig";
@@ -25,8 +25,7 @@ initializeIcons();
 
 const App: React.FunctionComponent = () => {
   // For handling encrypted portal tokens sent via query paramter
-  const params = new URLSearchParams(window.location.search);
-  const [encryptedToken, setEncryptedToken] = React.useState<string>(params && params.get("key"));
+  const [encryptedToken, setEncryptedToken] = React.useState<EncryptedAccessToken>();
   const encryptedTokenMetadata = useTokenMetadata(encryptedToken);
 
   // For showing/hiding panel

--- a/src/HostedExplorerChildFrame.ts
+++ b/src/HostedExplorerChildFrame.ts
@@ -1,5 +1,5 @@
 import { AuthType } from "./AuthType";
-import { AccessInputMetadata, DatabaseAccount } from "./Contracts/DataModels";
+import { AccessInputMetadata, DatabaseAccount, EncryptedAccessToken } from "./Contracts/DataModels";
 
 type HostedConfig = AAD | ConnectionString | EncryptedToken | ResourceToken;
 export interface HostedExplorerChildFrame extends Window {
@@ -15,7 +15,7 @@ export interface AAD {
 export interface ConnectionString {
   authType: AuthType.ConnectionString;
   // Connection string uses still use encrypted token for Cassandra/Mongo APIs as they us the portal backend proxy
-  encryptedToken: string;
+  encryptedToken: EncryptedAccessToken;
   encryptedTokenMetadata: AccessInputMetadata;
   // Master key is currently only used by Graph API. All other APIs use encrypted tokens and proxy with connection string
   masterKey?: string;

--- a/src/HostedExplorerChildFrame.ts
+++ b/src/HostedExplorerChildFrame.ts
@@ -23,7 +23,7 @@ export interface ConnectionString {
 
 export interface EncryptedToken {
   authType: AuthType.EncryptedToken;
-  encryptedToken: string;
+  encryptedToken: EncryptedAccessToken;
   encryptedTokenMetadata: AccessInputMetadata;
 }
 

--- a/src/Platform/Hosted/Components/ConnectExplorer.tsx
+++ b/src/Platform/Hosted/Components/ConnectExplorer.tsx
@@ -55,11 +55,18 @@ export const ConnectExplorer: React.FunctionComponent<Props> = ({
                 const result: GenerateTokenResponse | GenerateTokenResponse2 = JSON.parse(await response.json());
                 if ("readWrite" in result) {
                   // V1 Token encryption (to be deprecated)
-                  setEncryptedToken({version: 1, primaryToken: decodeURIComponent(result.readWrite || result.read), secondaryToken: ""});
-                }
-                else {
+                  setEncryptedToken({
+                    version: 1,
+                    primaryToken: decodeURIComponent(result.readWrite || result.read),
+                    secondaryToken: "",
+                  });
+                } else {
                   // V2 Token encryption
-                  setEncryptedToken({version: 2, primaryToken: result.readWritePrimary, secondaryToken: result.readWriteSecondary});
+                  setEncryptedToken({
+                    version: 2,
+                    primaryToken: result.readWritePrimary,
+                    secondaryToken: result.readWriteSecondary,
+                  });
                 }
                 setAuthType(AuthType.ConnectionString);
               }}

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -18,14 +18,14 @@ import {
   ConnectionString,
   EncryptedToken,
   HostedExplorerChildFrame,
-  ResourceToken,
+  ResourceToken
 } from "../HostedExplorerChildFrame";
 import { emulatorAccount } from "../Platform/Emulator/emulatorAccount";
 import { extractFeatures } from "../Platform/Hosted/extractFeatures";
 import { parseResourceTokenConnectionString } from "../Platform/Hosted/Helpers/ResourceTokenUtils";
 import {
   getDatabaseAccountKindFromExperience,
-  getDatabaseAccountPropertiesFromMetadata,
+  getDatabaseAccountPropertiesFromMetadata
 } from "../Platform/Hosted/HostedUtils";
 import { CollectionCreation } from "../Shared/Constants";
 import { DefaultExperienceUtility } from "../Shared/DefaultExperienceUtility";
@@ -175,7 +175,7 @@ function configureHostedWithConnectionString(config: ConnectionString): Explorer
   updateUserContext({
     // For legacy reasons lots of code expects a connection string login to look and act like an encrypted token login
     authType: AuthType.EncryptedToken,
-    accessToken: encodeURIComponent(config.encryptedToken),
+    accessToken: encodeURIComponent(config.encryptedToken.primaryToken),
     databaseAccount,
     masterKey: config.masterKey,
   });
@@ -212,7 +212,7 @@ function configureHostedWithEncryptedToken(config: EncryptedToken): Explorer {
   const apiExperience = DefaultExperienceUtility.getDefaultExperienceFromApiKind(config.encryptedTokenMetadata.apiKind);
   updateUserContext({
     authType: AuthType.EncryptedToken,
-    accessToken: encodeURIComponent(config.encryptedToken),
+    accessToken: encodeURIComponent(config.encryptedToken.primaryToken),
     databaseAccount: {
       id: "",
       location: "",

--- a/src/hooks/usePortalAccessToken.tsx
+++ b/src/hooks/usePortalAccessToken.tsx
@@ -10,8 +10,7 @@ export async function fetchAccessData(portalToken: EncryptedAccessToken): Promis
   // Portal encrypted token API quirk: The token header must be URL encoded
   if (portalToken.version === 1) {
     headers.append("x-ms-encrypted-auth-token", encodeURIComponent(portalToken.primaryToken));
-  }
-  else {
+  } else {
     headers.append("x-ms-cosmos-auth-token-primary", portalToken.primaryToken);
     headers.append("x-ms-cosmos-auth-token-secondary", portalToken.secondaryToken);
   }
@@ -30,7 +29,7 @@ export async function fetchAccessData(portalToken: EncryptedAccessToken): Promis
   );
 }
 
-export function useTokenMetadata(token: string): AccessInputMetadata | undefined {
+export function useTokenMetadata(token: EncryptedAccessToken): AccessInputMetadata | undefined {
   const [state, setState] = useState<AccessInputMetadata | undefined>();
 
   useEffect(() => {

--- a/src/hooks/usePortalAccessToken.tsx
+++ b/src/hooks/usePortalAccessToken.tsx
@@ -1,14 +1,20 @@
 import { useEffect, useState } from "react";
 import { ApiEndpoints } from "../Common/Constants";
 import { configContext } from "../ConfigContext";
-import { AccessInputMetadata } from "../Contracts/DataModels";
+import { AccessInputMetadata, EncryptedAccessToken } from "../Contracts/DataModels";
 
 const url = `${configContext.BACKEND_ENDPOINT}${ApiEndpoints.guestRuntimeProxy}/accessinputmetadata?_=1609359229955`;
 
-export async function fetchAccessData(portalToken: string): Promise<AccessInputMetadata> {
+export async function fetchAccessData(portalToken: EncryptedAccessToken): Promise<AccessInputMetadata> {
   const headers = new Headers();
   // Portal encrypted token API quirk: The token header must be URL encoded
-  headers.append("x-ms-encrypted-auth-token", encodeURIComponent(portalToken));
+  if (portalToken.version === 1) {
+    headers.append("x-ms-encrypted-auth-token", encodeURIComponent(portalToken.primaryToken));
+  }
+  else {
+    headers.append("x-ms-cosmos-auth-token-primary", portalToken.primaryToken);
+    headers.append("x-ms-cosmos-auth-token-secondary", portalToken.secondaryToken);
+  }
 
   const options = {
     method: "GET",


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1352?feature.someFeatureFlagYouMightNeed=true)

This change introduces a new auth token format (primary & secondary tokens to support secret rotation) side-by-side with
the current format. We will deprecate the current format in a subsequent change to be coordinated with support in portal backend.