### PR TITLE
Users/jawelton/support new auth tokens

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -203,6 +203,8 @@ export class HttpHeaders {
   public static partitionKey: string = "x-ms-documentdb-partitionkey";
   public static migrateOfferToManualThroughput: string = "x-ms-cosmos-migrate-offer-to-manual-throughput";
   public static migrateOfferToAutopilot: string = "x-ms-cosmos-migrate-offer-to-autopilot";
+  public static authTokenPrimary: string = "x-ms-cosmos-auth-token-primary";
+  public static authTokenSecondary: string = "x-ms-cosmos-auth-token-secondary";
 }
 
 export class ApiType {

--- a/src/Common/CosmosClient.ts
+++ b/src/Common/CosmosClient.ts
@@ -56,12 +56,12 @@ export const endpoint = () => {
 export async function getTokenFromAuthService(verb: string, resourceType: string, resourceId?: string): Promise<any> {
   try {
     const host = configContext.BACKEND_ENDPOINT;
-    const authorizationHeaders = getAuthorizationHeaders();
-    authorizationHeaders.append(HttpHeaders.contentType, "application/json");
+    const headers = getAuthorizationHeaders();
+    headers[HttpHeaders.contentType] = "application/json";
 
     const response = await _global.fetch(host + "/api/guest/runtimeproxy/authorizationTokens", {
       method: "POST",
-      headers: authorizationHeaders,
+      headers: headers,
       body: JSON.stringify({
         verb,
         resourceType,

--- a/src/Common/CosmosClient.ts
+++ b/src/Common/CosmosClient.ts
@@ -1,4 +1,5 @@
 import * as Cosmos from "@azure/cosmos";
+import { getAuthorizationHeaders } from "Utils/AuthorizationUtils";
 import { configContext, Platform } from "../ConfigContext";
 import { userContext } from "../UserContext";
 import { logConsoleError } from "../Utils/NotificationConsoleUtils";
@@ -55,12 +56,12 @@ export const endpoint = () => {
 export async function getTokenFromAuthService(verb: string, resourceType: string, resourceId?: string): Promise<any> {
   try {
     const host = configContext.BACKEND_ENDPOINT;
+    const authorizationHeaders = getAuthorizationHeaders();
+    authorizationHeaders.append(HttpHeaders.contentType, "application/json");
+
     const response = await _global.fetch(host + "/api/guest/runtimeproxy/authorizationTokens", {
       method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-ms-encrypted-auth-token": userContext.accessToken,
-      },
+      headers: authorizationHeaders,
       body: JSON.stringify({
         verb,
         resourceType,

--- a/src/Common/MongoProxyClient.ts
+++ b/src/Common/MongoProxyClient.ts
@@ -1,5 +1,6 @@
 import { Constants as CosmosSDKConstants } from "@azure/cosmos";
 import queryString from "querystring";
+import { getAccessTokenAuthorizationHeaders } from "Utils/AuthorizationUtils";
 import { allowedMongoProxyEndpoints, validateEndpoint } from "Utils/EndpointValidation";
 import { AuthType } from "../AuthType";
 import { configContext } from "../ConfigContext";
@@ -22,7 +23,10 @@ const defaultHeaders = {
 
 function authHeaders() {
   if (userContext.authType === AuthType.EncryptedToken) {
-    return { [HttpHeaders.guestAccessToken]: userContext.accessToken };
+    const accessTokenHeaders: Headers = getAccessTokenAuthorizationHeaders(userContext.accessToken);
+    const headers: { [key: string]: string } = {};
+    accessTokenHeaders.forEach((value, key) => (headers[key] = value));
+    return headers;
   } else {
     return { [HttpHeaders.authorization]: userContext.authorizationToken };
   }

--- a/src/Common/MongoProxyClient.ts
+++ b/src/Common/MongoProxyClient.ts
@@ -23,10 +23,7 @@ const defaultHeaders = {
 
 function authHeaders() {
   if (userContext.authType === AuthType.EncryptedToken) {
-    const accessTokenHeaders: Headers = getAccessTokenAuthorizationHeaders(userContext.accessToken);
-    const headers: { [key: string]: string } = {};
-    accessTokenHeaders.forEach((value, key) => (headers[key] = value));
-    return headers;
+    return getAccessTokenAuthorizationHeaders(userContext.accessToken);
   } else {
     return { [HttpHeaders.authorization]: userContext.authorizationToken };
   }

--- a/src/Common/PortalNotifications.ts
+++ b/src/Common/PortalNotifications.ts
@@ -1,8 +1,7 @@
 import { configContext, Platform } from "../ConfigContext";
 import * as DataModels from "../Contracts/DataModels";
-import * as ViewModels from "../Contracts/ViewModels";
 import { userContext } from "../UserContext";
-import { getAuthorizationHeader } from "../Utils/AuthorizationUtils";
+import { getAuthorizationHeaders } from "../Utils/AuthorizationUtils";
 
 const notificationsPath = () => {
   switch (configContext.platform) {
@@ -24,8 +23,7 @@ export const fetchPortalNotifications = async (): Promise<DataModels.Notificatio
   const url = `${configContext.BACKEND_ENDPOINT}${notificationsPath()}?accountName=${
     databaseAccount.name
   }&subscriptionId=${subscriptionId}&resourceGroup=${resourceGroup}`;
-  const authorizationHeader: ViewModels.AuthorizationTokenHeaderMetadata = getAuthorizationHeader();
-  const headers = { [authorizationHeader.header]: authorizationHeader.token };
+  const headers: Headers = getAuthorizationHeaders();
 
   const response = await window.fetch(url, {
     headers,

--- a/src/Common/PortalNotifications.ts
+++ b/src/Common/PortalNotifications.ts
@@ -23,8 +23,8 @@ export const fetchPortalNotifications = async (): Promise<DataModels.Notificatio
   const url = `${configContext.BACKEND_ENDPOINT}${notificationsPath()}?accountName=${
     databaseAccount.name
   }&subscriptionId=${subscriptionId}&resourceGroup=${resourceGroup}`;
-  const headers: Headers = getAuthorizationHeaders();
 
+  const headers = getAuthorizationHeaders();
   const response = await window.fetch(url, {
     headers,
   });

--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -78,8 +78,19 @@ export enum ApiKind {
 }
 
 export interface GenerateTokenResponse {
+  readWritePrimary: string;
+  readWriteSecondary: string;
+}
+
+export interface GenerateTokenResponse2 {
   readWrite: string;
   read: string;
+}
+
+export interface EncryptedAccessToken {
+  version: 1 | 2;
+  primaryToken: string;
+  secondaryToken: string;
 }
 
 export interface Subscription {

--- a/src/Explorer/Notebook/NotebookContainerClient.ts
+++ b/src/Explorer/Notebook/NotebookContainerClient.ts
@@ -11,7 +11,7 @@ import * as Logger from "../../Common/Logger";
 import * as DataModels from "../../Contracts/DataModels";
 import { IPhoenixServiceInfo, IProvisionData, IResponse } from "../../Contracts/DataModels";
 import { userContext } from "../../UserContext";
-import { getAuthorizationHeader } from "../../Utils/AuthorizationUtils";
+import { getAuthorizationHeaders } from "../../Utils/AuthorizationUtils";
 import { logConsoleProgress } from "../../Utils/NotificationConsoleUtils";
 import { useNotebook } from "./useNotebook";
 
@@ -185,11 +185,9 @@ export class NotebookContainerClient {
     };
   }
 
-  private getHeaders(): HeadersInit {
-    const authorizationHeader = getAuthorizationHeader();
-    return {
-      [authorizationHeader.header]: authorizationHeader.token,
-      [HttpHeaders.contentType]: "application/json",
-    };
+  private getHeaders(): Headers {
+    const headers: Headers = getAuthorizationHeaders();
+    headers.append(HttpHeaders.contentType, "application/json");
+    return headers;
   }
 }

--- a/src/Explorer/Notebook/NotebookContainerClient.ts
+++ b/src/Explorer/Notebook/NotebookContainerClient.ts
@@ -5,13 +5,12 @@ import { useDialog } from "Explorer/Controls/Dialog";
 import promiseRetry, { AbortError } from "p-retry";
 import { PhoenixClient } from "Phoenix/PhoenixClient";
 import * as Constants from "../../Common/Constants";
-import { ConnectionStatusType, HttpHeaders, HttpStatusCodes, Notebook, PoolIdType } from "../../Common/Constants";
+import { ConnectionStatusType, HttpStatusCodes, Notebook, PoolIdType } from "../../Common/Constants";
 import { getErrorMessage } from "../../Common/ErrorHandlingUtils";
 import * as Logger from "../../Common/Logger";
 import * as DataModels from "../../Contracts/DataModels";
 import { IPhoenixServiceInfo, IProvisionData, IResponse } from "../../Contracts/DataModels";
 import { userContext } from "../../UserContext";
-import { getAuthorizationHeaders } from "../../Utils/AuthorizationUtils";
 import { logConsoleProgress } from "../../Utils/NotificationConsoleUtils";
 import { useNotebook } from "./useNotebook";
 
@@ -183,11 +182,5 @@ export class NotebookContainerClient {
       notebookServerEndpoint: notebookServerInfo.notebookServerEndpoint,
       authToken,
     };
-  }
-
-  private getHeaders(): Headers {
-    const headers: Headers = getAuthorizationHeaders();
-    headers.append(HttpHeaders.contentType, "application/json");
-    return headers;
   }
 }

--- a/src/Explorer/Notebook/useNotebook.ts
+++ b/src/Explorer/Notebook/useNotebook.ts
@@ -129,7 +129,7 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
         : databaseAccount?.properties?.writeLocations?.[0]?.locationName.toLowerCase();
     const disallowedLocationsUri = `${configContext.BACKEND_ENDPOINT}/api/disallowedLocations`;
     const authorizationHeaders = getAuthorizationHeaders();
-    authorizationHeaders.append(Constants.HttpHeaders.contentType, "application/json");
+    authorizationHeaders[Constants.HttpHeaders.contentType] = "application/json";
 
     try {
       const response = await fetch(disallowedLocationsUri, {

--- a/src/Explorer/Notebook/useNotebook.ts
+++ b/src/Explorer/Notebook/useNotebook.ts
@@ -15,7 +15,7 @@ import { IPinnedRepo } from "../../Juno/JunoClient";
 import { Action, ActionModifiers } from "../../Shared/Telemetry/TelemetryConstants";
 import * as TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
 import { userContext } from "../../UserContext";
-import { getAuthorizationHeader } from "../../Utils/AuthorizationUtils";
+import { getAuthorizationHeaders } from "../../Utils/AuthorizationUtils";
 import * as GitHubUtils from "../../Utils/GitHubUtils";
 import { NotebookContentItem, NotebookContentItemType } from "./NotebookContentItem";
 import NotebookManager from "./NotebookManager";
@@ -128,17 +128,16 @@ export const useNotebook: UseStore<NotebookState> = create((set, get) => ({
         ? databaseAccount?.location
         : databaseAccount?.properties?.writeLocations?.[0]?.locationName.toLowerCase();
     const disallowedLocationsUri = `${configContext.BACKEND_ENDPOINT}/api/disallowedLocations`;
-    const authorizationHeader = getAuthorizationHeader();
+    const authorizationHeaders = getAuthorizationHeaders();
+    authorizationHeaders.append(Constants.HttpHeaders.contentType, "application/json");
+
     try {
       const response = await fetch(disallowedLocationsUri, {
         method: "POST",
         body: JSON.stringify({
           resourceTypes: [Constants.ArmResourceTypes.notebookWorkspaces],
         }),
-        headers: {
-          [authorizationHeader.header]: authorizationHeader.token,
-          [Constants.HttpHeaders.contentType]: "application/json",
-        },
+        headers: authorizationHeaders,
       });
 
       if (!response.ok) {

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -12,7 +12,7 @@ import * as HeadersUtility from "../../Common/HeadersUtility";
 import { configContext } from "../../ConfigContext";
 import * as ViewModels from "../../Contracts/ViewModels";
 import { userContext } from "../../UserContext";
-import { getAuthorizationHeader } from "../../Utils/AuthorizationUtils";
+import { getAuthorizationHeaders } from "../../Utils/AuthorizationUtils";
 import * as NotificationConsoleUtils from "../../Utils/NotificationConsoleUtils";
 import { logConsoleInfo, logConsoleProgress } from "../../Utils/NotificationConsoleUtils";
 import Explorer from "../Explorer";
@@ -523,8 +523,10 @@ export class CassandraAPIDataClient extends TableDataClient {
   }
 
   private setAuthorizationHeader: (xhr: XMLHttpRequest) => boolean = (xhr: XMLHttpRequest): boolean => {
-    const authorizationHeaderMetadata: ViewModels.AuthorizationTokenHeaderMetadata = getAuthorizationHeader();
-    xhr.setRequestHeader(authorizationHeaderMetadata.header, authorizationHeaderMetadata.token);
+    const authorizationHeaderMetadata: Headers = getAuthorizationHeaders();
+    authorizationHeaderMetadata.forEach((value, key) => {
+      xhr.setRequestHeader(key, value);
+    });
 
     return true;
   };

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -523,9 +523,9 @@ export class CassandraAPIDataClient extends TableDataClient {
   }
 
   private setAuthorizationHeader: (xhr: XMLHttpRequest) => boolean = (xhr: XMLHttpRequest): boolean => {
-    const authorizationHeaderMetadata: Headers = getAuthorizationHeaders();
-    authorizationHeaderMetadata.forEach((value, key) => {
-      xhr.setRequestHeader(key, value);
+    const authorizationHeaderMetadata = getAuthorizationHeaders();
+    Object.entries(authorizationHeaderMetadata).forEach((value, index, array) => {
+      xhr.setRequestHeader(value[0], value[1]);
     });
 
     return true;

--- a/src/Explorer/Tabs/MongoShellTab/MongoShellTabComponent.tsx
+++ b/src/Explorer/Tabs/MongoShellTab/MongoShellTabComponent.tsx
@@ -1,3 +1,4 @@
+import { EncryptedAccessToken } from "Contracts/DataModels";
 import React, { Component } from "react";
 import * as Constants from "../../../Common/Constants";
 import { configContext, Platform } from "../../../ConfigContext";
@@ -135,7 +136,7 @@ export default class MongoShellTabComponent extends Component<
     const databaseId = this.props.collection.databaseId;
     const collectionId = this.props.collection.id();
     const apiEndpoint = configContext.BACKEND_ENDPOINT;
-    const encryptedAuthToken: string = userContext.accessToken;
+    const encryptedAuthToken: EncryptedAccessToken = userContext.accessToken;
 
     shellIframe.contentWindow.postMessage(
       {

--- a/src/HostedExplorer.tsx
+++ b/src/HostedExplorer.tsx
@@ -5,7 +5,7 @@ import { render } from "react-dom";
 import ChevronRight from "../images/chevron-right.svg";
 import "../less/hostedexplorer.less";
 import { AuthType } from "./AuthType";
-import { DatabaseAccount } from "./Contracts/DataModels";
+import { DatabaseAccount, EncryptedAccessToken } from "./Contracts/DataModels";
 import "./Explorer/Menus/NavBar/MeControlComponent.less";
 import { useAADAuth } from "./hooks/useAADAuth";
 import { useConfig } from "./hooks/useConfig";
@@ -25,8 +25,7 @@ initializeIcons();
 
 const App: React.FunctionComponent = () => {
   // For handling encrypted portal tokens sent via query paramter
-  const params = new URLSearchParams(window.location.search);
-  const [encryptedToken, setEncryptedToken] = React.useState<string>(params && params.get("key"));
+  const [encryptedToken, setEncryptedToken] = React.useState<EncryptedAccessToken>();
   const encryptedTokenMetadata = useTokenMetadata(encryptedToken);
 
   // For showing/hiding panel

--- a/src/HostedExplorerChildFrame.ts
+++ b/src/HostedExplorerChildFrame.ts
@@ -1,5 +1,5 @@
 import { AuthType } from "./AuthType";
-import { AccessInputMetadata, DatabaseAccount } from "./Contracts/DataModels";
+import { AccessInputMetadata, DatabaseAccount, EncryptedAccessToken } from "./Contracts/DataModels";
 
 type HostedConfig = AAD | ConnectionString | EncryptedToken | ResourceToken;
 export interface HostedExplorerChildFrame extends Window {
@@ -15,7 +15,7 @@ export interface AAD {
 export interface ConnectionString {
   authType: AuthType.ConnectionString;
   // Connection string uses still use encrypted token for Cassandra/Mongo APIs as they us the portal backend proxy
-  encryptedToken: string;
+  encryptedToken: EncryptedAccessToken;
   encryptedTokenMetadata: AccessInputMetadata;
   // Master key is currently only used by Graph API. All other APIs use encrypted tokens and proxy with connection string
   masterKey?: string;

--- a/src/HostedExplorerChildFrame.ts
+++ b/src/HostedExplorerChildFrame.ts
@@ -23,7 +23,7 @@ export interface ConnectionString {
 
 export interface EncryptedToken {
   authType: AuthType.EncryptedToken;
-  encryptedToken: string;
+  encryptedToken: EncryptedAccessToken;
   encryptedTokenMetadata: AccessInputMetadata;
 }
 

--- a/src/Juno/JunoClient.test.ts
+++ b/src/Juno/JunoClient.test.ts
@@ -1,7 +1,7 @@
+import { getAuthorizationHeaders } from "Utils/AuthorizationUtils";
 import { HttpHeaders, HttpStatusCodes } from "../Common/Constants";
 import { DatabaseAccount } from "../Contracts/DataModels";
 import { updateUserContext, userContext } from "../UserContext";
-import { getAuthorizationHeader } from "../Utils/AuthorizationUtils";
 import { IPinnedRepo, IPublishNotebookRequest, JunoClient } from "./JunoClient";
 
 const sampleSubscriptionId = "subscriptionId";
@@ -225,7 +225,9 @@ describe("Gallery", () => {
 
     const response = await junoClient.increaseNotebookDownloadCount(id);
 
-    const authorizationHeader = getAuthorizationHeader();
+    const expectedHeaders = getAuthorizationHeaders();
+    expectedHeaders.append(HttpHeaders.contentType, "application/json");
+
     expect(response.status).toBe(HttpStatusCodes.OK);
     expect(window.fetch).toBeCalledWith(
       `${JunoClient.getJunoEndpoint()}/api/notebooks/subscriptions/${sampleSubscriptionId}/databaseAccounts/${
@@ -233,10 +235,7 @@ describe("Gallery", () => {
       }/gallery/${id}/downloads`,
       {
         method: "PATCH",
-        headers: {
-          [authorizationHeader.header]: authorizationHeader.token,
-          [HttpHeaders.contentType]: "application/json",
-        },
+        headers: expectedHeaders,
       }
     );
   });
@@ -250,7 +249,9 @@ describe("Gallery", () => {
 
     const response = await junoClient.favoriteNotebook(id);
 
-    const authorizationHeader = getAuthorizationHeader();
+    const expectedHeaders = getAuthorizationHeaders();
+    expectedHeaders.append(HttpHeaders.contentType, "application/json");
+
     expect(response.status).toBe(HttpStatusCodes.OK);
     expect(window.fetch).toBeCalledWith(
       `${JunoClient.getJunoEndpoint()}/api/notebooks/subscriptions/${sampleSubscriptionId}/databaseAccounts/${
@@ -258,10 +259,7 @@ describe("Gallery", () => {
       }/gallery/${id}/favorite`,
       {
         method: "PATCH",
-        headers: {
-          [authorizationHeader.header]: authorizationHeader.token,
-          [HttpHeaders.contentType]: "application/json",
-        },
+        headers: expectedHeaders,
       }
     );
   });
@@ -275,7 +273,9 @@ describe("Gallery", () => {
 
     const response = await junoClient.unfavoriteNotebook(id);
 
-    const authorizationHeader = getAuthorizationHeader();
+    const expectedHeaders = getAuthorizationHeaders();
+    expectedHeaders.append(HttpHeaders.contentType, "application/json");
+
     expect(response.status).toBe(HttpStatusCodes.OK);
     expect(window.fetch).toBeCalledWith(
       `${JunoClient.getJunoEndpoint()}/api/notebooks/subscriptions/${sampleSubscriptionId}/databaseAccounts/${
@@ -283,10 +283,7 @@ describe("Gallery", () => {
       }/gallery/${id}/unfavorite`,
       {
         method: "PATCH",
-        headers: {
-          [authorizationHeader.header]: authorizationHeader.token,
-          [HttpHeaders.contentType]: "application/json",
-        },
+        headers: expectedHeaders,
       }
     );
   });
@@ -299,17 +296,16 @@ describe("Gallery", () => {
 
     const response = await junoClient.getFavoriteNotebooks();
 
-    const authorizationHeader = getAuthorizationHeader();
+    const expectedHeaders = getAuthorizationHeaders();
+    expectedHeaders.append(HttpHeaders.contentType, "application/json");
+
     expect(response.status).toBe(HttpStatusCodes.OK);
     expect(window.fetch).toBeCalledWith(
       `${JunoClient.getJunoEndpoint()}/api/notebooks/subscriptions/${sampleSubscriptionId}/databaseAccounts/${
         sampleDatabaseAccount.name
       }/gallery/favorites`,
       {
-        headers: {
-          [authorizationHeader.header]: authorizationHeader.token,
-          [HttpHeaders.contentType]: "application/json",
-        },
+        headers: expectedHeaders,
       }
     );
   });
@@ -322,17 +318,16 @@ describe("Gallery", () => {
 
     const response = await junoClient.getPublishedNotebooks();
 
-    const authorizationHeader = getAuthorizationHeader();
+    const expectedHeaders = getAuthorizationHeaders();
+    expectedHeaders.append(HttpHeaders.contentType, "application/json");
+
     expect(response.status).toBe(HttpStatusCodes.OK);
     expect(window.fetch).toBeCalledWith(
       `${JunoClient.getJunoEndpoint()}/api/notebooks/subscriptions/${sampleSubscriptionId}/databaseAccounts/${
         sampleDatabaseAccount.name
       }/gallery/published`,
       {
-        headers: {
-          [authorizationHeader.header]: authorizationHeader.token,
-          [HttpHeaders.contentType]: "application/json",
-        },
+        headers: expectedHeaders,
       }
     );
   });
@@ -346,7 +341,9 @@ describe("Gallery", () => {
 
     const response = await junoClient.deleteNotebook(id);
 
-    const authorizationHeader = getAuthorizationHeader();
+    const expectedHeaders = getAuthorizationHeaders();
+    expectedHeaders.append(HttpHeaders.contentType, "application/json");
+
     expect(response.status).toBe(HttpStatusCodes.OK);
     expect(window.fetch).toBeCalledWith(
       `${JunoClient.getJunoEndpoint()}/api/notebooks/subscriptions/${sampleSubscriptionId}/databaseAccounts/${
@@ -354,10 +351,7 @@ describe("Gallery", () => {
       }/gallery/${id}`,
       {
         method: "DELETE",
-        headers: {
-          [authorizationHeader.header]: authorizationHeader.token,
-          [HttpHeaders.contentType]: "application/json",
-        },
+        headers: expectedHeaders,
       }
     );
   });
@@ -376,7 +370,9 @@ describe("Gallery", () => {
 
     const response = await junoClient.publishNotebook(name, description, tags, thumbnailUrl, content);
 
-    const authorizationHeader = getAuthorizationHeader();
+    const expectedHeaders = getAuthorizationHeaders();
+    expectedHeaders.append(HttpHeaders.contentType, "application/json");
+
     expect(response.status).toBe(HttpStatusCodes.OK);
     expect(window.fetch).toBeCalledWith(
       `${JunoClient.getJunoEndpoint()}/api/notebooks/subscriptions/${sampleSubscriptionId}/databaseAccounts/${
@@ -384,10 +380,7 @@ describe("Gallery", () => {
       }/gallery`,
       {
         method: "PUT",
-        headers: {
-          [authorizationHeader.header]: authorizationHeader.token,
-          [HttpHeaders.contentType]: "application/json",
-        },
+        headers: expectedHeaders,
         body: JSON.stringify({
           name,
           description,

--- a/src/Juno/JunoClient.test.ts
+++ b/src/Juno/JunoClient.test.ts
@@ -226,7 +226,7 @@ describe("Gallery", () => {
     const response = await junoClient.increaseNotebookDownloadCount(id);
 
     const expectedHeaders = getAuthorizationHeaders();
-    expectedHeaders.append(HttpHeaders.contentType, "application/json");
+    expectedHeaders[HttpHeaders.contentType] = "application/json";
 
     expect(response.status).toBe(HttpStatusCodes.OK);
     expect(window.fetch).toBeCalledWith(
@@ -250,7 +250,7 @@ describe("Gallery", () => {
     const response = await junoClient.favoriteNotebook(id);
 
     const expectedHeaders = getAuthorizationHeaders();
-    expectedHeaders.append(HttpHeaders.contentType, "application/json");
+    expectedHeaders[HttpHeaders.contentType] = "application/json";
 
     expect(response.status).toBe(HttpStatusCodes.OK);
     expect(window.fetch).toBeCalledWith(
@@ -274,7 +274,7 @@ describe("Gallery", () => {
     const response = await junoClient.unfavoriteNotebook(id);
 
     const expectedHeaders = getAuthorizationHeaders();
-    expectedHeaders.append(HttpHeaders.contentType, "application/json");
+    expectedHeaders[HttpHeaders.contentType] = "application/json";
 
     expect(response.status).toBe(HttpStatusCodes.OK);
     expect(window.fetch).toBeCalledWith(
@@ -297,7 +297,7 @@ describe("Gallery", () => {
     const response = await junoClient.getFavoriteNotebooks();
 
     const expectedHeaders = getAuthorizationHeaders();
-    expectedHeaders.append(HttpHeaders.contentType, "application/json");
+    expectedHeaders[HttpHeaders.contentType] = "application/json";
 
     expect(response.status).toBe(HttpStatusCodes.OK);
     expect(window.fetch).toBeCalledWith(
@@ -319,7 +319,7 @@ describe("Gallery", () => {
     const response = await junoClient.getPublishedNotebooks();
 
     const expectedHeaders = getAuthorizationHeaders();
-    expectedHeaders.append(HttpHeaders.contentType, "application/json");
+    expectedHeaders[HttpHeaders.contentType] = "application/json";
 
     expect(response.status).toBe(HttpStatusCodes.OK);
     expect(window.fetch).toBeCalledWith(
@@ -342,7 +342,7 @@ describe("Gallery", () => {
     const response = await junoClient.deleteNotebook(id);
 
     const expectedHeaders = getAuthorizationHeaders();
-    expectedHeaders.append(HttpHeaders.contentType, "application/json");
+    expectedHeaders[HttpHeaders.contentType] = "application/json";
 
     expect(response.status).toBe(HttpStatusCodes.OK);
     expect(window.fetch).toBeCalledWith(
@@ -371,7 +371,7 @@ describe("Gallery", () => {
     const response = await junoClient.publishNotebook(name, description, tags, thumbnailUrl, content);
 
     const expectedHeaders = getAuthorizationHeaders();
-    expectedHeaders.append(HttpHeaders.contentType, "application/json");
+    expectedHeaders[HttpHeaders.contentType] = "application/json";
 
     expect(response.status).toBe(HttpStatusCodes.OK);
     expect(window.fetch).toBeCalledWith(

--- a/src/Juno/JunoClient.ts
+++ b/src/Juno/JunoClient.ts
@@ -515,8 +515,8 @@ export class JunoClient {
   }
 
   private static getHeaders(): HeadersInit {
-    const headers: Headers = getAuthorizationHeaders();
-    headers.append(HttpHeaders.contentType, "application/json");
+    const headers = getAuthorizationHeaders();
+    headers[HttpHeaders.contentType] = "application/json";
     return headers;
   }
 

--- a/src/Juno/JunoClient.ts
+++ b/src/Juno/JunoClient.ts
@@ -8,7 +8,7 @@ import { AuthorizeAccessComponent } from "../Explorer/Controls/GitHub/AuthorizeA
 import { IGitHubResponse } from "../GitHub/GitHubClient";
 import { IGitHubOAuthToken } from "../GitHub/GitHubOAuthService";
 import { userContext } from "../UserContext";
-import { getAuthorizationHeader } from "../Utils/AuthorizationUtils";
+import { getAuthorizationHeaders } from "../Utils/AuthorizationUtils";
 
 export interface IJunoResponse<T> {
   status: number;
@@ -515,11 +515,9 @@ export class JunoClient {
   }
 
   private static getHeaders(): HeadersInit {
-    const authorizationHeader = getAuthorizationHeader();
-    return {
-      [authorizationHeader.header]: authorizationHeader.token,
-      [HttpHeaders.contentType]: "application/json",
-    };
+    const headers: Headers = getAuthorizationHeaders();
+    headers.append(HttpHeaders.contentType, "application/json");
+    return headers;
   }
 
   private static getGitHubClientParams(): URLSearchParams {

--- a/src/Phoenix/PhoenixClient.ts
+++ b/src/Phoenix/PhoenixClient.ts
@@ -29,7 +29,7 @@ import {
 import { useNotebook } from "../Explorer/Notebook/useNotebook";
 import * as TelemetryProcessor from "../Shared/Telemetry/TelemetryProcessor";
 import { userContext } from "../UserContext";
-import { getAuthorizationHeader } from "../Utils/AuthorizationUtils";
+import { getAuthorizationHeaders } from "../Utils/AuthorizationUtils";
 
 export class PhoenixClient {
   private armResourceId: string;
@@ -244,11 +244,9 @@ export class PhoenixClient {
   }
 
   private static getHeaders(): HeadersInit {
-    const authorizationHeader = getAuthorizationHeader();
-    return {
-      [authorizationHeader.header]: authorizationHeader.token,
-      [HttpHeaders.contentType]: "application/json",
-    };
+    const headers = getAuthorizationHeaders();
+    headers.append(HttpHeaders.contentType, "application/json");
+    return headers;
   }
 
   public ConvertToForbiddenErrorString(jsonData: IPhoenixError): string {

--- a/src/Phoenix/PhoenixClient.ts
+++ b/src/Phoenix/PhoenixClient.ts
@@ -245,7 +245,7 @@ export class PhoenixClient {
 
   private static getHeaders(): HeadersInit {
     const headers = getAuthorizationHeaders();
-    headers.append(HttpHeaders.contentType, "application/json");
+    headers[HttpHeaders.contentType] = "application/json";
     return headers;
   }
 

--- a/src/Platform/Hosted/Components/ConnectExplorer.tsx
+++ b/src/Platform/Hosted/Components/ConnectExplorer.tsx
@@ -55,11 +55,18 @@ export const ConnectExplorer: React.FunctionComponent<Props> = ({
                 const result: GenerateTokenResponse | GenerateTokenResponse2 = JSON.parse(await response.json());
                 if ("readWrite" in result) {
                   // V1 Token encryption (to be deprecated)
-                  setEncryptedToken({version: 1, primaryToken: decodeURIComponent(result.readWrite || result.read), secondaryToken: ""});
-                }
-                else {
+                  setEncryptedToken({
+                    version: 1,
+                    primaryToken: decodeURIComponent(result.readWrite || result.read),
+                    secondaryToken: "",
+                  });
+                } else {
                   // V2 Token encryption
-                  setEncryptedToken({version: 2, primaryToken: result.readWritePrimary, secondaryToken: result.readWriteSecondary});
+                  setEncryptedToken({
+                    version: 2,
+                    primaryToken: result.readWritePrimary,
+                    secondaryToken: result.readWriteSecondary,
+                  });
                 }
                 setAuthType(AuthType.ConnectionString);
               }}

--- a/src/UserContext.ts
+++ b/src/UserContext.ts
@@ -3,7 +3,7 @@ import { usePostgres } from "hooks/usePostgres";
 import { Action } from "Shared/Telemetry/TelemetryConstants";
 import { traceOpen } from "Shared/Telemetry/TelemetryProcessor";
 import { AuthType } from "./AuthType";
-import { DatabaseAccount } from "./Contracts/DataModels";
+import { DatabaseAccount, EncryptedAccessToken } from "./Contracts/DataModels";
 import { SubscriptionType } from "./Contracts/SubscriptionType";
 import { extractFeatures, Features } from "./Platform/Hosted/extractFeatures";
 import { CollectionCreation, CollectionCreationDefaults } from "./Shared/Constants";
@@ -48,7 +48,7 @@ interface UserContext {
   readonly databaseAccount?: DatabaseAccount;
   readonly endpoint?: string;
   readonly aadToken?: string;
-  readonly accessToken?: string;
+  readonly accessToken?: EncryptedAccessToken;
   readonly authorizationToken?: string;
   readonly resourceToken?: string;
   readonly subscriptionType?: SubscriptionType;

--- a/src/Utils/AuthorizationUtils.test.ts
+++ b/src/Utils/AuthorizationUtils.test.ts
@@ -4,15 +4,6 @@ import { updateUserContext } from "../UserContext";
 import * as AuthorizationUtils from "./AuthorizationUtils";
 jest.mock("../Explorer/Explorer");
 
-function headersToArray(headers: Headers): [string, string][] {
-  const headersArray: [string, string][] = [];
-  headers.forEach((key, value) => {
-    headersArray.push([key, value]);
-  });
-
-  return headersArray;
-}
-
 describe("AuthorizationUtils", () => {
   describe("getAuthorizationHeader()", () => {
     it("should return authorization header if authentication type is AAD", () => {
@@ -21,7 +12,7 @@ describe("AuthorizationUtils", () => {
         authorizationToken: "some-token",
       });
 
-      const authHeaders: [string, string][] = headersToArray(AuthorizationUtils.getAuthorizationHeaders());
+      const authHeaders = Object.entries(AuthorizationUtils.getAuthorizationHeaders());
       expect(authHeaders.length).toBe(1);
       expect(authHeaders[0][0]).toBe(Constants.HttpHeaders.authorization);
       expect(authHeaders[0][1]).toBe("some-token");
@@ -33,7 +24,7 @@ describe("AuthorizationUtils", () => {
         accessToken: { version: 1, primaryToken: "some-token", secondaryToken: "" },
       });
 
-      const authHeaders: [string, string][] = headersToArray(AuthorizationUtils.getAuthorizationHeaders());
+      const authHeaders = Object.entries(AuthorizationUtils.getAuthorizationHeaders());
       expect(authHeaders.length).toBe(1);
       expect(authHeaders[0][0]).toBe(Constants.HttpHeaders.guestAccessToken);
       expect(authHeaders[0][1]).toBe("some-token");
@@ -45,7 +36,7 @@ describe("AuthorizationUtils", () => {
         accessToken: { version: 2, primaryToken: "some-token", secondaryToken: "some-other-token" },
       });
 
-      const authHeaders: [string, string][] = headersToArray(AuthorizationUtils.getAuthorizationHeaders());
+      const authHeaders = Object.entries(AuthorizationUtils.getAuthorizationHeaders());
       expect(authHeaders.length).toBe(2);
       expect(authHeaders[0][0]).toBe(Constants.HttpHeaders.authTokenPrimary);
       expect(authHeaders[0][1]).toBe("some-token");

--- a/src/Utils/AuthorizationUtils.ts
+++ b/src/Utils/AuthorizationUtils.ts
@@ -7,22 +7,22 @@ import * as Logger from "../Common/Logger";
 import { configContext } from "../ConfigContext";
 import { userContext } from "../UserContext";
 
-export function getAuthorizationHeaders(): Headers {
+export function getAuthorizationHeaders() {
   if (userContext.authType === AuthType.EncryptedToken) {
-    return userContext.accessToken ? getAccessTokenAuthorizationHeaders(userContext.accessToken) : new Headers();
+    return userContext.accessToken ? getAccessTokenAuthorizationHeaders(userContext.accessToken) : {};
   } else {
-    return new Headers([[Constants.HttpHeaders.authorization, userContext.authorizationToken || ""]]);
+    return { [Constants.HttpHeaders.authorization]: userContext.authorizationToken || "" };
   }
 }
 
-export function getAccessTokenAuthorizationHeaders(token: EncryptedAccessToken): Headers {
+export function getAccessTokenAuthorizationHeaders(token: EncryptedAccessToken) {
   if (token.version === 1) {
-    return new Headers([[HttpHeaders.guestAccessToken, encodeURIComponent(token.primaryToken)]]);
+    return { [HttpHeaders.guestAccessToken]: encodeURIComponent(token.primaryToken) };
   } else {
-    return new Headers([
-      [HttpHeaders.authTokenPrimary, token.primaryToken],
-      [HttpHeaders.authTokenSecondary, token.secondaryToken],
-    ]);
+    return {
+      [HttpHeaders.authTokenPrimary]: token.primaryToken,
+      [HttpHeaders.authTokenSecondary]: token.secondaryToken,
+    };
   }
 }
 

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -175,7 +175,7 @@ function configureHostedWithConnectionString(config: ConnectionString): Explorer
   updateUserContext({
     // For legacy reasons lots of code expects a connection string login to look and act like an encrypted token login
     authType: AuthType.EncryptedToken,
-    accessToken: encodeURIComponent(config.encryptedToken),
+    accessToken: config.encryptedToken,
     databaseAccount,
     masterKey: config.masterKey,
   });
@@ -212,7 +212,7 @@ function configureHostedWithEncryptedToken(config: EncryptedToken): Explorer {
   const apiExperience = DefaultExperienceUtility.getDefaultExperienceFromApiKind(config.encryptedTokenMetadata.apiKind);
   updateUserContext({
     authType: AuthType.EncryptedToken,
-    accessToken: encodeURIComponent(config.encryptedToken),
+    accessToken: config.encryptedToken,
     databaseAccount: {
       id: "",
       location: "",

--- a/src/hooks/usePortalAccessToken.tsx
+++ b/src/hooks/usePortalAccessToken.tsx
@@ -1,14 +1,20 @@
 import { useEffect, useState } from "react";
 import { ApiEndpoints } from "../Common/Constants";
 import { configContext } from "../ConfigContext";
-import { AccessInputMetadata } from "../Contracts/DataModels";
+import { AccessInputMetadata, EncryptedAccessToken } from "../Contracts/DataModels";
 
 const url = `${configContext.BACKEND_ENDPOINT}${ApiEndpoints.guestRuntimeProxy}/accessinputmetadata?_=1609359229955`;
 
-export async function fetchAccessData(portalToken: string): Promise<AccessInputMetadata> {
+export async function fetchAccessData(portalToken: EncryptedAccessToken): Promise<AccessInputMetadata> {
   const headers = new Headers();
   // Portal encrypted token API quirk: The token header must be URL encoded
-  headers.append("x-ms-encrypted-auth-token", encodeURIComponent(portalToken));
+  if (portalToken.version === 1) {
+    headers.append("x-ms-encrypted-auth-token", encodeURIComponent(portalToken.primaryToken));
+  }
+  else {
+    headers.append("x-ms-cosmos-auth-token-primary", portalToken.primaryToken);
+    headers.append("x-ms-cosmos-auth-token-secondary", portalToken.secondaryToken);
+  }
 
   const options = {
     method: "GET",

--- a/src/hooks/usePortalAccessToken.tsx
+++ b/src/hooks/usePortalAccessToken.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { getAccessTokenAuthorizationHeaders } from "Utils/AuthorizationUtils";
 import { ApiEndpoints } from "../Common/Constants";
 import { configContext } from "../ConfigContext";
 import { AccessInputMetadata, EncryptedAccessToken } from "../Contracts/DataModels";
@@ -6,16 +7,7 @@ import { AccessInputMetadata, EncryptedAccessToken } from "../Contracts/DataMode
 const url = `${configContext.BACKEND_ENDPOINT}${ApiEndpoints.guestRuntimeProxy}/accessinputmetadata?_=1609359229955`;
 
 export async function fetchAccessData(portalToken: EncryptedAccessToken): Promise<AccessInputMetadata> {
-  const headers = new Headers();
-  // Portal encrypted token API quirk: The token header must be URL encoded
-  if (portalToken.version === 1) {
-    headers.append("x-ms-encrypted-auth-token", encodeURIComponent(portalToken.primaryToken));
-  }
-  else {
-    headers.append("x-ms-cosmos-auth-token-primary", portalToken.primaryToken);
-    headers.append("x-ms-cosmos-auth-token-secondary", portalToken.secondaryToken);
-  }
-
+  const headers = getAccessTokenAuthorizationHeaders(portalToken);
   const options = {
     method: "GET",
     headers: headers,
@@ -30,7 +22,7 @@ export async function fetchAccessData(portalToken: EncryptedAccessToken): Promis
   );
 }
 
-export function useTokenMetadata(token: string): AccessInputMetadata | undefined {
+export function useTokenMetadata(token: EncryptedAccessToken): AccessInputMetadata | undefined {
   const [state, setState] = useState<AccessInputMetadata | undefined>();
 
   useEffect(() => {


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1353?feature.someFeatureFlagYouMightNeed=true)

This change introduces a new auth token format (primary & secondary tokens to support secret rotation) side-by-side with
the current format. We will deprecate the current format in a subsequent change to be coordinated with support in portal backend.

It also refactors some code where we generate request headers based on authentication.
