### PR TITLE
Fix "Change network settings" button send the wrong message type

### DIFF
--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -32,7 +32,7 @@ export const Tabs = ({ explorer }: TabsProps): JSX.Element => {
         <MessageBar
           messageBarType={MessageBarType.warning}
           actions={
-            <MessageBarButton onClick={() => sendMessage({ type: MessageTypes.OpenCosmosDBNetworkingBlade })}>
+            <MessageBarButton onClick={() => sendMessage({ type: MessageTypes.OpenPostgresNetworkingBlade })}>
               Change network settings
             </MessageBarButton>
           }


### PR DESCRIPTION
The button should send `OpenPostgresNetworkingBlade` instead of `OpenCosmosDBNetworkingBlade` message type.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
