### PR TITLE
Lazy loading containers

### DIFF
--- a/less/resourceTree.less
+++ b/less/resourceTree.less
@@ -11,6 +11,10 @@
   .collectionHeader {
     font-size: 12px;
   }
+
+  .loadMoreHeader {
+    color: RGB(5, 99, 193);
+  }
 }
 
 .notebookResourceTree {
@@ -24,5 +28,3 @@
     pointer-events: none;
   }
 }
-
-

--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -141,7 +141,7 @@ export class Queries {
   public static UnlimitedPageOption: string = "unlimited";
   public static itemsPerPage: number = 100;
   public static unlimitedItemsPerPage: number = 100; // TODO: Figure out appropriate value so it works for accounts with a large number of partitions
-
+  public static containersPerPage: number = 3;
   public static QueryEditorMinHeightRatio: number = 0.1;
   public static QueryEditorMaxHeightRatio: number = 0.4;
   public static readonly DefaultMaxDegreeOfParallelism = 6;

--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -141,7 +141,7 @@ export class Queries {
   public static UnlimitedPageOption: string = "unlimited";
   public static itemsPerPage: number = 100;
   public static unlimitedItemsPerPage: number = 100; // TODO: Figure out appropriate value so it works for accounts with a large number of partitions
-  public static containersPerPage: number = 3;
+  public static containersPerPage: number = 50;
   public static QueryEditorMinHeightRatio: number = 0.1;
   public static QueryEditorMaxHeightRatio: number = 0.4;
   public static readonly DefaultMaxDegreeOfParallelism = 6;

--- a/src/Common/dataAccess/readCollections.ts
+++ b/src/Common/dataAccess/readCollections.ts
@@ -34,19 +34,23 @@ export async function readCollections(databaseId: string): Promise<DataModels.Co
 
 export async function readCollectionsWithPagination(
   databaseId: string,
-  continuationToken?: string,
+  continuationToken?: string
 ): Promise<DataModels.CollectionsWithPagination> {
   const clearMessage = logConsoleProgress(`Querying containers for database ${databaseId}`);
   try {
-    const sdkResponse = await client().database(databaseId).containers.query(
-      { query: "SELECT * FROM c" },
-      {
-        continuationToken,
-        maxItemCount: Queries.containersPerPage,
-      }).fetchNext();
+    const sdkResponse = await client()
+      .database(databaseId)
+      .containers.query(
+        { query: "SELECT * FROM c" },
+        {
+          continuationToken,
+          maxItemCount: Queries.containersPerPage,
+        }
+      )
+      .fetchNext();
     const collectionsWithPagination: DataModels.CollectionsWithPagination = {
       collections: sdkResponse.resources as DataModels.Collection[],
-      continuationToken: sdkResponse.continuationToken
+      continuationToken: sdkResponse.continuationToken,
     };
     return collectionsWithPagination;
   } catch (error) {

--- a/src/Common/dataAccess/readCollections.ts
+++ b/src/Common/dataAccess/readCollections.ts
@@ -1,3 +1,4 @@
+import { Queries } from "Common/Constants";
 import { AuthType } from "../../AuthType";
 import * as DataModels from "../../Contracts/DataModels";
 import { userContext } from "../../UserContext";
@@ -23,6 +24,31 @@ export async function readCollections(databaseId: string): Promise<DataModels.Co
 
     const sdkResponse = await client().database(databaseId).containers.readAll().fetchAll();
     return sdkResponse.resources as DataModels.Collection[];
+  } catch (error) {
+    handleError(error, "ReadCollections", `Error while querying containers for database ${databaseId}`);
+    throw error;
+  } finally {
+    clearMessage();
+  }
+}
+
+export async function readCollectionsWithPagination(
+  databaseId: string,
+  continuationToken?: string,
+): Promise<DataModels.CollectionsWithPagination> {
+  const clearMessage = logConsoleProgress(`Querying containers for database ${databaseId}`);
+  try {
+    const sdkResponse = await client().database(databaseId).containers.query(
+      { query: "SELECT * FROM c" },
+      {
+        continuationToken,
+        maxItemCount: Queries.containersPerPage,
+      }).fetchNext();
+    const collectionsWithPagination: DataModels.CollectionsWithPagination = {
+      collections: sdkResponse.resources as DataModels.Collection[],
+      continuationToken: sdkResponse.continuationToken
+    };
+    return collectionsWithPagination;
   } catch (error) {
     handleError(error, "ReadCollections", `Error while querying containers for database ${databaseId}`);
     throw error;

--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -158,14 +158,14 @@ export interface Collection extends Resource {
 
 export interface CollectionsWithPagination {
   continuationToken?: string;
-  collections?: Collection[]
+  collections?: Collection[];
 }
 
 export interface Database extends Resource {
   collections?: Collection[];
 }
 
-export interface DocumentId extends Resource { }
+export interface DocumentId extends Resource {}
 
 export interface ConflictId extends Resource {
   resourceId?: string;

--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -156,11 +156,16 @@ export interface Collection extends Resource {
   requestSchema?: () => void;
 }
 
+export interface CollectionsWithPagination {
+  continuationToken?: string;
+  collections?: Collection[]
+}
+
 export interface Database extends Resource {
   collections?: Collection[];
 }
 
-export interface DocumentId extends Resource {}
+export interface DocumentId extends Resource { }
 
 export interface ConflictId extends Resource {
   resourceId?: string;

--- a/src/Contracts/ViewModels.ts
+++ b/src/Contracts/ViewModels.ts
@@ -3,7 +3,7 @@ import {
   Resource,
   StoredProcedureDefinition,
   TriggerDefinition,
-  UserDefinedFunctionDefinition,
+  UserDefinedFunctionDefinition
 } from "@azure/cosmos";
 import Explorer from "../Explorer/Explorer";
 import { ConsoleData } from "../Explorer/Menus/NotificationConsole/ConsoleData";
@@ -87,13 +87,13 @@ export interface Database extends TreeNode {
   isDatabaseExpanded: ko.Observable<boolean>;
   isDatabaseShared: ko.Computed<boolean>;
   isSampleDB?: boolean;
-
+  collectionsContinuationToken?: string;
   selectedSubnodeKind: ko.Observable<CollectionTabKind>;
 
   expandDatabase(): Promise<void>;
   collapseDatabase(): void;
 
-  loadCollections(): Promise<void>;
+  loadCollections(restart?: boolean): Promise<void>;
   findCollectionWithId(collectionId: string): Collection;
   openAddCollection(database: Database, event: MouseEvent): void;
   onSettingsClick: () => void;

--- a/src/Contracts/ViewModels.ts
+++ b/src/Contracts/ViewModels.ts
@@ -3,7 +3,7 @@ import {
   Resource,
   StoredProcedureDefinition,
   TriggerDefinition,
-  UserDefinedFunctionDefinition
+  UserDefinedFunctionDefinition,
 } from "@azure/cosmos";
 import Explorer from "../Explorer/Explorer";
 import { ConsoleData } from "../Explorer/Menus/NotificationConsole/ConsoleData";

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -577,7 +577,7 @@ export default class Explorer {
     try {
       await Promise.all(
         databasesToLoad.map(async (database: ViewModels.Database) => {
-          await database.loadCollections();
+          await database.loadCollections(true);
           const isNewDatabase: boolean = _.some(newDatabases, (db: ViewModels.Database) => db.id() === database.id());
           if (isNewDatabase) {
             database.expandDatabase();

--- a/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
+++ b/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
@@ -195,7 +195,7 @@ export const SettingsPane: FunctionComponent = () => {
             <div className="settingsSectionLabel">
               Enable container pagination
               <InfoTooltip>
-                Load {Constants.Queries.containersPerPage.toString()} containers at a time.
+                Load 50 containers at a time.
                 Currently, containers are not pulled in alphanumeric order.
               </InfoTooltip>
             </div>

--- a/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
+++ b/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
@@ -196,6 +196,7 @@ export const SettingsPane: FunctionComponent = () => {
               Enable container pagination
               <InfoTooltip>
                 Load {Constants.Queries.containersPerPage.toString()} containers at a time.
+                Currently, containers are not pulled in alphanumeric order.
               </InfoTooltip>
             </div>
             <Checkbox

--- a/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
+++ b/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
@@ -79,7 +79,8 @@ export const SettingsPane: FunctionComponent = () => {
 
     if (shouldShowGraphAutoVizOption) {
       logConsoleInfo(
-        `Graph result will be displayed as ${LocalStorageUtility.getEntryBoolean(StorageKey.IsGraphAutoVizDisabled) ? "JSON" : "Graph"
+        `Graph result will be displayed as ${
+          LocalStorageUtility.getEntryBoolean(StorageKey.IsGraphAutoVizDisabled) ? "JSON" : "Graph"
         }`
       );
     }
@@ -195,8 +196,7 @@ export const SettingsPane: FunctionComponent = () => {
             <div className="settingsSectionLabel">
               Enable container pagination
               <InfoTooltip>
-                Load 50 containers at a time.
-                Currently, containers are not pulled in alphanumeric order.
+                Load 50 containers at a time. Currently, containers are not pulled in alphanumeric order.
               </InfoTooltip>
             </div>
             <Checkbox

--- a/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
+++ b/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
@@ -21,6 +21,11 @@ export const SettingsPane: FunctionComponent = () => {
   const [customItemPerPage, setCustomItemPerPage] = useState<number>(
     LocalStorageUtility.getEntryNumber(StorageKey.CustomItemPerPage) || 0
   );
+  const [containerPaginationEnabled, setContainerPaginationEnabled] = useState<boolean>(
+    LocalStorageUtility.hasItem(StorageKey.ContainerPaginationEnabled)
+      ? LocalStorageUtility.getEntryString(StorageKey.ContainerPaginationEnabled) === "true"
+      : false
+  );
   const [crossPartitionQueryEnabled, setCrossPartitionQueryEnabled] = useState<boolean>(
     LocalStorageUtility.hasItem(StorageKey.IsCrossPartitionQueryEnabled)
       ? LocalStorageUtility.getEntryString(StorageKey.IsCrossPartitionQueryEnabled) === "true"
@@ -50,6 +55,7 @@ export const SettingsPane: FunctionComponent = () => {
       isCustomPageOptionSelected() ? customItemPerPage : Constants.Queries.unlimitedItemsPerPage
     );
     LocalStorageUtility.setEntryNumber(StorageKey.CustomItemPerPage, customItemPerPage);
+    LocalStorageUtility.setEntryString(StorageKey.ContainerPaginationEnabled, containerPaginationEnabled.toString());
     LocalStorageUtility.setEntryString(StorageKey.IsCrossPartitionQueryEnabled, crossPartitionQueryEnabled.toString());
     LocalStorageUtility.setEntryNumber(StorageKey.MaxDegreeOfParellism, maxDegreeOfParallelism);
 
@@ -73,8 +79,7 @@ export const SettingsPane: FunctionComponent = () => {
 
     if (shouldShowGraphAutoVizOption) {
       logConsoleInfo(
-        `Graph result will be displayed as ${
-          LocalStorageUtility.getEntryBoolean(StorageKey.IsGraphAutoVizDisabled) ? "JSON" : "Graph"
+        `Graph result will be displayed as ${LocalStorageUtility.getEntryBoolean(StorageKey.IsGraphAutoVizDisabled) ? "JSON" : "Graph"
         }`
       );
     }
@@ -185,6 +190,25 @@ export const SettingsPane: FunctionComponent = () => {
             </div>
           </div>
         )}
+        <div className="settingsSection">
+          <div className="settingsSectionPart">
+            <div className="settingsSectionLabel">
+              Enable container pagination
+              <InfoTooltip>
+                Load {Constants.Queries.containersPerPage.toString()} containers at a time.
+              </InfoTooltip>
+            </div>
+            <Checkbox
+              styles={{
+                label: { padding: 0 },
+              }}
+              className="padding"
+              ariaLabel="Enable container pagination"
+              checked={containerPaginationEnabled}
+              onChange={() => setContainerPaginationEnabled(!containerPaginationEnabled)}
+            />
+          </div>
+        </div>
         {shouldShowCrossPartitionOption && (
           <div className="settingsSection">
             <div className="settingsSectionPart">

--- a/src/Explorer/Panes/SettingsPane/__snapshots__/SettingsPane.test.tsx.snap
+++ b/src/Explorer/Panes/SettingsPane/__snapshots__/SettingsPane.test.tsx.snap
@@ -106,6 +106,35 @@ exports[`Settings Pane should render Default properly 1`] = `
         <div
           className="settingsSectionLabel"
         >
+          Enable container pagination
+          <InfoTooltip>
+            Load 50 containers at a time. Currently, containers are not pulled in alphanumeric order.
+          </InfoTooltip>
+        </div>
+        <StyledCheckboxBase
+          ariaLabel="Enable container pagination"
+          checked={false}
+          className="padding"
+          onChange={[Function]}
+          styles={
+            Object {
+              "label": Object {
+                "padding": 0,
+              },
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="settingsSection"
+    >
+      <div
+        className="settingsSectionPart"
+      >
+        <div
+          className="settingsSectionLabel"
+        >
           Enable cross-partition query
           <InfoTooltip>
             Send more than one request while executing a query. More than one request is necessary if the query is not scoped to single partition key value.
@@ -182,6 +211,35 @@ exports[`Settings Pane should render Gremlin properly 1`] = `
   <div
     className="paneMainContent"
   >
+    <div
+      className="settingsSection"
+    >
+      <div
+        className="settingsSectionPart"
+      >
+        <div
+          className="settingsSectionLabel"
+        >
+          Enable container pagination
+          <InfoTooltip>
+            Load 50 containers at a time. Currently, containers are not pulled in alphanumeric order.
+          </InfoTooltip>
+        </div>
+        <StyledCheckboxBase
+          ariaLabel="Enable container pagination"
+          checked={false}
+          className="padding"
+          onChange={[Function]}
+          styles={
+            Object {
+              "label": Object {
+                "padding": 0,
+              },
+            }
+          }
+        />
+      </div>
+    </div>
     <div
       className="settingsSection"
     >

--- a/src/Explorer/Tree/Database.tsx
+++ b/src/Explorer/Tree/Database.tsx
@@ -164,7 +164,7 @@ export default class Database implements ViewModels.Database {
     });
   }
 
-  public async loadCollections(restart: boolean = false) {
+  public async loadCollections(restart = false) {
     const collectionVMs: Collection[] = [];
     let collections: DataModels.Collection[] = [];
     if (restart) {
@@ -178,7 +178,7 @@ export default class Database implements ViewModels.Database {
         this.id(),
         this.collectionsContinuationToken);
 
-      if (collectionsWithPagination.collections?.length == Constants.Queries.containersPerPage) {
+      if (collectionsWithPagination.collections?.length === Constants.Queries.containersPerPage) {
         this.collectionsContinuationToken = collectionsWithPagination.continuationToken;
       } else {
         this.collectionsContinuationToken = undefined;

--- a/src/Explorer/Tree/Database.tsx
+++ b/src/Explorer/Tree/Database.tsx
@@ -143,7 +143,7 @@ export default class Database implements ViewModels.Database {
 
     await this.loadOffer();
 
-    if (this.collections()?.length == 0) {
+    if (this.collections()?.length === 0) {
       await this.loadCollections(true);
     }
 

--- a/src/Explorer/Tree/Database.tsx
+++ b/src/Explorer/Tree/Database.tsx
@@ -170,13 +170,14 @@ export default class Database implements ViewModels.Database {
     if (restart) {
       this.collectionsContinuationToken = undefined;
     }
-    const containerPaginationEnabled = StorageUtility.LocalStorageUtility.getEntryString(
-      StorageUtility.StorageKey.ContainerPaginationEnabled
-    ) === "true";
+    const containerPaginationEnabled =
+      StorageUtility.LocalStorageUtility.getEntryString(StorageUtility.StorageKey.ContainerPaginationEnabled) ===
+      "true";
     if (containerPaginationEnabled) {
       const collectionsWithPagination: DataModels.CollectionsWithPagination = await readCollectionsWithPagination(
         this.id(),
-        this.collectionsContinuationToken);
+        this.collectionsContinuationToken
+      );
 
       if (collectionsWithPagination.collections?.length === Constants.Queries.containersPerPage) {
         this.collectionsContinuationToken = collectionsWithPagination.continuationToken;

--- a/src/Explorer/Tree/Database.tsx
+++ b/src/Explorer/Tree/Database.tsx
@@ -142,7 +142,11 @@ export default class Database implements ViewModels.Database {
     }
 
     await this.loadOffer();
-    await this.loadCollections(true);
+
+    if (this.collections()?.length == 0) {
+      await this.loadCollections(true);
+    }
+
     this.isDatabaseExpanded(true);
     TelemetryProcessor.trace(Action.ExpandTreeNode, ActionModifiers.Mark, {
       description: "Database node",

--- a/src/Explorer/Tree/ResourceTree.tsx
+++ b/src/Explorer/Tree/ResourceTree.tsx
@@ -479,6 +479,17 @@ export const ResourceTree: React.FC<ResourceTreeProps> = ({ container }: Resourc
           databaseNode.children.push(buildCollectionNode(database, collection))
         );
 
+      if (database.collectionsContinuationToken) {
+        const loadMoreNode: TreeNode = {
+          label: "load more",
+          onClick: async () => {
+            await database.loadCollections();
+            useDatabases.getState().updateDatabase(this);
+          }
+        }
+        databaseNode.children.push(loadMoreNode)
+      }
+
       database.collections.subscribe((collections: ViewModels.Collection[]) => {
         collections.forEach((collection: ViewModels.Collection) =>
           databaseNode.children.push(buildCollectionNode(database, collection))

--- a/src/Explorer/Tree/ResourceTree.tsx
+++ b/src/Explorer/Tree/ResourceTree.tsx
@@ -482,6 +482,7 @@ export const ResourceTree: React.FC<ResourceTreeProps> = ({ container }: Resourc
       if (database.collectionsContinuationToken) {
         const loadMoreNode: TreeNode = {
           label: "load more",
+          className: "loadMoreHeader",
           onClick: async () => {
             await database.loadCollections();
             useDatabases.getState().updateDatabase(database);

--- a/src/Explorer/Tree/ResourceTree.tsx
+++ b/src/Explorer/Tree/ResourceTree.tsx
@@ -485,9 +485,9 @@ export const ResourceTree: React.FC<ResourceTreeProps> = ({ container }: Resourc
           onClick: async () => {
             await database.loadCollections();
             useDatabases.getState().updateDatabase(database);
-          }
-        }
-        databaseNode.children.push(loadMoreNode)
+          },
+        };
+        databaseNode.children.push(loadMoreNode);
       }
 
       database.collections.subscribe((collections: ViewModels.Collection[]) => {

--- a/src/Explorer/Tree/ResourceTree.tsx
+++ b/src/Explorer/Tree/ResourceTree.tsx
@@ -484,7 +484,7 @@ export const ResourceTree: React.FC<ResourceTreeProps> = ({ container }: Resourc
           label: "load more",
           onClick: async () => {
             await database.loadCollections();
-            useDatabases.getState().updateDatabase(this);
+            useDatabases.getState().updateDatabase(database);
           }
         }
         databaseNode.children.push(loadMoreNode)

--- a/src/Shared/StorageUtility.ts
+++ b/src/Shared/StorageUtility.ts
@@ -4,6 +4,7 @@ import * as SessionStorageUtility from "./SessionStorageUtility";
 export { LocalStorageUtility, SessionStorageUtility };
 export enum StorageKey {
   ActualItemPerPage,
+  ContainerPaginationEnabled,
   CustomItemPerPage,
   DatabaseAccountId,
   EncryptedKeyToken,


### PR DESCRIPTION
[Preview this branch](https://ms.portal.azure.com/?dataExplorerSource=https%3A%2F%2Fcosmos-explorer-preview.azurewebsites.net%2Fcommit%2F8688fa71ac5947c5b8c5aeb55c0a8b122cb186d2%2Fexplorer.html%3Ffeature.pr%3Dhttps%253A%252F%252Fgithub.com%252FAzure%252Fcosmos-explorer%252Fpull%252F1411%2523users%252Faisayas%252Flazyloading#@microsoft.onmicrosoft.com/resource/subscriptions/b9c77f10-b438-4c32-9819-eef8a654e478/resourceGroups/aisayas/providers/Microsoft.DocumentDb/databaseAccounts/aisayas-gremlin/dataExplorer)

Load containers with a _load more_ button if a database has more than 50 containers. Toggle was also added to allow the user to opt in (or out). 

**Note - Containers are not fetched in alphanumeric order during pagination

<img width="268" alt="image" src="https://user-images.githubusercontent.com/29680641/228901251-6d9232e4-1a69-440e-8e4a-653e629e6672.png">

<img width="412" alt="image" src="https://user-images.githubusercontent.com/29680641/228901360-f94efe37-d157-4af5-bbf9-8a79aa0095fa.png">

