### PR TITLE
Load Legacy Mongo Shell V2 by default

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,8 @@ module.exports = {
   // clearMocks: false,
 
   // Indicates whether the coverage information should be collected while executing the test
-  collectCoverage: true,
+
+  collectCoverage: process.env.skipCodeCoverage === "true" ? false : true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   collectCoverageFrom: ["src/**/*.{js,jsx,ts,tsx}"],

--- a/src/Explorer/Tabs/MongoShellTab/getMongoShellOrigin.test.ts
+++ b/src/Explorer/Tabs/MongoShellTab/getMongoShellOrigin.test.ts
@@ -12,18 +12,19 @@ describe("getMongoShellOrigin", () => {
         new URLSearchParams({
           "feature.enableLegacyMongoShellV1": "false",
           "feature.enableLegacyMongoShellV2": "false",
-          "feature.enableLegacyMongoShellV1Dist": "false",
-          "feature.enableLegacyMongoShellV2Dist": "false",
+          "feature.enableLegacyMongoShellV1Debug": "false",
+          "feature.enableLegacyMongoShellV2Debug": "false",
+          "feature.loadLegacyMongoShellFromBE": "false",
         })
       ),
     });
   });
 
-  it("should return BACKEND_ENDPOINT by default", () => {
-    expect(getMongoShellOrigin()).toBe(configContext.BACKEND_ENDPOINT);
+  it("should return  by default", () => {
+    expect(getMongoShellOrigin()).toBe(window.origin);
   });
 
-  it("should return /mongoshell/index.html when enableLegacyMongoShellV1", () => {
+  it("should return window.origin when enableLegacyMongoShellV1", () => {
     updateUserContext({
       features: extractFeatures(
         new URLSearchParams({
@@ -35,7 +36,7 @@ describe("getMongoShellOrigin", () => {
     expect(getMongoShellOrigin()).toBe(window.origin);
   });
 
-  it("should return /mongoshell/index.html when enableLegacyMongoShellV2===true", () => {
+  it("should return window.origin when enableLegacyMongoShellV2===true", () => {
     updateUserContext({
       features: extractFeatures(
         new URLSearchParams({
@@ -47,11 +48,11 @@ describe("getMongoShellOrigin", () => {
     expect(getMongoShellOrigin()).toBe(window.origin);
   });
 
-  it("should return /mongoshell/index.html when enableLegacyMongoShellV1Dist===true", () => {
+  it("should return window.origin when enableLegacyMongoShellV1Debug===true", () => {
     updateUserContext({
       features: extractFeatures(
         new URLSearchParams({
-          "feature.enableLegacyMongoShellV1Dist": "true",
+          "feature.enableLegacyMongoShellV1Debug": "true",
         })
       ),
     });
@@ -59,15 +60,27 @@ describe("getMongoShellOrigin", () => {
     expect(getMongoShellOrigin()).toBe(window.origin);
   });
 
-  it("should return /mongoshell/index.html when enableLegacyMongoShellV2Dist===true", () => {
+  it("should return window.origin when enableLegacyMongoShellV2Debug===true", () => {
     updateUserContext({
       features: extractFeatures(
         new URLSearchParams({
-          "feature.enableLegacyMongoShellV2Dist": "true",
+          "feature.enableLegacyMongoShellV2Debug": "true",
         })
       ),
     });
 
     expect(getMongoShellOrigin()).toBe(window.origin);
+  });
+
+  it("should return BACKEND_ENDPOINT when loadLegacyMongoShellFromBE===true", () => {
+    updateUserContext({
+      features: extractFeatures(
+        new URLSearchParams({
+          "feature.loadLegacyMongoShellFromBE": "true",
+        })
+      ),
+    });
+
+    expect(getMongoShellOrigin()).toBe(configContext.BACKEND_ENDPOINT);
   });
 });

--- a/src/Explorer/Tabs/MongoShellTab/getMongoShellOrigin.ts
+++ b/src/Explorer/Tabs/MongoShellTab/getMongoShellOrigin.ts
@@ -2,14 +2,9 @@ import { configContext } from "../../../ConfigContext";
 import { userContext } from "../../../UserContext";
 
 export function getMongoShellOrigin(): string {
-  if (
-    userContext.features.enableLegacyMongoShellV1 === true ||
-    userContext.features.enableLegacyMongoShellV2 === true ||
-    userContext.features.enableLegacyMongoShellV1Dist === true ||
-    userContext.features.enableLegacyMongoShellV2Dist === true
-  ) {
-    return window.origin;
+  if (userContext.features.loadLegacyMongoShellFromBE === true) {
+    return configContext.BACKEND_ENDPOINT;
   }
 
-  return configContext.BACKEND_ENDPOINT;
+  return window.origin;
 }

--- a/src/Explorer/Tabs/MongoShellTab/getMongoShellUrl.ts
+++ b/src/Explorer/Tabs/MongoShellTab/getMongoShellUrl.ts
@@ -12,25 +12,28 @@ export function getMongoShellUrl(): string {
     return `/mongoshell/index.html?${queryString}`;
   }
 
-  if (userContext.features.enableLegacyMongoShellV1Dist === true) {
-    return `/mongoshell/dist/index.html?${queryString}`;
+  if (userContext.features.enableLegacyMongoShellV1Debug === true) {
+    return `/mongoshell/debug/index.html?${queryString}`;
   }
 
   if (userContext.features.enableLegacyMongoShellV2 === true) {
     return `/mongoshell/indexv2.html?${queryString}`;
   }
 
-  if (userContext.features.enableLegacyMongoShellV2Dist === true) {
-    return `/mongoshell/dist/indexv2.html?${queryString}`;
+  if (userContext.features.enableLegacyMongoShellV2Debug === true) {
+    return `/mongoshell/debug/indexv2.html?${queryString}`;
   }
-
-  const extensionEndpoint: string = getExtensionEndpoint(configContext.platform, configContext.BACKEND_ENDPOINT);
 
   if (userContext.portalEnv === "localhost") {
-    return `${extensionEndpoint}/content/mongoshell/index.html?${queryString}`;
+    return `/mongoshell/indexv2.html?${queryString}`;
   }
 
-  return `${extensionEndpoint}/content/mongoshell/dist/index.html?${queryString}`;
+  if (userContext.features.loadLegacyMongoShellFromBE === true) {
+    const extensionEndpoint: string = getExtensionEndpoint(configContext.platform, configContext.BACKEND_ENDPOINT);
+    return `${extensionEndpoint}/content/mongoshell/debug/index.html?${queryString}`;
+  }
+
+  return `/mongoshell/indexv2.html?${queryString}`;
 }
 
 export function getExtensionEndpoint(platform: string, backendEndpoint: string): string {

--- a/src/Platform/Hosted/extractFeatures.ts
+++ b/src/Platform/Hosted/extractFeatures.ts
@@ -31,9 +31,10 @@ export type Features = {
   readonly enableThroughputCap: boolean;
   readonly enableHierarchicalKeys: boolean;
   readonly enableLegacyMongoShellV1: boolean;
-  readonly enableLegacyMongoShellV1Dist: boolean;
+  readonly enableLegacyMongoShellV1Debug: boolean;
   readonly enableLegacyMongoShellV2: boolean;
-  readonly enableLegacyMongoShellV2Dist: boolean;
+  readonly enableLegacyMongoShellV2Debug: boolean;
+  readonly loadLegacyMongoShellFromBE: boolean;
 
   // can be set via both flight and feature flag
   autoscaleDefault: boolean;
@@ -97,9 +98,10 @@ export function extractFeatures(given = new URLSearchParams(window.location.sear
     enableThroughputCap: "true" === get("enablethroughputcap"),
     enableHierarchicalKeys: "true" === get("enablehierarchicalkeys"),
     enableLegacyMongoShellV1: "true" === get("enablelegacymongoshellv1"),
-    enableLegacyMongoShellV1Dist: "true" === get("enablelegacymongoshellv1dist"),
+    enableLegacyMongoShellV1Debug: "true" === get("enablelegacymongoshellv1debug"),
     enableLegacyMongoShellV2: "true" === get("enablelegacymongoshellv2"),
-    enableLegacyMongoShellV2Dist: "true" === get("enablelegacymongoshellv2dist"),
+    enableLegacyMongoShellV2Debug: "true" === get("enablelegacymongoshellv2debug"),
+    loadLegacyMongoShellFromBE: "true" === get("loadlegacymongoshellfrombe"),
   };
 }
 


### PR DESCRIPTION
- Load Legacy Mongo Shell V2 by default
- Add/Keep feature flags to load from portal BE and V1
- Skip code coverage if skipCodeCoverage environment variable is set to "true"

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
