### PR TITLE
Border at the bottom has been added  for the tabs to differntiate from unselected tabs

### DIFF
--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -121,7 +121,7 @@ function TabNav({ tab, active, tabKind }: { tab?: Tab; active: boolean; tabKind?
             className="tabNavText"
             style={active ? { fontWeight: "bolder", borderBottom: "2px solid rgba(0,120,212,1)" } : {}}
           >
-            {useObservable(tab?.tabTitle || ko.observable(ReactTabKind[tabKind]))}
+            {useObservable(tab?.tabTitle || getReactTabTitle())
           </span>
           {tabKind !== ReactTabKind.Home && (
             <span className="tabIconSection">

--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -121,7 +121,7 @@ function TabNav({ tab, active, tabKind }: { tab?: Tab; active: boolean; tabKind?
             className="tabNavText"
             style={active ? { fontWeight: "bolder", borderBottom: "2px solid rgba(0,120,212,1)" } : {}}
           >
-            {useObservable(tab?.tabTitle || getReactTabTitle())
+            {useObservable(tab?.tabTitle || getReactTabTitle())}
           </span>
           {tabKind !== ReactTabKind.Home && (
             <span className="tabIconSection">

--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -117,7 +117,12 @@ function TabNav({ tab, active, tabKind }: { tab?: Tab; active: boolean; tabKind?
               <img className="loadingIcon" title="Loading" src={loadingIcon} alt="Loading" />
             )}
           </span>
-          <span className="tabNavText">{useObservable(tab?.tabTitle || getReactTabTitle())}</span>
+          <span
+            className="tabNavText"
+            style={active ? { fontWeight: "bolder", borderBottom: "2px solid rgba(0,120,212,1)" } : {}}
+          >
+            {useObservable(tab?.tabTitle || ko.observable(ReactTabKind[tabKind]))}
+          </span>
           {tabKind !== ReactTabKind.Home && (
             <span className="tabIconSection">
               <CloseButton tab={tab} active={active} hovering={hovering} tabKind={tabKind} />


### PR DESCRIPTION
…m unselected tabs while using contrast themes

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1509?feature.someFeatureFlagYouMightNeed=true)
The selected tabs present in " data explorer " are not differentiated from unselected tabs when high contrast themes are applied. A border at the bottom has been added for the tabs to differentiate from the unselected ones.