### PR TITLE
Update Postgres RP API version

### DIFF
--- a/src/Explorer/Tabs/QuickstartTab.tsx
+++ b/src/Explorer/Tabs/QuickstartTab.tsx
@@ -32,7 +32,7 @@ export const QuickstartTab: React.FC<QuickstartTabProps> = ({ explorer }: Quicks
       host: configContext.ARM_ENDPOINT,
       path: firewallRulesUri,
       method: "GET",
-      apiVersion: "2020-10-05-privatepreview",
+      apiVersion: "2022-11-08",
     });
     const firewallRules: PostgresFirewallRule[] = response?.data?.value || response?.value || [];
     const isEnabled = firewallRules.some(

--- a/src/Explorer/Tabs/TerminalTab.tsx
+++ b/src/Explorer/Tabs/TerminalTab.tsx
@@ -134,7 +134,7 @@ export default class TerminalTab extends TabsBase {
       host: configContext.ARM_ENDPOINT,
       path: firewallRulesUri,
       method: "GET",
-      apiVersion: "2020-10-05-privatepreview",
+      apiVersion: "2022-11-08",
     });
     const firewallRules: DataModels.PostgresFirewallRule[] = response?.data?.value || response?.value || [];
     const isEnabled = firewallRules.some(


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

This change updates the Postgres RP API version from 2020-10-05-privatepreview to 2022-11-08.

