### PR TITLE
Reverse cross partition query behavior in DE Query settings pane

### DIFF
--- a/src/Explorer/ContextMenuButtonFactory.tsx
+++ b/src/Explorer/ContextMenuButtonFactory.tsx
@@ -141,14 +141,12 @@ export const createCollectionContextMenuButton = (
   return items;
 };
 
-export const createSampleCollectionContextMenuButton = (
-  selectedCollection: ViewModels.CollectionBase
-): TreeNodeMenuItem[] => {
+export const createSampleCollectionContextMenuButton = (): TreeNodeMenuItem[] => {
   const items: TreeNodeMenuItem[] = [];
   if (userContext.apiType === "SQL") {
     items.push({
       iconSrc: AddSqlQueryIcon,
-      onClick: () => selectedCollection && useTabs.getState().openAndActivateReactTab(ReactTabKind.QueryCopilot),
+      onClick: () => useTabs.getState().openAndActivateReactTab(ReactTabKind.QueryCopilot),
       label: "New SQL Query",
     });
   }

--- a/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
+++ b/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
@@ -2,12 +2,12 @@ import { Checkbox, ChoiceGroup, IChoiceGroupOption, SpinButton } from "@fluentui
 import * as Constants from "Common/Constants";
 import { InfoTooltip } from "Common/Tooltip/InfoTooltip";
 import { configContext } from "ConfigContext";
-import { useSidePanel } from "hooks/useSidePanel";
-import React, { FunctionComponent, MouseEvent, useState } from "react";
 import { LocalStorageUtility, StorageKey } from "Shared/StorageUtility";
 import * as StringUtility from "Shared/StringUtility";
 import { userContext } from "UserContext";
 import { logConsoleInfo } from "Utils/NotificationConsoleUtils";
+import { useSidePanel } from "hooks/useSidePanel";
+import React, { FunctionComponent, MouseEvent, useState } from "react";
 import { RightPaneForm, RightPaneFormProps } from "../RightPaneForm/RightPaneForm";
 
 export const SettingsPane: FunctionComponent = () => {
@@ -29,7 +29,7 @@ export const SettingsPane: FunctionComponent = () => {
   const [crossPartitionQueryEnabled, setCrossPartitionQueryEnabled] = useState<boolean>(
     LocalStorageUtility.hasItem(StorageKey.IsCrossPartitionQueryEnabled)
       ? LocalStorageUtility.getEntryString(StorageKey.IsCrossPartitionQueryEnabled) === "true"
-      : true
+      : false
   );
   const [graphAutoVizDisabled, setGraphAutoVizDisabled] = useState<string>(
     LocalStorageUtility.hasItem(StorageKey.IsGraphAutoVizDisabled)

--- a/src/Explorer/Panes/SettingsPane/__snapshots__/SettingsPane.test.tsx.snap
+++ b/src/Explorer/Panes/SettingsPane/__snapshots__/SettingsPane.test.tsx.snap
@@ -142,7 +142,7 @@ exports[`Settings Pane should render Default properly 1`] = `
         </div>
         <StyledCheckboxBase
           ariaLabel="Enable cross partition query"
-          checked={true}
+          checked={false}
           className="padding"
           onChange={[Function]}
           styles={

--- a/src/Explorer/QueryCopilot/Modal/WelcomeModal.tsx
+++ b/src/Explorer/QueryCopilot/Modal/WelcomeModal.tsx
@@ -18,7 +18,6 @@ export const WelcomeModal = ({ visible }: { visible: boolean }): JSX.Element => 
 
   return (
     <>
-      (
       <Modal isOpen={isModalVisible} onDismiss={hideModal} isBlocking={false}>
         <Stack className="modalContentPadding">
           <Stack horizontal>
@@ -110,7 +109,6 @@ export const WelcomeModal = ({ visible }: { visible: boolean }): JSX.Element => 
           </Stack>
         </Stack>
       </Modal>
-      )
     </>
   );
 };

--- a/src/Explorer/QueryCopilot/QueryCopilotTab.tsx
+++ b/src/Explorer/QueryCopilot/QueryCopilotTab.tsx
@@ -448,19 +448,17 @@ export const QueryCopilotTab: React.FC<QueryCopilotTabProps> = ({
         <Link href="" target="_blank">
           Read preview terms
         </Link>
-        {showErrorMessageBar ? (
+        {showErrorMessageBar && (
           <Stack style={{ backgroundColor: "#FEF0F1", padding: "4px 8px" }} horizontal verticalAlign="center">
             <Image src={XErrorMessage} style={{ marginRight: "8px" }} />
             <Text style={{ fontSize: 12 }}>
               We ran into an error and were not able to execute query. Please try again after sometime
             </Text>
           </Stack>
-        ) : (
-          <></>
         )}
       </Text>
 
-      {showFeedbackBar ? (
+      {showFeedbackBar && (
         <Stack style={{ backgroundColor: "#FFF8F0", padding: "2px 8px" }} horizontal verticalAlign="center">
           <Text style={{ fontWeight: 600, fontSize: 12 }}>Provide feedback on the query generated</Text>
           {showCallout && !hideFeedbackModalForLikedQueries && (
@@ -528,8 +526,6 @@ export const QueryCopilotTab: React.FC<QueryCopilotTabProps> = ({
             Delete code
           </CommandBarButton>
         </Stack>
-      ) : (
-        <></>
       )}
 
       <Stack className="tabPaneContentContainer">
@@ -553,9 +549,9 @@ export const QueryCopilotTab: React.FC<QueryCopilotTabProps> = ({
           />
         </SplitterLayout>
       </Stack>
-      <WelcomeModal visible={localStorage.getItem("hideWelcomeModal") !== "true"}></WelcomeModal>
-      {isSamplePromptsOpen ? <SamplePrompts sampleProps={sampleProps} /> : <></>}
-      {query !== "" && query.trim().length !== 0 ? (
+      <WelcomeModal visible={localStorage.getItem("hideWelcomeModal") !== "true"} />
+      {isSamplePromptsOpen && <SamplePrompts sampleProps={sampleProps} />}
+      {query !== "" && query.trim().length !== 0 && (
         <DeletePopup
           showDeletePopup={showDeletePopup}
           setShowDeletePopup={setShowDeletePopup}
@@ -563,8 +559,6 @@ export const QueryCopilotTab: React.FC<QueryCopilotTabProps> = ({
           clearFeedback={resetButtonState}
           showFeedbackBar={setShowFeedbackBar}
         />
-      ) : (
-        <></>
       )}
       <CopyPopup showCopyPopup={showCopyPopup} setShowCopyPopup={setshowCopyPopup} />
     </Stack>

--- a/src/Explorer/QueryCopilot/QueryCopilotTab.tsx
+++ b/src/Explorer/QueryCopilot/QueryCopilotTab.tsx
@@ -294,6 +294,7 @@ export const QueryCopilotTab: React.FC<QueryCopilotTabProps> = ({
       generateSQLQuery();
     }
     showTeachingBubble();
+    useTabs.getState().setIsQueryErrorThrown(false);
   }, []);
 
   return (

--- a/src/Explorer/Tree/SampleDataTree.tsx
+++ b/src/Explorer/Tree/SampleDataTree.tsx
@@ -29,9 +29,7 @@ export const SampleDataTree = ({
             iconSrc: CollectionIcon,
             isExpanded: false,
             className: "dataResourceTree",
-            contextMenu: ResourceTreeContextMenuButtonFactory.createSampleCollectionContextMenuButton(
-              sampleDataResourceTokenCollection
-            ),
+            contextMenu: ResourceTreeContextMenuButtonFactory.createSampleCollectionContextMenuButton(),
             onClick: () => {
               // Rewritten version of expandCollapseCollection
               useSelectedNode.getState().setSelectedNode(sampleDataResourceTokenCollection);


### PR DESCRIPTION
This PR contains reversing logic for cross partition queries, removing parameter which were previously used in Query Copilot part of the code that opens Query Copilot tab, and also small changes/improvements/bugs in Query Copilot in general.

Related work items:
https://msdata.visualstudio.com/CosmosDB/_workitems/edit/2183598
https://msdata.visualstudio.com/CosmosDB/_workitems/edit/2523302

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1521?feature.someFeatureFlagYouMightNeed=true)
