### PR TITLE
removing the connect value for ariacontrols variable

### DIFF
--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -68,7 +68,7 @@ export const Tabs = ({ explorer }: TabsProps): JSX.Element => {
 function TabNav({ tab, active, tabKind }: { tab?: Tab; active: boolean; tabKind?: ReactTabKind }) {
   const [hovering, setHovering] = useState(false);
   const focusTab = useRef<HTMLLIElement>() as MutableRefObject<HTMLLIElement>;
-  const tabId = tab ? tab.tabId : "connect";
+  const tabId = tab ? tab.tabId : "";
 
   const getReactTabTitle = (): ko.Observable<string> => {
     if (tabKind === ReactTabKind.QueryCopilot) {


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1527?feature.someFeatureFlagYouMightNeed=true)

Aria-controls is an attribute that identifies the controlled element from the controlling element. Eg..,. A button is present which opens a tab. Here the button is the controller and the tab is the controlled element. Establishing this relation helps in navigation of the page logically with supported browsers.But in our case, we don't have an id "connect " to use aria-controls. Hence removing the connect that appears in the case of default "Home" tab

https://msdata.visualstudio.com/CosmosDB/_workitems/edit/2236143