### PR TITLE
[Query Copilot] Not disabling create database/container buttons for Sample Database

### DIFF
--- a/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
@@ -268,7 +268,6 @@ function createNewCollectionGroup(container: Explorer): CommandButtonComponentPr
     ariaLabel: label,
     hasPopup: true,
     id: "createNewContainerCommandButton",
-    disabled: useSelectedNode.getState().isQueryCopilotCollectionSelected(),
   };
 }
 
@@ -314,7 +313,6 @@ function createNewDatabase(container: Explorer): CommandButtonComponentProps {
     commandButtonLabel: label,
     ariaLabel: label,
     hasPopup: true,
-    disabled: useSelectedNode.getState().isQueryCopilotCollectionSelected(),
   };
 }
 


### PR DESCRIPTION
This pull request contains fix where it will allow user to create Container or Database even if Sample Database is selected.

Related work items:
[AB#2528027](https://msdata.visualstudio.com/ba574a88-a171-48e0-8fcb-5fef6d23739c/_workitems/edit/2528027)

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1531?feature.someFeatureFlagYouMightNeed=true)
