### PR TITLE
Query Results no longer blocked for clicking/copying content

### DIFF
--- a/src/Explorer/Controls/Editor/EditorReact.tsx
+++ b/src/Explorer/Controls/Editor/EditorReact.tsx
@@ -31,6 +31,13 @@ export class EditorReact extends React.Component<EditorReactProps, EditorReactSt
 
   public componentDidMount(): void {
     this.createEditor(this.configureEditor.bind(this));
+
+    setTimeout(() => {
+      const suggestionWidget = this.editor?.getDomNode()?.querySelector(".suggest-widget") as HTMLElement;
+      if (suggestionWidget) {
+        suggestionWidget.style.display = "none";
+      }
+    }, 100);
   }
 
   public componentDidUpdate(previous: EditorReactProps) {


### PR DESCRIPTION
This pull request contains fix for a bug that doesn't allow user clicking the Query Results in the SQL/Query Copilot Tab. User would be able to select and copy content of the query results with this fix.

Related task:
[AB#2501400](https://msdata.visualstudio.com/ba574a88-a171-48e0-8fcb-5fef6d23739c/_workitems/edit/2501400)

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1537?feature.someFeatureFlagYouMightNeed=true)
