### PR TITLE
[Query Copilot] Hide error message bar when request is successful

### DIFF
--- a/src/Explorer/QueryCopilot/QueryCopilotTab.tsx
+++ b/src/Explorer/QueryCopilot/QueryCopilotTab.tsx
@@ -188,6 +188,7 @@ export const QueryCopilotTab: React.FC<QueryCopilotTabProps> = ({
           query += generateSQLQueryResponse.sql;
           setQuery(query);
           setGeneratedQuery(generateSQLQueryResponse.sql);
+          setShowErrorMessageBar(false);
         }
       } else {
         handleError(JSON.stringify(generateSQLQueryResponse), "copilotInternalServerError");
@@ -231,6 +232,7 @@ export const QueryCopilotTab: React.FC<QueryCopilotTabProps> = ({
 
       setQueryResults(queryResults);
       setErrorMessage("");
+      setShowErrorMessageBar(false);
     } catch (error) {
       const errorMessage = getErrorMessage(error);
       setErrorMessage(errorMessage);

--- a/src/Explorer/QueryCopilot/SamplePrompts/SamplePrompts.test.tsx
+++ b/src/Explorer/QueryCopilot/SamplePrompts/SamplePrompts.test.tsx
@@ -1,3 +1,4 @@
+import { DefaultButton, IconButton } from "@fluentui/react";
 import { shallow } from "enzyme";
 import React from "react";
 import { SamplePrompts, SamplePromptsProps } from "./SamplePrompts";
@@ -10,6 +11,7 @@ describe("Sample Prompts snapshot test", () => {
     setIsSamplePromptsOpen: setIsSamplePromptsOpenMock,
     setTextBox: setTextBoxMock,
   };
+  beforeEach(() => jest.clearAllMocks());
 
   it("should render properly if isSamplePromptsOpen is true", () => {
     const wrapper = shallow(<SamplePrompts sampleProps={sampleProps} />);
@@ -23,5 +25,67 @@ describe("Sample Prompts snapshot test", () => {
     const wrapper = shallow(<SamplePrompts sampleProps={sampleProps} />);
 
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should call setTextBox and setIsSamplePromptsOpen(false) when a button is clicked", () => {
+    const wrapper = shallow(<SamplePrompts sampleProps={sampleProps} />);
+
+    wrapper.find(DefaultButton).at(0).simulate("click");
+    expect(setTextBoxMock).toHaveBeenCalledWith("Show me products less than 100 dolars");
+    expect(setIsSamplePromptsOpenMock).toHaveBeenCalledWith(false);
+
+    wrapper.find(DefaultButton).at(3).simulate("click");
+    expect(setTextBoxMock).toHaveBeenCalledWith(
+      "Write a query to return all records in this table created in the last thirty days"
+    );
+    expect(setIsSamplePromptsOpenMock).toHaveBeenCalledWith(false);
+  });
+
+  it("should call setIsSamplePromptsOpen(false) when the close button is clicked", () => {
+    const wrapper = shallow(<SamplePrompts sampleProps={sampleProps} />);
+
+    wrapper.find(IconButton).first().simulate("click");
+
+    expect(setIsSamplePromptsOpenMock).toHaveBeenCalledWith(false);
+  });
+
+  it("should call setTextBox and setIsSamplePromptsOpen(false) when a simple prompt button is clicked", () => {
+    const wrapper = shallow(<SamplePrompts sampleProps={sampleProps} />);
+
+    wrapper.find(DefaultButton).at(0).simulate("click");
+    expect(setTextBoxMock).toHaveBeenCalledWith("Show me products less than 100 dolars");
+    expect(setIsSamplePromptsOpenMock).toHaveBeenCalledWith(false);
+
+    wrapper.find(DefaultButton).at(1).simulate("click");
+    expect(setTextBoxMock).toHaveBeenCalledWith("Show schema");
+    expect(setIsSamplePromptsOpenMock).toHaveBeenCalledWith(false);
+  });
+
+  it("should call setTextBox and setIsSamplePromptsOpen(false) when an intermediate prompt button is clicked", () => {
+    const wrapper = shallow(<SamplePrompts sampleProps={sampleProps} />);
+
+    wrapper.find(DefaultButton).at(2).simulate("click");
+    expect(setTextBoxMock).toHaveBeenCalledWith(
+      "Show items with a description that contains a number between 0 and 99 inclusive."
+    );
+    expect(setIsSamplePromptsOpenMock).toHaveBeenCalledWith(false);
+
+    wrapper.find(DefaultButton).at(3).simulate("click");
+    expect(setTextBoxMock).toHaveBeenCalledWith(
+      "Write a query to return all records in this table created in the last thirty days"
+    );
+    expect(setIsSamplePromptsOpenMock).toHaveBeenCalledWith(false);
+  });
+
+  it("should call setTextBox and setIsSamplePromptsOpen(false) when a complex prompt button is clicked", () => {
+    const wrapper = shallow(<SamplePrompts sampleProps={sampleProps} />);
+
+    wrapper.find(DefaultButton).at(4).simulate("click");
+    expect(setTextBoxMock).toHaveBeenCalledWith("Show all the products that customer Bob has reviewed.");
+    expect(setIsSamplePromptsOpenMock).toHaveBeenCalledWith(false);
+
+    wrapper.find(DefaultButton).at(5).simulate("click");
+    expect(setTextBoxMock).toHaveBeenCalledWith("Which computers are more than 300 dollars and less than 400 dollars?");
+    expect(setIsSamplePromptsOpenMock).toHaveBeenCalledWith(false);
   });
 });


### PR DESCRIPTION
This pull request contains fix when error message bar is hidden or shown based on the outcome of sent requests.

Related tasks:
[AB#2549397](https://msdata.visualstudio.com/ba574a88-a171-48e0-8fcb-5fef6d23739c/_workitems/edit/2549397)

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1542?feature.someFeatureFlagYouMightNeed=true)
