### PR TITLE
[Query Copilot] Update feature flag after sample data connection info fetch

### DIFF
--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -97,6 +97,12 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
           () => this.setState({}),
           (state) => state.showResetPasswordBubble
         ),
+      },
+      {
+        dispose: useDatabases.subscribe(
+          () => this.setState({}),
+          (state) => state.sampleDataResourceTokenCollection
+        ),
       }
     );
   }

--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -113,7 +113,7 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
   };
 
   private getSplashScreenButtons = (): JSX.Element => {
-    if (userContext.features.enableCopilot && userContext.apiType === "SQL") {
+    if (userContext.sampleDataConnectionInfo && userContext.features.enableCopilot && userContext.apiType === "SQL") {
       return (
         <Stack style={{ width: "66%", cursor: "pointer", margin: "40px auto" }} tokens={{ childrenGap: 16 }}>
           <Stack horizontal tokens={{ childrenGap: 16 }}>

--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -113,7 +113,11 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
   };
 
   private getSplashScreenButtons = (): JSX.Element => {
-    if (userContext.sampleDataConnectionInfo && userContext.features.enableCopilot && userContext.apiType === "SQL") {
+    if (
+      useDatabases.getState().sampleDataResourceTokenCollection &&
+      userContext.features.enableCopilot &&
+      userContext.apiType === "SQL"
+    ) {
       return (
         <Stack style={{ width: "66%", cursor: "pointer", margin: "40px auto" }} tokens={{ childrenGap: 16 }}>
           <Stack horizontal tokens={{ childrenGap: 16 }}>

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -435,11 +435,6 @@ async function updateContextForSampleData(explorer: Explorer): Promise<void> {
   const sampleDataConnectionInfo = parseResourceTokenConnectionString(data.connectionString);
   updateUserContext({
     sampleDataConnectionInfo,
-    features: extractFeatures(
-      new URLSearchParams({
-        "feature.enableCopilot": sampleDataConnectionInfo ? "true" : "false",
-      })
-    ),
   });
 
   await explorer.refreshSampleData();

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -433,7 +433,14 @@ async function updateContextForSampleData(explorer: Explorer): Promise<void> {
 
   const data: SampledataconnectionResponse = await response.json();
   const sampleDataConnectionInfo = parseResourceTokenConnectionString(data.connectionString);
-  updateUserContext({ sampleDataConnectionInfo });
+  updateUserContext({
+    sampleDataConnectionInfo,
+    features: extractFeatures(
+      new URLSearchParams({
+        "feature.enableCopilot": sampleDataConnectionInfo ? "true" : "false",
+      })
+    ),
+  });
 
   await explorer.refreshSampleData();
 }

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -433,9 +433,7 @@ async function updateContextForSampleData(explorer: Explorer): Promise<void> {
 
   const data: SampledataconnectionResponse = await response.json();
   const sampleDataConnectionInfo = parseResourceTokenConnectionString(data.connectionString);
-  updateUserContext({
-    sampleDataConnectionInfo,
-  });
+  updateUserContext({ sampleDataConnectionInfo });
 
   await explorer.refreshSampleData();
 }


### PR DESCRIPTION
- After the sample data info fetch is finished, update the feature flag to true or false, thus even if the feature flag is enabled it will not show query more faster with copilot, unless sample data can be reached

[AB#2573352](https://msdata.visualstudio.com/ba574a88-a171-48e0-8fcb-5fef6d23739c/_workitems/edit/2573352)

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1560?feature.someFeatureFlagYouMightNeed=true)
