### PR TITLE
Fix active tabs border on Fabric

### DIFF
--- a/less/documentDBFabric.less
+++ b/less/documentDBFabric.less
@@ -70,6 +70,10 @@ a:focus {
   border-bottom: 2px solid @FabricAccentMedium;
 }
 
+.nav-tabs>li.active>.tabNavContentContainer>.tab_Content>.tabNavText {
+  border-bottom: 0px none transparent;
+}
+
 .tabNavContentContainer {
   padding: @SmallSpace 0px @SmallSpace 0px;
 


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1614?feature.someFeatureFlagYouMightNeed=true)

With my last fix in https://github.com/Azure/cosmos-explorer/pull/1607/commits/c8b533f0aab657b6da47305f70cd8e5ad9939948 for Portal, I broke the active Tab design for Fabric, sorry about that!

Bug:
<img width="160" alt="image" src="https://github.com/Azure/cosmos-explorer/assets/951587/23d05553-b8ab-4ccf-bc49-2cb3d6a68203">

Fixed:
<img width="103" alt="image" src="https://github.com/Azure/cosmos-explorer/assets/951587/a428c929-ca9d-4e5a-a9e7-484e6ae11e38">
