### PR TITLE
File Upload Tooltip

### DIFF
--- a/src/Explorer/Panes/UploadItemsPane/UploadItemsPane.tsx
+++ b/src/Explorer/Panes/UploadItemsPane/UploadItemsPane.tsx
@@ -1,8 +1,8 @@
-import { DetailsList, DetailsListLayoutMode, IColumn, SelectionMode } from "@fluentui/react";
+import { DetailsList, DetailsListLayoutMode, IColumn, SelectionMode, TooltipHost } from "@fluentui/react";
 import { Upload } from "Common/Upload/Upload";
 import { UploadDetailsRecord } from "Contracts/ViewModels";
-import React, { ChangeEvent, FunctionComponent, useState } from "react";
 import { logConsoleError } from "Utils/NotificationConsoleUtils";
+import React, { ChangeEvent, FunctionComponent, useState } from "react";
 import { getErrorMessage } from "../../Tables/Utilities";
 import { useSelectedNode } from "../../useSelectedNode";
 import { RightPaneForm, RightPaneFormProps } from "../RightPaneForm/RightPaneForm";
@@ -52,6 +52,23 @@ export const UploadItemsPane: FunctionComponent = () => {
     onSubmit,
   };
 
+  const renderStatusCell = (item: UploadDetailsRecord) => {
+    const tooltipContent = `${item.numSucceeded} created, ${item.numThrottled} throttled, ${item.numFailed} errors`;
+    return (
+      <TooltipHost content={tooltipContent}>
+        <span>{tooltipContent}</span>
+      </TooltipHost>
+    );
+  };
+
+  const renderFileNameCell = (item: UploadDetailsRecord) => {
+    return (
+      <TooltipHost content={item.fileName}>
+        <span>{item.fileName}</span>
+      </TooltipHost>
+    );
+  };
+
   const columns: IColumn[] = [
     {
       key: "fileName",
@@ -59,6 +76,11 @@ export const UploadItemsPane: FunctionComponent = () => {
       fieldName: "fileName",
       minWidth: 140,
       maxWidth: 140,
+      isRowHeader: true,
+      isResizable: true,
+      data: "string",
+      isPadded: true,
+      onRender: renderFileNameCell,
     },
     {
       key: "status",
@@ -70,6 +92,7 @@ export const UploadItemsPane: FunctionComponent = () => {
       isResizable: true,
       data: "string",
       isPadded: true,
+      onRender: renderStatusCell,
     },
   ];
 

--- a/src/Explorer/Panes/UploadItemsPane/UploadItemsPane.tsx
+++ b/src/Explorer/Panes/UploadItemsPane/UploadItemsPane.tsx
@@ -1,4 +1,4 @@
-import { DetailsList, DetailsListLayoutMode, IColumn, SelectionMode, TooltipHost } from "@fluentui/react";
+import { DetailsList, DetailsListLayoutMode, DirectionalHint, IColumn, SelectionMode, TooltipHost } from "@fluentui/react";
 import { Upload } from "Common/Upload/Upload";
 import { UploadDetailsRecord } from "Contracts/ViewModels";
 import { logConsoleError } from "Utils/NotificationConsoleUtils";
@@ -52,23 +52,6 @@ export const UploadItemsPane: FunctionComponent = () => {
     onSubmit,
   };
 
-  const renderStatusCell = (item: UploadDetailsRecord) => {
-    const tooltipContent = `${item.numSucceeded} created, ${item.numThrottled} throttled, ${item.numFailed} errors`;
-    return (
-      <TooltipHost content={tooltipContent}>
-        <span>{tooltipContent}</span>
-      </TooltipHost>
-    );
-  };
-
-  const renderFileNameCell = (item: UploadDetailsRecord) => {
-    return (
-      <TooltipHost content={item.fileName}>
-        <span>{item.fileName}</span>
-      </TooltipHost>
-    );
-  };
-
   const columns: IColumn[] = [
     {
       key: "fileName",
@@ -80,7 +63,6 @@ export const UploadItemsPane: FunctionComponent = () => {
       isResizable: true,
       data: "string",
       isPadded: true,
-      onRender: renderFileNameCell,
     },
     {
       key: "status",
@@ -92,17 +74,25 @@ export const UploadItemsPane: FunctionComponent = () => {
       isResizable: true,
       data: "string",
       isPadded: true,
-      onRender: renderStatusCell,
     },
   ];
 
   const _renderItemColumn = (item: UploadDetailsRecord, index: number, column: IColumn) => {
+    let fieldContent: string;
+    const tooltipId = `tooltip-${index}-${column.key}`;
+
     switch (column.key) {
       case "status":
-        return `${item.numSucceeded} created, ${item.numThrottled} throttled, ${item.numFailed} errors`;
+        fieldContent = `${item.numSucceeded} created, ${item.numThrottled} throttled, ${item.numFailed} errors`;
+        break;
       default:
-        return item.fileName;
+        fieldContent = item.fileName;
     }
+    return (
+        <TooltipHost content={fieldContent} id={tooltipId} directionalHint={DirectionalHint.rightCenter}>
+        {fieldContent}
+        </TooltipHost>
+    );
   };
 
   return (

--- a/src/Explorer/Panes/UploadItemsPane/UploadItemsPane.tsx
+++ b/src/Explorer/Panes/UploadItemsPane/UploadItemsPane.tsx
@@ -1,4 +1,11 @@
-import { DetailsList, DetailsListLayoutMode, DirectionalHint, IColumn, SelectionMode, TooltipHost } from "@fluentui/react";
+import {
+  DetailsList,
+  DetailsListLayoutMode,
+  DirectionalHint,
+  IColumn,
+  SelectionMode,
+  TooltipHost,
+} from "@fluentui/react";
 import { Upload } from "Common/Upload/Upload";
 import { UploadDetailsRecord } from "Contracts/ViewModels";
 import { logConsoleError } from "Utils/NotificationConsoleUtils";
@@ -89,9 +96,9 @@ export const UploadItemsPane: FunctionComponent = () => {
         fieldContent = item.fileName;
     }
     return (
-        <TooltipHost content={fieldContent} id={tooltipId} directionalHint={DirectionalHint.rightCenter}>
+      <TooltipHost content={fieldContent} id={tooltipId} directionalHint={DirectionalHint.rightCenter}>
         {fieldContent}
-        </TooltipHost>
+      </TooltipHost>
     );
   };
 

--- a/src/Explorer/Panes/UploadItemsPane/UploadItemsPane.tsx
+++ b/src/Explorer/Panes/UploadItemsPane/UploadItemsPane.tsx
@@ -66,10 +66,6 @@ export const UploadItemsPane: FunctionComponent = () => {
       fieldName: "fileName",
       minWidth: 140,
       maxWidth: 140,
-      isRowHeader: true,
-      isResizable: true,
-      data: "string",
-      isPadded: true,
     },
     {
       key: "status",


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1621?feature.someFeatureFlagYouMightNeed=true)

When uploading json files to a database, longer file names and messages were cut off with no tooltip to show the full file name or message.  This tooltip was added.

![example_tooltip](https://github.com/Azure/cosmos-explorer/assets/124094535/165ff144-8f1a-495f-a20d-5b2f4cfa5d71)

![example_tooltip](https://github.com/Azure/cosmos-explorer/assets/124094535/6e831394-32f9-47e2-8584-1ad860803fa9)
