### PR TITLE
Prevent prettier from converting CRLF to LF

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,6 +233,7 @@
   },
   "homepage": "https://github.com/Azure/cosmos-explorer",
   "prettier": {
-    "printWidth": 120
+    "printWidth": 120,
+    "endOfLine": "auto"
   }
 }


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1624?feature.someFeatureFlagYouMightNeed=true)

This change fixes the issue when running `npm run format` on windows, git then shows 700+ files changed making it impossible to find which file had code that was actually reformatted.

Explanation:
* End of line character(s): traditionally CRLF (carriage return + line feed or '\r\n') in windows, LF ('\n') in linux.
* On windows, the recommended config by git bash is to set: `"autocrlf" = true`. Meaning, git saves files with CRLF, but uploads with LF so that the repository in linux always contains files with LF.
The config is saved during installation here: `C:\Program Files\Git\etc\gitconfig`.
You can override this by doing `git config <your parameter change here>` which will create or modify a `.gitconfig` file in your home dir (`~/.gitconfig` in git bash).
* You can check line endings of your files with: `git ls-files --eol` or there a VSC extension called "Render line endings".
This outputs something like: `i/lf    w/crlf  attr/                   tslint.json` where "i/" means index (ie what's in github) and "w/" means workspace (your local file).
* The problem is `npm run format` (which calls prettier) converts everything to LF. So git downloaded the file as CRLF, now it's changed to LF by prettier and shows up in `git diff`. Git will say that next time it touches the file, it'll convert it back to CRLF, but that's not helping see which file was actually reformatted beside the line endings.
* This PR change makes prettier ignore line endings, so that we let git handle line endings.
Prettier used to ignore line endings pre-v2.0.0, but now forces to LF.
More info [here](https://prettier.io/docs/en/options.html#end-of-line).

Notes:
* Windows does not actually require CRLF, but ["many editors on Windows silently replace existing LF-style line endings with CRLF, or insert both line-ending characters when the user hits the enter key"](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration). Note that VSC is good about it and you can choose in the bottom bar what line endings you want. So if you use VSC, `"autocrlf=input` would work fine with the current setup.
* I noticed that our repo contains files with CRLF. They're mostly config files. Normally, since most of use either have `autocrlf` set to `true` or `input`, they will eventually by modified to LF when someone commits a new change to the file.
