### PR TITLE
Remove obsolete unit test

### DIFF
--- a/src/Explorer/DataSamples/ContainerSampleGenerator.test.ts
+++ b/src/Explorer/DataSamples/ContainerSampleGenerator.test.ts
@@ -123,19 +123,6 @@ describe("ContainerSampleGenerator", () => {
     await generator.createSampleContainerAsync();
   });
 
-  it("should not create any sample for Mongo API account", async () => {
-    const experience = "Sample generation not supported for this API Mongo";
-    updateUserContext({
-      databaseAccount: {
-        properties: {
-          capabilities: [{ name: "EnableMongo" }],
-        },
-      } as DatabaseAccount,
-    });
-
-    expect(ContainerSampleGenerator.createSampleGeneratorAsync(explorerStub)).rejects.toMatch(experience);
-  });
-
   it("should not create any sample for Table API account", async () => {
     const experience = "Sample generation not supported for this API Tables";
     updateUserContext({


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1655?feature.someFeatureFlagYouMightNeed=true)

[This commit](https://github.com/Azure/cosmos-explorer/pull/1313/files) enables sample collection for mongo api.
The test being removed was not working (`await` missing [here](https://github.com/Azure/cosmos-explorer/blob/f36fccd3efe80834a7ac169a498a8bd000875786/src/Explorer/DataSamples/ContainerSampleGenerator.test.ts#L136)) and is incorrect, since we now support sample generation for Mongo API.