### PR TITLE
Bug 2724821: Heading hierarchy is not defined sequentially on the "Data explorer" page.

### DIFF
--- a/src/Explorer/Tabs/QueryTab/QueryResultSection.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryResultSection.tsx
@@ -433,7 +433,7 @@ export const QueryResultSection: React.FC<QueryResultProps> = ({
                   {queryResults && !error && (
                     <div className="queryMetricsSummaryContainer">
                       <div className="queryMetricsSummary">
-                        <h5>Query Statistics</h5>
+                        <h3>Query Statistics</h3>
                         <DetailsList
                           items={generateQueryStatsItems()}
                           columns={columns}


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
