### PR TITLE
Explorer null handling

### DIFF
--- a/src/Explorer/Panes/Tables/EditTableEntityPanel.tsx
+++ b/src/Explorer/Panes/Tables/EditTableEntityPanel.tsx
@@ -390,6 +390,7 @@ export const EditTableEntityPanel: FunctionComponent<EditTableEntityPanelProps> 
           </Stack>
         )}
       </div>
+      <div className="panelNullWarning" style={{ padding: "20px", color: "red" }}>Warning: Null fields may not be edited.</div>
     </RightPaneForm>
   );
 };

--- a/src/Explorer/Panes/Tables/EditTableEntityPanel.tsx
+++ b/src/Explorer/Panes/Tables/EditTableEntityPanel.tsx
@@ -390,7 +390,9 @@ export const EditTableEntityPanel: FunctionComponent<EditTableEntityPanelProps> 
           </Stack>
         )}
       </div>
-      <div className="panelNullWarning" style={{ padding: "20px", color: "red" }}>Warning: Null fields may not be edited.</div>
+      <div className="panelNullWarning" style={{ padding: "20px", color: "red" }}>
+        Warning: Null fields may not be edited.
+      </div>
     </RightPaneForm>
   );
 };

--- a/src/Explorer/Panes/Tables/EditTableEntityPanel.tsx
+++ b/src/Explorer/Panes/Tables/EditTableEntityPanel.tsx
@@ -391,7 +391,7 @@ export const EditTableEntityPanel: FunctionComponent<EditTableEntityPanelProps> 
         )}
       </div>
       <div className="panelNullWarning" style={{ padding: "20px", color: "red" }}>
-        Warning: Null fields may not be edited.
+        Warning: Null fields will not be displayed for editing.
       </div>
     </RightPaneForm>
   );

--- a/src/Explorer/Panes/Tables/__snapshots__/EditTableEntityPanel.test.tsx.snap
+++ b/src/Explorer/Panes/Tables/__snapshots__/EditTableEntityPanel.test.tsx.snap
@@ -355,6 +355,17 @@ exports[`Excute Edit Table Entity Pane should render Default properly 1`] = `
           </div>
         </Stack>
       </div>
+      <div
+        className="panelNullWarning"
+        style={
+          Object {
+            "color": "red",
+            "padding": "20px",
+          }
+        }
+      >
+        Warning: Null fields will not be displayed for editing.
+      </div>
       <PanelFooterComponent
         buttonLabel="Update"
         isButtonDisabled={false}

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -19,9 +19,6 @@ import Explorer from "../Explorer";
 import * as TableConstants from "./Constants";
 import * as Entities from "./Entities";
 import * as TableEntityProcessor from "./TableEntityProcessor";
-import { getLocalDateTime } from "./QueryBuilder/DateTimeUtilities";
-import { v4 as uuidv4 } from "uuid";
-import moment from "moment";
 
 export interface CassandraTableKeys {
   partitionKeys: CassandraTableKey[];
@@ -34,7 +31,7 @@ export interface CassandraTableKey {
 }
 
 export abstract class TableDataClient {
-  constructor() {}
+  constructor() { }
 
   public abstract createDocument(
     collection: ViewModels.Collection,
@@ -151,31 +148,7 @@ export class CassandraAPIDataClient extends TableDataClient {
     let values = "(";
     for (let property in entity) {
       if (entity[property]._ === "" || undefined) {
-        switch (entity[property].$) {
-          case "Timestamp":
-            entity[property]._ = getLocalDateTime(new Date().toString());
-            break;
-          case "Date":
-            entity[property]._ = moment().format("YYYY-MM-DD");
-            break;
-          case "Uuid":
-            entity[property]._ = uuidv4().toString();
-            break;
-          case "Boolean":
-            const bool: boolean = false;
-            entity[property]._ = bool.toString();
-            break;
-          case "Int":
-          case "Double":
-          case "Decimal":
-          case "Float":
-          case "Bigint":
-            entity[property]._ = "0";
-            break;
-          default:
-            entity[property]._ = "";
-            break;
-        }
+        continue;
       }
       properties = properties.concat(`${property}, `);
       const propertyType = entity[property].$;
@@ -212,7 +185,6 @@ export class CassandraAPIDataClient extends TableDataClient {
     newEntity: Entities.ITableEntity,
   ): Promise<Entities.ITableEntity> {
     const clearMessage = NotificationConsoleUtils.logConsoleProgress(`Updating row ${originalDocument.RowKey._}`);
-
     try {
       let whereSegment = " WHERE";
       let keys: CassandraTableKey[] = collection.cassandraKeys.partitionKeys.concat(
@@ -236,31 +208,7 @@ export class CassandraAPIDataClient extends TableDataClient {
           newEntity[property]._.toString() !== originalDocument[property]._.toString()
         ) {
           if (newEntity[property]._.toString() === "" || undefined) {
-            switch (newEntity[property].$) {
-              case "Timestamp":
-                newEntity[property]._ = getLocalDateTime(new Date().toString());
-                break;
-              case "Date":
-                newEntity[property]._ = moment().format("YYYY-MM-DD");
-                break;
-              case "Uuid":
-                newEntity[property]._ = uuidv4().toString();
-                break;
-              case "Boolean":
-                const bool: boolean = false;
-                newEntity[property]._ = bool.toString();
-                break;
-              case "Int":
-              case "Double":
-              case "Decimal":
-              case "Float":
-              case "Bigint":
-                newEntity[property]._ = "0";
-                break;
-              default:
-                newEntity[property]._ = "";
-                break;
-            }
+            continue;
           }
           let propertyQuerySegment = this.isStringType(newEntity[property].$)
             ? `${property} = '${newEntity[property]._}',`

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -147,7 +147,7 @@ export class CassandraAPIDataClient extends TableDataClient {
     let properties = "(";
     let values = "(";
     for (let property in entity) {
-      if (entity[property]._ === "" || undefined) {
+      if (entity[property]._ === "" || entity[property]._ === undefined) {
         continue;
       }
       properties = properties.concat(`${property}, `);
@@ -208,7 +208,7 @@ export class CassandraAPIDataClient extends TableDataClient {
           !originalDocument[property] ||
           newEntity[property]._.toString() !== originalDocument[property]._.toString()
         ) {
-          if (newEntity[property]._.toString() === "" || undefined) {
+          if (newEntity[property]._.toString() === "" || newEntity[property]._.toString() === undefined) {
             continue;
           }
           let propertyQuerySegment = this.isStringType(newEntity[property].$)

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -21,6 +21,7 @@ import * as Entities from "./Entities";
 import * as TableEntityProcessor from "./TableEntityProcessor";
 import { getLocalDateTime } from "./QueryBuilder/DateTimeUtilities";
 import { v4 as uuidv4 } from "uuid";
+import moment from "moment";
 
 export interface CassandraTableKeys {
   partitionKeys: CassandraTableKey[];
@@ -150,31 +151,26 @@ export class CassandraAPIDataClient extends TableDataClient {
     let values = "(";
     for (let property in entity) {
       if (entity[property]._ === "" || undefined) {
-        // Numberic types require a value, otherwise the column will not be created/editable.
         switch (entity[property].$) {
           case "Timestamp":
             entity[property]._ = getLocalDateTime(new Date().toString());
             break;
-          case "Int":
-          case "Double":
-            const int: number = 0;
-            entity[property]._ = int.toString();
-            break;
-          case "Float":
-            const fl: number = parseFloat("0.0");
-            entity[property]._ = fl.toString();
-            break;
-          case "Bigint":
-            const bg: bigint = BigInt(0);
-            entity[property]._ = bg.toString();
-            break;
-          case "Decimal":
-            const dec: number = 0.0;
-            entity[property]._ = dec.toString();
+          case "Date":
+            entity[property]._ = moment().format("YYYY-MM-DD");
             break;
           case "Uuid":
-            const id: string = uuidv4();
-            entity[property]._ = id.toString();
+            entity[property]._ = uuidv4().toString();
+            break;
+          case "Boolean":
+            const bool: boolean = false;
+            entity[property]._ = bool.toString();
+            break;
+          case "Int":
+          case "Double":
+          case "Decimal":
+          case "Float":
+          case "Bigint":
+            entity[property]._ = "0";
             break;
           default:
             entity[property]._ = "";
@@ -240,31 +236,26 @@ export class CassandraAPIDataClient extends TableDataClient {
           newEntity[property]._.toString() !== originalDocument[property]._.toString()
         ) {
           if (newEntity[property]._.toString() === "" || undefined) {
-            // Deleting a column would do nothing if not set to 0 for numeric types.
             switch (newEntity[property].$) {
               case "Timestamp":
                 newEntity[property]._ = getLocalDateTime(new Date().toString());
                 break;
-              case "Int":
-              case "Double":
-                const int: number = 0;
-                newEntity[property]._ = int.toString();
-                break;
-              case "Float":
-                const fl: number = parseFloat("0.0");
-                newEntity[property]._ = fl.toString();
-                break;
-              case "Bigint":
-                const bg: bigint = BigInt(0);
-                newEntity[property]._ = bg.toString();
-                break;
-              case "Decimal":
-                const dec: number = 0.0;
-                newEntity[property]._ = dec.toString();
+              case "Date":
+                newEntity[property]._ = moment().format("YYYY-MM-DD");
                 break;
               case "Uuid":
-                const id: string = uuidv4();
-                newEntity[property]._ = id.toString();
+                newEntity[property]._ = uuidv4().toString();
+                break;
+              case "Boolean":
+                const bool: boolean = false;
+                newEntity[property]._ = bool.toString();
+                break;
+              case "Int":
+              case "Double":
+              case "Decimal":
+              case "Float":
+              case "Bigint":
+                newEntity[property]._ = "0";
                 break;
               default:
                 newEntity[property]._ = "";

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -20,7 +20,7 @@ import * as TableConstants from "./Constants";
 import * as Entities from "./Entities";
 import * as TableEntityProcessor from "./TableEntityProcessor";
 import { getLocalDateTime } from "./QueryBuilder/DateTimeUtilities";
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4 } from "uuid";
 
 export interface CassandraTableKeys {
   partitionKeys: CassandraTableKey[];
@@ -33,7 +33,7 @@ export interface CassandraTableKey {
 }
 
 export abstract class TableDataClient {
-  constructor() { }
+  constructor() {}
 
   public abstract createDocument(
     collection: ViewModels.Collection,
@@ -176,7 +176,8 @@ export class CassandraAPIDataClient extends TableDataClient {
             const id: string = uuidv4();
             entity[property]._ = id.toString();
             break;
-          default: entity[property]._ = "";
+          default:
+            entity[property]._ = "";
             break;
         }
       }
@@ -265,7 +266,8 @@ export class CassandraAPIDataClient extends TableDataClient {
                 const id: string = uuidv4();
                 newEntity[property]._ = id.toString();
                 break;
-              default: newEntity[property]._ = "";
+              default:
+                newEntity[property]._ = "";
                 break;
             }
           }

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -185,6 +185,7 @@ export class CassandraAPIDataClient extends TableDataClient {
     newEntity: Entities.ITableEntity,
   ): Promise<Entities.ITableEntity> {
     const clearMessage = NotificationConsoleUtils.logConsoleProgress(`Updating row ${originalDocument.RowKey._}`);
+    
     try {
       let whereSegment = " WHERE";
       let keys: CassandraTableKey[] = collection.cassandraKeys.partitionKeys.concat(

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -31,7 +31,7 @@ export interface CassandraTableKey {
 }
 
 export abstract class TableDataClient {
-  constructor() { }
+  constructor() {}
 
   public abstract createDocument(
     collection: ViewModels.Collection,

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -208,7 +208,7 @@ export class CassandraAPIDataClient extends TableDataClient {
           !originalDocument[property] ||
           newEntity[property]._.toString() !== originalDocument[property]._.toString()
         ) {
-          if (newEntity[property]._.toString() === "" || newEntity[property]._.toString() === undefined) {
+          if (newEntity[property]._.toString() === "" || newEntity[property]._ === undefined) {
             continue;
           }
           let propertyQuerySegment = this.isStringType(newEntity[property].$)

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -185,7 +185,7 @@ export class CassandraAPIDataClient extends TableDataClient {
     newEntity: Entities.ITableEntity,
   ): Promise<Entities.ITableEntity> {
     const clearMessage = NotificationConsoleUtils.logConsoleProgress(`Updating row ${originalDocument.RowKey._}`);
-    
+
     try {
       let whereSegment = " WHERE";
       let keys: CassandraTableKey[] = collection.cassandraKeys.partitionKeys.concat(


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1658?feature.someFeatureFlagYouMightNeed=true)

Data Explorer was not handling NULL values properly.

Issue 1: If a row had fields which where NULL, when opening the row to edit, the fields that were NULL did not show so the user could insert values in those fields. 

Issue 2: When attempting to insert a new row, when trying to leave non-string data types as empty, errors are thrown from backend but not caught and displayed properly in DE.

RESOLUTION: The backend requires a valid value for all types so it was advised to display a Warning on the edit panel that null values cannot be edited. 