### PR TITLE
Bug 2748824:"Provision dedicated throughput for this table "check box is misaligned in normal mode (100%)

### DIFF
--- a/src/Explorer/Panes/CassandraAddCollectionPane/CassandraAddCollectionPane.tsx
+++ b/src/Explorer/Panes/CassandraAddCollectionPane/CassandraAddCollectionPane.tsx
@@ -314,7 +314,7 @@ export const CassandraAddCollectionPane: FunctionComponent<CassandraAddCollectio
         </Stack>
 
         {!isServerlessAccount() && isKeyspaceShared && !keyspaceCreateNew && (
-          <Stack>
+          <Stack horizontal verticalAlign="center">
             <input
               type="checkbox"
               id="tableSharedThroughput"


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1661?feature.someFeatureFlagYouMightNeed=true)

Provisioned thoughput checkbox present in the "New keySpace" dialog is not aligned and the contents of the checkbox is scattered improperly.