### PR TITLE
Check for accounts that are restricted from connection string login.

### DIFF
--- a/src/Platform/Hosted/Components/ConnectExplorer.tsx
+++ b/src/Platform/Hosted/Components/ConnectExplorer.tsx
@@ -42,16 +42,6 @@ export const isAccountRestrictedForConnectionStringLogin = async (connectionStri
   return (await response.text()) === "True";
 };
 
-export const hideErrorDetails = () => {
-  window.document.getElementById("errorDetails").innerText = "";
-  window.document.getElementById("errorDetailsInfoTooltip").style.display = "none";
-};
-
-export const showErrorDetails = (errorMessage: string) => {
-  window.document.getElementById("errorDetails").innerText = errorMessage;
-  window.document.getElementById("errorDetailsInfoTooltip").style.display = "inline";
-};
-
 export const ConnectExplorer: React.FunctionComponent<Props> = ({
   setEncryptedToken,
   login,
@@ -60,6 +50,7 @@ export const ConnectExplorer: React.FunctionComponent<Props> = ({
   setConnectionString,
 }: Props) => {
   const [isFormVisible, { setTrue: showForm }] = useBoolean(false);
+  const [errorMessage, setErrorMessage] = React.useState("");
   const enableConnectionStringLogin = !userContext.features.disableConnectionStringLogin;
 
   return (
@@ -75,15 +66,15 @@ export const ConnectExplorer: React.FunctionComponent<Props> = ({
               id="connectWithConnectionString"
               onSubmit={async (event) => {
                 event.preventDefault();
-                hideErrorDetails();
-
-                if (await isAccountRestrictedForConnectionStringLogin(connectionString)) {
-                  showErrorDetails("This account has been blocked from connection-string login.");
-                  return;
-                }
+                setErrorMessage("");
 
                 if (isResourceTokenConnectionString(connectionString)) {
                   setAuthType(AuthType.ResourceToken);
+                  return;
+                }
+
+                if (await isAccountRestrictedForConnectionStringLogin(connectionString)) {
+                  setErrorMessage("This account has been blocked from connection-string login.");
                   return;
                 }
 
@@ -104,10 +95,12 @@ export const ConnectExplorer: React.FunctionComponent<Props> = ({
                     setConnectionString(event.target.value);
                   }}
                 />
-                <span className="errorDetailsInfoTooltip" id="errorDetailsInfoTooltip" style={{ display: "none" }}>
-                  <img className="errorImg" src={ErrorImage} alt="Error notification" />
-                  <span className="errorDetails" id="errorDetails"></span>
-                </span>
+                {errorMessage.length > 0 && (
+                  <span className="errorDetailsInfoTooltip">
+                    <img className="errorImg" src={ErrorImage} alt="Error notification" />
+                    <span className="errorDetails">{errorMessage}</span>
+                  </span>
+                )}
               </p>
               <p className="connectExplorerContent">
                 <input className="filterbtnstyle" type="submit" value="Connect" />

--- a/src/Platform/Hosted/Components/ConnectExplorer.tsx
+++ b/src/Platform/Hosted/Components/ConnectExplorer.tsx
@@ -31,11 +31,9 @@ export const fetchEncryptedToken = async (connectionString: string): Promise<str
 };
 
 export const isAccountRestrictedForConnectionStringLogin = async (connectionString: string): Promise<boolean> => {
-  console.log("DEBUG: START");
   const headers = new Headers();
   headers.append(HttpHeaders.connectionString, connectionString);
-  //const url = configContext.BACKEND_ENDPOINT + "/api/accountrestrictions/checkconnectionstringlogin";
-  const url = "https://localhost:12901" + "/api/accountrestrictions/checkconnectionstringlogin";
+  const url = configContext.BACKEND_ENDPOINT + "/api/accountrestrictions/checkconnectionstringlogin";
   const response = await fetch(url, { headers, method: "POST" });
   if (!response.ok) {
     throw response;

--- a/src/Platform/Hosted/Components/ConnectExplorer.tsx
+++ b/src/Platform/Hosted/Components/ConnectExplorer.tsx
@@ -33,7 +33,7 @@ export const fetchEncryptedToken = async (connectionString: string): Promise<str
 export const isAccountRestrictedForConnectionStringLogin = async (connectionString: string): Promise<boolean> => {
   const headers = new Headers();
   headers.append(HttpHeaders.connectionString, connectionString);
-  const url = configContext.BACKEND_ENDPOINT + "/api/accountrestrictions/checkconnectionstringlogin";
+  const url = configContext.BACKEND_ENDPOINT + "/api/guest/accountrestrictions/checkconnectionstringlogin";
   const response = await fetch(url, { headers, method: "POST" });
   if (!response.ok) {
     throw response;

--- a/src/Platform/Hosted/Components/ConnectExplorer.tsx
+++ b/src/Platform/Hosted/Components/ConnectExplorer.tsx
@@ -68,13 +68,13 @@ export const ConnectExplorer: React.FunctionComponent<Props> = ({
                 event.preventDefault();
                 setErrorMessage("");
 
-                if (isResourceTokenConnectionString(connectionString)) {
-                  setAuthType(AuthType.ResourceToken);
+                if (await isAccountRestrictedForConnectionStringLogin(connectionString)) {
+                  setErrorMessage("This account has been blocked from connection-string login.");
                   return;
                 }
 
-                if (await isAccountRestrictedForConnectionStringLogin(connectionString)) {
-                  setErrorMessage("This account has been blocked from connection-string login.");
+                if (isResourceTokenConnectionString(connectionString)) {
+                  setAuthType(AuthType.ResourceToken);
                   return;
                 }
 

--- a/test/sql/resourceToken.spec.ts
+++ b/test/sql/resourceToken.spec.ts
@@ -3,17 +3,8 @@ import { CosmosClient, PermissionMode } from "@azure/cosmos";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { jest } from "@jest/globals";
 import "expect-playwright";
-import { isAccountRestrictedForConnectionStringLogin } from "../../src/Platform/Hosted/Components/ConnectExplorer";
 import { generateUniqueName } from "../utils/shared";
 jest.setTimeout(120000);
-
-jest.mock("../../src/Platform/Hosted/Components/ConnectExplorer", () => {
-  const original = jest.requireActual("../../src/Platform/Hosted/Components/ConnectExplorer");
-  return {
-    ...original,
-    isAccountRestrictedForConnectionStringLogin: jest.fn(),
-  };
-});
 
 const clientId = "fd8753b0-0707-4e32-84e9-2532af865fb4";
 const secret = process.env["NOTEBOOKS_TEST_RUNNER_CLIENT_SECRET"];
@@ -41,8 +32,6 @@ test("Resource token", async () => {
     resource: container.url,
   });
   const resourceTokenConnectionString = `AccountEndpoint=${account.documentEndpoint};DatabaseId=${database.id};CollectionId=${container.id};${containerPermission._token}`;
-
-  isAccountRestrictedForConnectionStringLogin.mockImplementation(() => Promise.resolve(false));
 
   await page.goto("https://localhost:1234/hostedExplorer.html");
   await page.waitForSelector("div > p.switchConnectTypeText");

--- a/test/sql/resourceToken.spec.ts
+++ b/test/sql/resourceToken.spec.ts
@@ -3,8 +3,17 @@ import { CosmosClient, PermissionMode } from "@azure/cosmos";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { jest } from "@jest/globals";
 import "expect-playwright";
+import { isAccountRestrictedForConnectionStringLogin } from "../../src/Platform/Hosted/Components/ConnectExplorer";
 import { generateUniqueName } from "../utils/shared";
 jest.setTimeout(120000);
+
+jest.mock("../../src/Platform/Hosted/Components/ConnectExplorer", () => {
+  const original = jest.requireActual("../../src/Platform/Hosted/Components/ConnectExplorer");
+  return {
+    ...original,
+    isAccountRestrictedForConnectionStringLogin: jest.fn(),
+  };
+});
 
 const clientId = "fd8753b0-0707-4e32-84e9-2532af865fb4";
 const secret = process.env["NOTEBOOKS_TEST_RUNNER_CLIENT_SECRET"];
@@ -32,6 +41,8 @@ test("Resource token", async () => {
     resource: container.url,
   });
   const resourceTokenConnectionString = `AccountEndpoint=${account.documentEndpoint};DatabaseId=${database.id};CollectionId=${container.id};${containerPermission._token}`;
+
+  isAccountRestrictedForConnectionStringLogin.mockImplementation(() => Promise.resolve(false));
 
   await page.goto("https://localhost:1234/hostedExplorer.html");
   await page.waitForSelector("div > p.switchConnectTypeText");


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1673?feature.someFeatureFlagYouMightNeed=true)

This change adds a call to the portal backend to determine if an account has been restricted from connection string based login.
If account has been restricted, user is informed via an error tooltip.