### PR TITLE
Adds restarting vcore mongo shell if user enters wrong password

### DIFF
--- a/src/Terminal/index.ts
+++ b/src/Terminal/index.ts
@@ -92,7 +92,6 @@ const closeTab = (props: TerminalProps, serverSettings: ServerConnection.ISettin
 };
 
 const main = async (): Promise<void> => {
-  //let session: ITerminalConnection | undefined;
   postRobot.on(
     "props",
     {


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1675)

On vCore Mongo, if the user enters an incorrect password, the whole terminal window closes. This adds a check for a specific message in the stdout which indicates the shell didn't accept the password and in that case recreates the terminal.

One of two things could happen in the future:
1. Once Phoenix adds the feature to fully login without the need for user input, this change could be undone.
2. If this is useful for other scenarios, other checks could be created.
