### PR TITLE
Bug 2748412: Focus order is not logical after expanding/collapse of "Collapse" control under "Data Explorer" screen.

### DIFF
--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -93,7 +93,7 @@ function TabNav({ tab, active, tabKind }: { tab?: Tab; active: boolean; tabKind?
     if (active && focusTab.current) {
       focusTab.current.focus();
     }
-  });
+  }, [active]);
   return (
     <li
       onMouseOver={() => setHovering(true)}


### PR DESCRIPTION
…ing continuosly

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1682?feature.someFeatureFlagYouMightNeed=true)
