### PR TITLE
Add directions to use AAD login if account blocked from connection string login.

### DIFF
--- a/src/Platform/Hosted/Components/ConnectExplorer.tsx
+++ b/src/Platform/Hosted/Components/ConnectExplorer.tsx
@@ -69,7 +69,9 @@ export const ConnectExplorer: React.FunctionComponent<Props> = ({
                 setErrorMessage("");
 
                 if (await isAccountRestrictedForConnectionStringLogin(connectionString)) {
-                  setErrorMessage("This account has been blocked from connection-string login.");
+                  setErrorMessage(
+                    "This account has been blocked from connection-string login. Please go to cosmos.azure.com/aad for AAD based login.",
+                  );
                   return;
                 }
 

--- a/src/Platform/Hosted/ConnectScreen.less
+++ b/src/Platform/Hosted/ConnectScreen.less
@@ -66,7 +66,7 @@
 }
 .connectExplorerContainer .connectExplorer .connectExplorerContent .errorDetailsInfoTooltip .errorDetails {
   bottom: 24px;
-  width: 145px;
+  width: 165px;
   visibility: hidden;
   background-color: #393939;
   color: #ffffff;


### PR DESCRIPTION
This change comes on request from Walmart to direct users to the aad redirect URL if they are blocked.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1683?feature.someFeatureFlagYouMightNeed=true)
