### PR TITLE
Increase NPS sample size and remove constraints

### DIFF
--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -272,7 +272,7 @@ export default class Explorer {
     if (!Platform.Portal) {
       return;
     }
-    
+
     const NINETY_DAYS_IN_MS = 7776000000;
     const ONE_DAY_IN_MS = 86400000;
     const THREE_DAYS_IN_MS = 259200000;
@@ -281,7 +281,7 @@ export default class Explorer {
       NINETY_DAYS_IN_MS,
     );
     const lastSubmitted: string = localStorage.getItem("lastSubmitted");
-    
+
     if (lastSubmitted !== null) {
       let lastSubmittedDate: number = parseInt(lastSubmitted);
       if (isNaN(lastSubmittedDate)) {
@@ -297,15 +297,16 @@ export default class Explorer {
 
     // Try Cosmos DB subscription - survey shown to 100% of users at day 1 in Data Explorer.
     if (userContext.isTryCosmosDBSubscription) {
-      if (
-        isAccountNewerThanThresholdInMs(userContext.databaseAccount?.systemData?.createdAt || "", ONE_DAY_IN_MS) 
-    ) {
+      if (isAccountNewerThanThresholdInMs(userContext.databaseAccount?.systemData?.createdAt || "", ONE_DAY_IN_MS)) {
         this.sendNPSMessage();
       }
     } else {
       // An existing account is older than 3 days but less than 90 days old. For existing account show to 100% of users in Data Explorer.
-       if (!isAccountNewerThanThresholdInMs(userContext.databaseAccount?.systemData?.createdAt || "", THREE_DAYS_IN_MS) && isAccountNewerThanNinetyDays) {
-          this.sendNPSMessage();
+      if (
+        !isAccountNewerThanThresholdInMs(userContext.databaseAccount?.systemData?.createdAt || "", THREE_DAYS_IN_MS) &&
+        isAccountNewerThanNinetyDays
+      ) {
+        this.sendNPSMessage();
       } else {
         // An existing account is greater than 90 days. For existing account show to random 33% of users in Data Explorer.
         if (this.getRandomInt(100) < 33) {

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -272,15 +272,16 @@ export default class Explorer {
     if (!Platform.Portal) {
       return;
     }
-
+    
     const NINETY_DAYS_IN_MS = 7776000000;
     const ONE_DAY_IN_MS = 86400000;
+    const THREE_DAYS_IN_MS = 259200000;
     const isAccountNewerThanNinetyDays = isAccountNewerThanThresholdInMs(
       userContext.databaseAccount?.systemData?.createdAt || "",
       NINETY_DAYS_IN_MS,
     );
     const lastSubmitted: string = localStorage.getItem("lastSubmitted");
-
+    
     if (lastSubmitted !== null) {
       let lastSubmittedDate: number = parseInt(lastSubmitted);
       if (isNaN(lastSubmittedDate)) {
@@ -294,30 +295,29 @@ export default class Explorer {
       }
     }
 
-    // Try Cosmos DB subscription - survey shown to random 25% of users at day 1 in Data Explorer.
+    // Try Cosmos DB subscription - survey shown to 100% of users at day 1 in Data Explorer.
     if (userContext.isTryCosmosDBSubscription) {
       if (
-        isAccountNewerThanThresholdInMs(userContext.databaseAccount?.systemData?.createdAt || "", ONE_DAY_IN_MS) &&
-        this.getRandomInt(100) < 25
-      ) {
-        sendMessage({ type: MessageTypes.DisplayNPSSurvey });
-        localStorage.setItem("lastSubmitted", Date.now().toString());
+        isAccountNewerThanThresholdInMs(userContext.databaseAccount?.systemData?.createdAt || "", ONE_DAY_IN_MS) 
+    ) {
+        this.sendNPSMessage();
       }
     } else {
-      // An existing account is lesser than 90 days old. For existing account show to random 10 % of users in Data Explorer.
-      if (isAccountNewerThanNinetyDays) {
-        if (this.getRandomInt(100) < 10) {
-          sendMessage({ type: MessageTypes.DisplayNPSSurvey });
-          localStorage.setItem("lastSubmitted", Date.now().toString());
-        }
+      // An existing account is older than 3 days but less than 90 days old. For existing account show to 100% of users in Data Explorer.
+       if (!isAccountNewerThanThresholdInMs(userContext.databaseAccount?.systemData?.createdAt || "", THREE_DAYS_IN_MS) && isAccountNewerThanNinetyDays) {
+          this.sendNPSMessage();
       } else {
-        // An existing account is greater than 90 days. For existing account show to random 25 % of users in Data Explorer.
-        if (this.getRandomInt(100) < 25) {
-          sendMessage({ type: MessageTypes.DisplayNPSSurvey });
-          localStorage.setItem("lastSubmitted", Date.now().toString());
+        // An existing account is greater than 90 days. For existing account show to random 33% of users in Data Explorer.
+        if (this.getRandomInt(100) < 33) {
+          this.sendNPSMessage();
         }
       }
     }
+  }
+
+  private sendNPSMessage() {
+    sendMessage({ type: MessageTypes.DisplayNPSSurvey });
+    localStorage.setItem("lastSubmitted", Date.now().toString());
   }
 
   public async refreshDatabaseForResourceToken(): Promise<void> {

--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -1431,8 +1431,6 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
       this.setState({ isExecuting: false });
       TelemetryProcessor.traceSuccess(Action.CreateCollection, telemetryData, startKey);
       useSidePanel.getState().closeSidePanel();
-      // open NPS Survey Dialog once the collection is created
-      this.props.explorer.openNPSSurveyDialog();
     } catch (error) {
       const errorMessage: string = getErrorMessage(error);
       this.setState({ isExecuting: false, errorMessage, showErrorDetails: true });

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -420,8 +420,9 @@ async function configurePortal(): Promise<Explorer> {
           updateContextsFromPortalMessage(inputs);
           explorer = new Explorer();
           resolve(explorer);
-          if (userContext.apiType === "Postgres") {
-            explorer.openNPSSurveyDialog();
+          
+          if (userContext.apiType === "Postgres" || userContext.apiType === "SQL" || userContext.apiType === "Mongo") {
+            setTimeout(() => explorer.openNPSSurveyDialog(), 3000);
           }
           if (openAction) {
             handleOpenAction(openAction, useDatabases.getState().databases, explorer);

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -420,10 +420,11 @@ async function configurePortal(): Promise<Explorer> {
           updateContextsFromPortalMessage(inputs);
           explorer = new Explorer();
           resolve(explorer);
-          
+
           if (userContext.apiType === "Postgres" || userContext.apiType === "SQL" || userContext.apiType === "Mongo") {
             setTimeout(() => explorer.openNPSSurveyDialog(), 3000);
           }
+
           if (openAction) {
             handleOpenAction(openAction, useDatabases.getState().databases, explorer);
           }


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1692?feature.someFeatureFlagYouMightNeed=true)

Remove the constraint that only will show the survey after the create a collection process (see note for b).  Show the NPS survey when user opens Data Explorer.   Same as PG does.
2.	Change the % of user's we display to.
a.	Account older than 90 days: from 25% to 33%
b.	Account between 3- 90 days: from 10% to 100%   
c.	Try Cosmos DB Account Day 1: from 25% to 100%
3.	User may only see survey 1 time every 90 days.

