### PR TITLE
Enabling enableEndpointDiscovery to test DE Region Outage Resiliency

### DIFF
--- a/src/Common/CosmosClient.ts
+++ b/src/Common/CosmosClient.ts
@@ -148,9 +148,6 @@ export function client(): Cosmos.CosmosClient {
     endpoint: endpoint() || "https://cosmos.azure.com", // CosmosClient gets upset if we pass a bad URL. This should never actually get called
     key: userContext.masterKey,
     tokenProvider,
-    connectionPolicy: {
-      enableEndpointDiscovery: true,
-    },
     userAgentSuffix: "Azure Portal",
     defaultHeaders: _defaultHeaders,
   };

--- a/src/Common/CosmosClient.ts
+++ b/src/Common/CosmosClient.ts
@@ -149,7 +149,7 @@ export function client(): Cosmos.CosmosClient {
     key: userContext.masterKey,
     tokenProvider,
     connectionPolicy: {
-      enableEndpointDiscovery: false,
+      enableEndpointDiscovery: true,
     },
     userAgentSuffix: "Azure Portal",
     defaultHeaders: _defaultHeaders,


### PR DESCRIPTION
During previous region outages, DE was unable to view account data.  

According to [this doc](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/troubleshoot-sdk-availability), setting enableEndpointDiscovery to false can compromise the SDK's ability to fail over if a region becomes unavailable.

Letting this bake in MPAC to see if there are any issues not encountered during validation.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1694)
