### PR TITLE
Revert Enabling Endpoint Discovery 

### DIFF
--- a/src/Common/CosmosClient.ts
+++ b/src/Common/CosmosClient.ts
@@ -148,6 +148,9 @@ export function client(): Cosmos.CosmosClient {
     endpoint: endpoint() || "https://cosmos.azure.com", // CosmosClient gets upset if we pass a bad URL. This should never actually get called
     key: userContext.masterKey,
     tokenProvider,
+    connectionPolicy: {
+      enableEndpointDiscovery: false,
+    },
     userAgentSuffix: "Azure Portal",
     defaultHeaders: _defaultHeaders,
   };


### PR DESCRIPTION
Reverting enabling endpoint discovery until next CCOA since it didn't have a chance to bake in MPAC during the current CCOA.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1698?feature.someFeatureFlagYouMightNeed=true)
