### PR TITLE
Bug 2819243: [Screen reader - Cosmos DB Query Copilot - Copilot]: Screen reader does not announce the status message which appears on invoking the 'Copy query' button.

### DIFF
--- a/src/Explorer/QueryCopilot/Popup/CopyPopup.tsx
+++ b/src/Explorer/QueryCopilot/Popup/CopyPopup.tsx
@@ -15,6 +15,7 @@ export const CopyPopup = ({
 
   return showCopyPopup ? (
     <Stack
+      role="status"
       style={{
         position: "fixed",
         width: 345,

--- a/src/Explorer/QueryCopilot/Popup/__snapshots__/CopyPopup.test.tsx.snap
+++ b/src/Explorer/QueryCopilot/Popup/__snapshots__/CopyPopup.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Copy Popup snapshot test should render when showCopyPopup is false 1`] 
 
 exports[`Copy Popup snapshot test should render when showCopyPopup is true 1`] = `
 <Stack
+  role="status"
   style={
     Object {
       "background": "#FFFFFF",


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
