### PR TITLE
Enabling endpoint discovery to test region failure

### DIFF
--- a/src/Common/CosmosClient.ts
+++ b/src/Common/CosmosClient.ts
@@ -148,9 +148,6 @@ export function client(): Cosmos.CosmosClient {
     endpoint: endpoint() || "https://cosmos.azure.com", // CosmosClient gets upset if we pass a bad URL. This should never actually get called
     key: userContext.masterKey,
     tokenProvider,
-    connectionPolicy: {
-      enableEndpointDiscovery: false,
-    },
     userAgentSuffix: "Azure Portal",
     defaultHeaders: _defaultHeaders,
   };


### PR DESCRIPTION
Enabling endpoint discovery in MPAC to test region outage in a non-development environment.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1711?feature.someFeatureFlagYouMightNeed=true)
