### PR TITLE
Bug 2819674: [Keyboard navigation - Cosmos DB Query Copilot - Save query]: Keyboard focus loss is observed by invoking the "X" (Close) button which is present in the 'Save query' dialog.

### DIFF
--- a/src/Explorer/Panes/PanelContainerComponent.tsx
+++ b/src/Explorer/Panes/PanelContainerComponent.tsx
@@ -76,7 +76,42 @@ export class PanelContainerComponent extends React.Component<PanelContainerProps
     );
   }
 
+  public isFocusable(element: HTMLElement) {
+    return (
+      element.tabIndex >= 0 ||
+      (element instanceof HTMLAnchorElement && element.href) ||
+      (element instanceof HTMLAreaElement && element.href) ||
+      (element instanceof HTMLInputElement && !element.disabled) ||
+      (element instanceof HTMLSelectElement && !element.disabled) ||
+      (element instanceof HTMLTextAreaElement && !element.disabled) ||
+      (element instanceof HTMLButtonElement && !element.disabled)
+    );
+  }
+  private findFocusableParent = (element: HTMLElement) => {
+    while (element) {
+      if (this.isFocusable(element)) {
+        return element;
+      }
+      element = element.parentNode as HTMLElement;
+    }
+    return null;
+  };
+
   private onDissmiss = (ev?: KeyboardEvent | React.SyntheticEvent<HTMLElement>): void => {
+    let elementIdToFocus = sessionStorage.getItem("focusedElementId") || null;
+    if (elementIdToFocus) {
+      let targetElement = document.getElementById(elementIdToFocus);
+
+      if (targetElement) {
+        let focusableParent = this.findFocusableParent(targetElement);
+        if (focusableParent) {
+          setTimeout(() => {
+            focusableParent.focus();
+          }, 100);
+          sessionStorage.removeItem("focusedElementId");
+        }
+      }
+    }
     if (ev && (ev.target as HTMLElement).id === "notificationConsoleHeader") {
       ev.preventDefault();
     } else {

--- a/src/Explorer/Panes/PanelContainerComponent.tsx
+++ b/src/Explorer/Panes/PanelContainerComponent.tsx
@@ -98,15 +98,15 @@ export class PanelContainerComponent extends React.Component<PanelContainerProps
   };
 
   private onDissmiss = (ev?: KeyboardEvent | React.SyntheticEvent<HTMLElement>): void => {
-    let elementIdToFocus = sessionStorage.getItem("focusedElementId") || null;
+    const elementIdToFocus = sessionStorage.getItem("focusedElementId") || null;
     if (elementIdToFocus) {
-      let targetElement = document.getElementById(elementIdToFocus);
+      const targetElement = document.getElementById(elementIdToFocus);
 
       if (targetElement) {
-        let focusableParent = this.findFocusableParent(targetElement);
+        const focusableParent = this.findFocusableParent(targetElement);
         if (focusableParent) {
           setTimeout(() => {
-            focusableParent.focus();
+            if (focusableParent) focusableParent.focus();
           }, 100);
           sessionStorage.removeItem("focusedElementId");
         }

--- a/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
@@ -224,6 +224,7 @@ export default class QueryTabComponent extends React.Component<IQueryTabComponen
   };
 
   public onSaveQueryClick = (): void => {
+    sessionStorage.setItem("focusedElementId", "savequery");
     useSidePanel.getState().openSidePanel("Save Query", <SaveQueryPane explorer={this.props.collection.container} />);
   };
 
@@ -394,6 +395,7 @@ export default class QueryTabComponent extends React.Component<IQueryTabComponen
       const label = "Save Query";
       buttons.push({
         iconSrc: SaveQueryIcon,
+        id: "savequery",
         iconAlt: label,
         onCommandClick: this.onSaveQueryClick,
         commandButtonLabel: label,


### PR DESCRIPTION
… dialog

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1717?feature.someFeatureFlagYouMightNeed=true)
