### PR TITLE
Fixing manual throughput cost estimate

### DIFF
--- a/src/Explorer/Controls/Settings/SettingsSubComponents/ThroughputInputComponents/ThroughputInputAutoPilotV3Component.tsx
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/ThroughputInputComponents/ThroughputInputAutoPilotV3Component.tsx
@@ -135,7 +135,7 @@ export class ThroughputInputAutoPilotV3Component extends React.Component<
           if (
             this.props.softAllowedMaximumThroughput
               ? this.props.maxAutoPilotThroughput <= this.props.softAllowedMaximumThroughput &&
-              AutoPilotUtils.isValidAutoPilotThroughput(this.props.maxAutoPilotThroughput)
+                AutoPilotUtils.isValidAutoPilotThroughput(this.props.maxAutoPilotThroughput)
               : AutoPilotUtils.isValidAutoPilotThroughput(this.props.maxAutoPilotThroughput)
           ) {
             isSaveable = true;
@@ -450,8 +450,8 @@ export class ThroughputInputAutoPilotV3Component extends React.Component<
     return this.props.isAutoPilotSelected
       ? this.props.maxAutoPilotThroughput
       : this.overrideWithAutoPilotSettings()
-        ? this.props.maxAutoPilotThroughputBaseline
-        : this.props.throughput;
+      ? this.props.maxAutoPilotThroughputBaseline
+      : this.props.throughput;
   };
 
   private getCurrentRuRange = (): "below" | "instant" | "delayed" | "requireSupport" => {
@@ -478,8 +478,8 @@ export class ThroughputInputAutoPilotV3Component extends React.Component<
           this.getCurrentRuRange() === "instant"
             ? "rgb(0, 120, 212)"
             : this.getCurrentRuRange() === "delayed"
-              ? "rgb(255 216 109)"
-              : "rgb(251, 217, 203)",
+            ? "rgb(255 216 109)"
+            : "rgb(251, 217, 203)",
       },
     ],
   });

--- a/src/Explorer/Controls/Settings/SettingsSubComponents/ThroughputInputComponents/ThroughputInputAutoPilotV3Component.tsx
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/ThroughputInputComponents/ThroughputInputAutoPilotV3Component.tsx
@@ -135,7 +135,7 @@ export class ThroughputInputAutoPilotV3Component extends React.Component<
           if (
             this.props.softAllowedMaximumThroughput
               ? this.props.maxAutoPilotThroughput <= this.props.softAllowedMaximumThroughput &&
-                AutoPilotUtils.isValidAutoPilotThroughput(this.props.maxAutoPilotThroughput)
+              AutoPilotUtils.isValidAutoPilotThroughput(this.props.maxAutoPilotThroughput)
               : AutoPilotUtils.isValidAutoPilotThroughput(this.props.maxAutoPilotThroughput)
           ) {
             isSaveable = true;
@@ -306,7 +306,7 @@ export class ThroughputInputAutoPilotV3Component extends React.Component<
     };
 
     const costElement = (): JSX.Element => {
-      const prices: PriceBreakdown = getRuPriceBreakdown(throughput, serverId, numberOfRegions, isMultimaster, true);
+      const prices: PriceBreakdown = getRuPriceBreakdown(throughput, serverId, numberOfRegions, isMultimaster, false);
       return (
         <Stack {...checkBoxAndInputStackProps} style={{ marginTop: 15 }}>
           {newThroughput && newThroughputCostElement()}
@@ -450,8 +450,8 @@ export class ThroughputInputAutoPilotV3Component extends React.Component<
     return this.props.isAutoPilotSelected
       ? this.props.maxAutoPilotThroughput
       : this.overrideWithAutoPilotSettings()
-      ? this.props.maxAutoPilotThroughputBaseline
-      : this.props.throughput;
+        ? this.props.maxAutoPilotThroughputBaseline
+        : this.props.throughput;
   };
 
   private getCurrentRuRange = (): "below" | "instant" | "delayed" | "requireSupport" => {
@@ -478,8 +478,8 @@ export class ThroughputInputAutoPilotV3Component extends React.Component<
           this.getCurrentRuRange() === "instant"
             ? "rgb(0, 120, 212)"
             : this.getCurrentRuRange() === "delayed"
-            ? "rgb(255 216 109)"
-            : "rgb(251, 217, 203)",
+              ? "rgb(255 216 109)"
+              : "rgb(251, 217, 203)",
       },
     ],
   });

--- a/src/Explorer/Controls/Settings/SettingsSubComponents/ThroughputInputComponents/__snapshots__/ThroughputInputAutoPilotV3Component.test.tsx.snap
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/ThroughputInputComponents/__snapshots__/ThroughputInputAutoPilotV3Component.test.tsx.snap
@@ -917,7 +917,7 @@ exports[`ThroughputInputAutoPilotV3Component spendAck checkbox visible 1`] = `
             >
               $
                
-              0.012
+              0.0080
               /hr
             </Text>
             <Text
@@ -929,7 +929,7 @@ exports[`ThroughputInputAutoPilotV3Component spendAck checkbox visible 1`] = `
             >
               $
                
-              0.29
+              0.19
               /day
             </Text>
             <Text
@@ -941,7 +941,7 @@ exports[`ThroughputInputAutoPilotV3Component spendAck checkbox visible 1`] = `
             >
               $
                
-              8.76
+              5.84
               /mo
             </Text>
           </Stack>
@@ -1354,7 +1354,7 @@ exports[`ThroughputInputAutoPilotV3Component throughput input visible 1`] = `
             >
               $
                
-              0.012
+              0.0080
               /hr
             </Text>
             <Text
@@ -1366,7 +1366,7 @@ exports[`ThroughputInputAutoPilotV3Component throughput input visible 1`] = `
             >
               $
                
-              0.29
+              0.19
               /day
             </Text>
             <Text
@@ -1378,7 +1378,7 @@ exports[`ThroughputInputAutoPilotV3Component throughput input visible 1`] = `
             >
               $
                
-              8.76
+              5.84
               /mo
             </Text>
           </Stack>


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

When viewing Scale & Settings tab on db/container, when set to Autoscale, the min & max values are correct. But when switching to Manual the cost estimate is using the same base RU value as autoscale ($0.00012) when it should be using its own base value ($0.00008).