### PR TITLE
Hide buttons from command bar for Fabric or when no write access

### DIFF
--- a/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
@@ -135,7 +135,7 @@ export function createStaticCommandBarButtons(
       buttons.push(newSqlQueryBtn);
     }
 
-    if (isQuerySupported && selectedNodeState.findSelectedCollection()) {
+    if (isQuerySupported && selectedNodeState.findSelectedCollection() && configContext.platform !== Platform.Fabric) {
       const openQueryBtn = createOpenQueryButton(container);
       openQueryBtn.children = [createOpenQueryButton(container), createOpenQueryFromDiskButton()];
       buttons.push(openQueryBtn);

--- a/src/Explorer/Tabs/DocumentsTab.ts
+++ b/src/Explorer/Tabs/DocumentsTab.ts
@@ -881,6 +881,11 @@ export default class DocumentsTab extends TabsBase {
   }
 
   protected getTabsButtons(): CommandButtonComponentProps[] {
+    if (!userContext.hasWriteAccess) {
+      // All the following buttons require write access
+      return [];
+    }
+
     const buttons: CommandButtonComponentProps[] = [];
     const label = !this.isPreferredApiMongoDB ? "New Item" : "New Document";
     if (this.newDocumentButton.visible()) {

--- a/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-console */
 import { FeedOptions, QueryOperationOptions } from "@azure/cosmos";
+import { Platform, configContext } from "ConfigContext";
 import { useDialog } from "Explorer/Controls/Dialog";
 import { QueryCopilotFeedbackModal } from "Explorer/QueryCopilot/Modal/QueryCopilotFeedbackModal";
 import { useCopilotStore } from "Explorer/QueryCopilot/QueryCopilotContext";
@@ -402,7 +403,7 @@ export default class QueryTabComponent extends React.Component<IQueryTabComponen
       });
     }
 
-    if (this.saveQueryButton.visible) {
+    if (this.saveQueryButton.visible && configContext.platform !== Platform.Fabric) {
       const label = "Save Query";
       buttons.push({
         iconSrc: SaveQueryIcon,

--- a/src/Platform/Fabric/FabricUtil.ts
+++ b/src/Platform/Fabric/FabricUtil.ts
@@ -31,6 +31,7 @@ const requestDatabaseResourceTokens = async (): Promise<void> => {
     updateUserContext({
       fabricContext: { ...userContext.fabricContext, databaseConnectionInfo: fabricDatabaseConnectionInfo },
       databaseAccount: { ...userContext.databaseAccount },
+      hasWriteAccess: false, // TODO: receive from fabricDatabaseConnectionInfo
     });
     scheduleRefreshDatabaseResourceToken();
   } catch (error) {


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

* The `userContext.hasWriteAccess` flag is currently only used to show Write vs Read-Only cosmos db account keys in the Connect tab. We extend the meaning of this flag to mean Data Explorer is in write vs read-only mode and hide buttons not relevant to read-only.
* Hide "New Items", "Update" in document tab when in read-only
* Fabric: 
  * Hide Open/Save Query, because queries are saved in another (not mounted) database
  * Set Data Explorer as read-only for now.