### PR TITLE
Correcting import for MessageTypes

### DIFF
--- a/src/Contracts/ExplorerContracts.ts
+++ b/src/Contracts/ExplorerContracts.ts
@@ -1,6 +1,6 @@
-import { MessageTypes } from "Contracts/MessageTypes";
 import * as ActionContracts from "./ActionContracts";
 import * as Diagnostics from "./Diagnostics";
+import { MessageTypes } from "./MessageTypes";
 import * as Versions from "./Versions";
 
 export { ActionContracts, Diagnostics, MessageTypes, Versions };


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1743?feature.someFeatureFlagYouMightNeed=true)


Having "Contracts/MessageTypes" brakes the Frontend code that pulls this. The folder name changes to DataExplorerContracts in the FrontEnd code resulting in the build not find the import.

![image](https://github.com/Azure/cosmos-explorer/assets/144163838/953b8f4d-9285-4526-ac5c-6ad37de1389f)


P.S. - I don't like where prettier moved the import :(