### PR TITLE
Fixing terminal tab to display correct API type for network warning

### DIFF
--- a/src/Explorer/Tabs/TerminalTab.tsx
+++ b/src/Explorer/Tabs/TerminalTab.tsx
@@ -34,6 +34,7 @@ class NotebookTerminalComponentAdapter implements ReactAdapter {
     private getTabId: () => string,
     private getUsername: () => string,
     private isAllPublicIPAddressesEnabled: ko.Observable<boolean>,
+    private kind: ViewModels.TerminalKind,
   ) {}
 
   public renderComponent(): JSX.Element {
@@ -42,7 +43,7 @@ class NotebookTerminalComponentAdapter implements ReactAdapter {
         <QuickstartFirewallNotification
           messageType={MessageTypes.OpenPostgresNetworkingBlade}
           screenshot={FirewallRuleScreenshot}
-          shellName="PostgreSQL"
+          shellName={this.getShellNameForDisplay(this.kind)}
         />
       );
     }
@@ -57,6 +58,18 @@ class NotebookTerminalComponentAdapter implements ReactAdapter {
     ) : (
       <Spinner styles={{ root: { marginTop: 10 } }} size={SpinnerSize.large}></Spinner>
     );
+  }
+
+  private getShellNameForDisplay(terminalKind: ViewModels.TerminalKind): string {
+    switch (terminalKind) {
+      case ViewModels.TerminalKind.Postgres:
+        return "PostgreSQL";
+      case ViewModels.TerminalKind.Mongo:
+      case ViewModels.TerminalKind.VCoreMongo:
+        return "MongoDB";
+      default:
+        return "";
+    }
   }
 }
 
@@ -76,6 +89,7 @@ export default class TerminalTab extends TabsBase {
       () => this.tabId,
       () => this.getUsername(),
       this.isAllPublicIPAddressesEnabled,
+      options.kind,
     );
     this.notebookTerminalComponentAdapter.parameters = ko.computed<boolean>(() => {
       if (


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1747)

Currently the network warning that displays on Postgres' and vCore Mongo's quickstarts only say PostgreSQL:
![image](https://github.com/Azure/cosmos-explorer/assets/25827057/719142aa-06d9-4c26-ab9e-c8549c9674a2)

Fixing this so it now shows the correct API type for the account:
![image](https://github.com/Azure/cosmos-explorer/assets/25827057/f430b5c6-3720-47c7-a3cf-0141cb199e42)
