### PR TITLE
Hide Save/Open query buttons and New Document/Save/Update buttons for Fabric read-only

### DIFF
--- a/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
@@ -135,7 +135,7 @@ export function createStaticCommandBarButtons(
       buttons.push(newSqlQueryBtn);
     }
 
-    if (isQuerySupported && selectedNodeState.findSelectedCollection()) {
+    if (isQuerySupported && selectedNodeState.findSelectedCollection() && configContext.platform !== Platform.Fabric) {
       const openQueryBtn = createOpenQueryButton(container);
       openQueryBtn.children = [createOpenQueryButton(container), createOpenQueryFromDiskButton()];
       buttons.push(openQueryBtn);

--- a/src/Explorer/Tabs/DocumentsTab.ts
+++ b/src/Explorer/Tabs/DocumentsTab.ts
@@ -881,6 +881,11 @@ export default class DocumentsTab extends TabsBase {
   }
 
   protected getTabsButtons(): CommandButtonComponentProps[] {
+    if (userContext.fabricContext?.isReadOnly) {
+      // All the following buttons require write access
+      return [];
+    }
+
     const buttons: CommandButtonComponentProps[] = [];
     const label = !this.isPreferredApiMongoDB ? "New Item" : "New Document";
     if (this.newDocumentButton.visible()) {

--- a/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-console */
 import { FeedOptions, QueryOperationOptions } from "@azure/cosmos";
+import { Platform, configContext } from "ConfigContext";
 import { useDialog } from "Explorer/Controls/Dialog";
 import { QueryCopilotFeedbackModal } from "Explorer/QueryCopilot/Modal/QueryCopilotFeedbackModal";
 import { useCopilotStore } from "Explorer/QueryCopilot/QueryCopilotContext";
@@ -402,7 +403,7 @@ export default class QueryTabComponent extends React.Component<IQueryTabComponen
       });
     }
 
-    if (this.saveQueryButton.visible) {
+    if (this.saveQueryButton.visible && configContext.platform !== Platform.Fabric) {
       const label = "Save Query";
       buttons.push({
         iconSrc: SaveQueryIcon,

--- a/src/Platform/Fabric/FabricUtil.ts
+++ b/src/Platform/Fabric/FabricUtil.ts
@@ -29,7 +29,11 @@ const requestDatabaseResourceTokens = async (): Promise<void> => {
     }
 
     updateUserContext({
-      fabricContext: { ...userContext.fabricContext, databaseConnectionInfo: fabricDatabaseConnectionInfo },
+      fabricContext: {
+        ...userContext.fabricContext,
+        databaseConnectionInfo: fabricDatabaseConnectionInfo,
+        isReadOnly: true,
+      },
       databaseAccount: { ...userContext.databaseAccount },
     });
     scheduleRefreshDatabaseResourceToken();

--- a/src/UserContext.ts
+++ b/src/UserContext.ts
@@ -50,6 +50,7 @@ export interface VCoreMongoConnectionParams {
 interface FabricContext {
   connectionId: string;
   databaseConnectionInfo: FabricDatabaseConnectionInfo | undefined;
+  isReadOnly: boolean;
 }
 
 interface UserContext {


### PR DESCRIPTION
* Introduce a new isReadOnly flag in fabric context (always false for now). The flag will be contained in the resource token call response in the future.
* Hide Save/Open query buttons which aren't relevant to Fabric (they save to a different database that isn't mirrored and not visible in Fabric)
* Hide the buttons associated to editing a document for Fabric read-only.
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
