### PR TITLE
Bug 1242529: [Usable - Azure Cosmos DB - Input Parameters]: Aria-label is not descriptive enough for the 'Close(x)' button of 'Input Parameters' blade.

### DIFF
--- a/src/Explorer/Panes/PanelContainerComponent.tsx
+++ b/src/Explorer/Panes/PanelContainerComponent.tsx
@@ -58,7 +58,7 @@ export class PanelContainerComponent extends React.Component<PanelContainerProps
         onDismiss={this.onDissmiss}
         isLightDismiss
         type={PanelType.custom}
-        closeButtonAriaLabel="Close"
+        closeButtonAriaLabel={`Close ${this.props.headerText}`}
         customWidth={this.props.panelWidth ? this.props.panelWidth : "440px"}
         headerClassName="panelHeader"
         onRenderNavigationContent={this.props.onRenderNavigationContent}

--- a/src/Explorer/Panes/__snapshots__/PanelContainerComponent.test.tsx.snap
+++ b/src/Explorer/Panes/__snapshots__/PanelContainerComponent.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PaneContainerComponent test should be resize if notification console is expanded 1`] = `
 <StyledPanelBase
-  closeButtonAriaLabel="Close"
+  closeButtonAriaLabel="Close test"
   customWidth="440px"
   headerClassName="panelHeader"
   headerText="test"
@@ -42,7 +42,7 @@ exports[`PaneContainerComponent test should render nothing if content is undefin
 
 exports[`PaneContainerComponent test should render with panel content and header 1`] = `
 <StyledPanelBase
-  closeButtonAriaLabel="Close"
+  closeButtonAriaLabel="Close test"
   customWidth="440px"
   headerClassName="panelHeader"
   headerText="test"


### PR DESCRIPTION
…me of the dialog box

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1760?feature.someFeatureFlagYouMightNeed=true)
