### PR TITLE
Bug 1249101: [Usable - Azure Cosmos DB - New Keyspace]: Link "capacity calculator" overlaps with the keyboard focus indicator boundary and not visible properly.

### DIFF
--- a/src/Explorer/Controls/ThroughputInput/ThroughputInput.less
+++ b/src/Explorer/Controls/ThroughputInput/ThroughputInput.less
@@ -14,7 +14,7 @@
 .throughputInputSpacing > :not(:last-child) {
   margin-bottom: @DefaultSpace;
 }
-.capacitycalculator-link:focus{
+.capacitycalculator-link:focus {
   text-decoration: underline;
   outline-offset: 2px;
 }

--- a/src/Explorer/Controls/ThroughputInput/ThroughputInput.tsx
+++ b/src/Explorer/Controls/ThroughputInput/ThroughputInput.tsx
@@ -224,8 +224,10 @@ export const ThroughputInput: FunctionComponent<ThroughputInputProps> = ({
             Estimate your required RU/s with{" "}
             <Link
               target="_blank"
+              className="capacitycalculator-link"
               href="https://cosmos.azure.com/capacitycalculator/"
               aria-label="capacity calculator of azure cosmos db"
+              style={{ outline: "none" }}
             >
               capacity calculator
             </Link>

--- a/src/Explorer/Controls/ThroughputInput/__snapshots__/ThroughputInput.test.tsx.snap
+++ b/src/Explorer/Controls/ThroughputInput/__snapshots__/ThroughputInput.test.tsx.snap
@@ -733,12 +733,24 @@ exports[`ThroughputInput Pane should render Default properly 1`] = `
              
             <StyledLinkBase
               aria-label="capacity calculator of azure cosmos db"
+              className="capacitycalculator-link"
               href="https://cosmos.azure.com/capacitycalculator/"
+              style={
+                Object {
+                  "outline": "none",
+                }
+              }
               target="_blank"
             >
               <LinkBase
                 aria-label="capacity calculator of azure cosmos db"
+                className="capacitycalculator-link"
                 href="https://cosmos.azure.com/capacitycalculator/"
+                style={
+                  Object {
+                    "outline": "none",
+                  }
+                }
                 styles={[Function]}
                 target="_blank"
                 theme={
@@ -1017,9 +1029,14 @@ exports[`ThroughputInput Pane should render Default properly 1`] = `
               >
                 <a
                   aria-label="capacity calculator of azure cosmos db"
-                  className="ms-Link root-117"
+                  className="ms-Link capacitycalculator-link root-117"
                   href="https://cosmos.azure.com/capacitycalculator/"
                   onClick={[Function]}
+                  style={
+                    Object {
+                      "outline": "none",
+                    }
+                  }
                   target="_blank"
                 >
                   capacity calculator


### PR DESCRIPTION
… for the link to be clearly visible

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1762?feature.someFeatureFlagYouMightNeed=true)
