### PR TITLE
Fix initial container loading in Fabric

### DIFF
--- a/src/Contracts/FabricMessagesContract.ts
+++ b/src/Contracts/FabricMessagesContract.ts
@@ -53,6 +53,7 @@ export type FabricMessageV2 =
       id: string;
       message: {
         connectionId: string;
+        isVisible: boolean;
       };
     }
   | {
@@ -72,7 +73,7 @@ export type FabricMessageV2 =
       };
     }
   | {
-      type: "setToolbarStatus";
+      type: "explorerVisible";
       message: {
         visible: boolean;
       };

--- a/src/UserContext.ts
+++ b/src/UserContext.ts
@@ -51,6 +51,7 @@ interface FabricContext {
   connectionId: string;
   databaseConnectionInfo: FabricDatabaseConnectionInfo | undefined;
   isReadOnly: boolean;
+  isVisible: boolean;
 }
 
 export type AdminFeedbackControlPolicy =

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -111,7 +111,7 @@ async function configureFabric(): Promise<Explorer> {
 
         switch (data.type) {
           case "initialize": {
-            isExplorerVisible = data.message.isVisible;
+            isExplorerVisible = data.message.isVisible ?? true; // preserve glitchy behavior if Fabric UX doesn't send isVisible
             const fabricVersion = data.version;
             if (!SUPPORTED_FABRIC_VERSIONS.includes(fabricVersion)) {
               // TODO Surface error to user


### PR DESCRIPTION
There is a rendering issue where the documents table doesn't resize properly if explorer is loaded in the beackground (invisible). To workaround this, track DE visibility from Fabric RPC and open the first container only once DE becomes visible. If DE has been already shown, open the container right away.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1771?feature.someFeatureFlagYouMightNeed=true)
