### PR TITLE
Don't show the new Home button in Fabric

### DIFF
--- a/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
@@ -58,10 +58,10 @@ export function createStaticCommandBarButtons(
     }
   };
 
-  const homeBtn = createHomeButton();
-  buttons.push(homeBtn);
-
   if (configContext.platform !== Platform.Fabric) {
+    const homeBtn = createHomeButton();
+    buttons.push(homeBtn);
+
     const newCollectionBtn = createNewCollectionGroup(container);
     buttons.push(newCollectionBtn);
     if (userContext.apiType !== "Tables" && userContext.apiType !== "Cassandra") {


### PR DESCRIPTION
as the whole Home tab feature is not supported there.

![image](https://github.com/Azure/cosmos-explorer/assets/951587/d1dbff7f-8a1e-46e0-8d75-5c8eba03272a)


[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1774?feature.someFeatureFlagYouMightNeed=true)
