### PR TITLE
Add Dedicated Gateway Type

### DIFF
--- a/src/Localization/en/SqlX.json
+++ b/src/Localization/en/SqlX.json
@@ -8,6 +8,7 @@
     "DedicatedGatewayPricing": "Learn more about dedicated gateway pricing.",
     "SKUs": "SKUs",
     "SKUsPlaceHolder": "Select SKUs",
+    "DedicatedGatewayTypePlaceHolder": "Select Dedicated Gateway Type",
     "NumberOfInstances": "Number of instances",
     "CosmosD4s": "Cosmos.D4s (General Purpose Cosmos Compute with 4 vCPUs, 16 GB Memory)",
     "CosmosD8s": "Cosmos.D8s (General Purpose Cosmos Compute with 8 vCPUs, 32 GB Memory)",

--- a/src/SelfServe/SqlX/SqlX.rp.ts
+++ b/src/SelfServe/SqlX/SqlX.rp.ts
@@ -33,11 +33,12 @@ export const getPath = (subscriptionId: string, resourceGroup: string, name: str
   return `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.DocumentDB/databaseAccounts/${name}/services/SqlDedicatedGateway`;
 };
 
-export const updateDedicatedGatewayResource = async (sku: string, instances: number): Promise<string> => {
+export const updateDedicatedGatewayResource = async (sku: string, dedicatedGatewayType: string, instances: number): Promise<string> => {
   const path = getPath(userContext.subscriptionId, userContext.resourceGroup, userContext.databaseAccount.name);
   const body: UpdateDedicatedGatewayRequestParameters = {
     properties: {
       instanceSize: sku,
+      // TODO: pass in DedicatedGatewayType into the properties on Update
       instanceCount: instances,
       serviceType: "SqlDedicatedGateway",
     },


### PR DESCRIPTION
## Why make this change?

To support distributed query on dedicated gateway.

## What is this change?

- Add a drop down for dedicated gateway type.
- On enable dedicated gateway, user can change the value of its type.
- Once saved and enabled, the type will be disabled.
- When rendering an account with dedicated gateway already provisioned, the dedicated gateway type should reflect correct value. 

## How was this tested?

Tested locally. 
