### PR TITLE
Add activate/close tab contracts and add to queryTab

### DIFF
--- a/src/Contracts/MessageTypes.ts
+++ b/src/Contracts/MessageTypes.ts
@@ -35,6 +35,7 @@ export enum MessageTypes {
   CreateWorkspace,
   CreateSparkPool,
   RefreshDatabaseAccount,
+  ActivateTab,
   CloseTab,
   OpenQuickstartBlade,
   OpenPostgreSQLPasswordReset,

--- a/src/Explorer/Tabs/QueryTab/QueryTab.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTab.tsx
@@ -1,3 +1,5 @@
+import { sendMessage } from "Common/MessageHandler";
+import { MessageTypes } from "Contracts/MessageTypes";
 import { CopilotProvider } from "Explorer/QueryCopilot/QueryCopilotContext";
 import { userContext } from "UserContext";
 import React from "react";
@@ -54,6 +56,11 @@ export class NewQueryTab extends TabsBase {
     );
   }
 
+  public onActivate(): void {
+    this.propagateTabInformation(MessageTypes.ActivateTab);
+    super.onActivate();
+  }
+
   public onTabClick(): void {
     useTabs.getState().activateTab(this);
     this.iTabAccessor.onTabClickEvent();
@@ -61,6 +68,7 @@ export class NewQueryTab extends TabsBase {
 
   public onCloseTabButtonClick(): void {
     useTabs.getState().closeTab(this);
+    this.propagateTabInformation(MessageTypes.CloseTab);
     if (this.iTabAccessor) {
       this.iTabAccessor.onCloseClickEvent(true);
     }
@@ -68,5 +76,16 @@ export class NewQueryTab extends TabsBase {
 
   public getContainer(): Explorer {
     return this.props.container;
+  }
+
+  private propagateTabInformation(type: MessageTypes): void {
+    sendMessage({
+      type,
+      data: {
+        kind: this.tabKind,
+        databaseId: this.collection?.databaseId,
+        collectionId: this.collection?.id?.(),
+      },
+    });
   }
 }


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1783?feature.someFeatureFlagYouMightNeed=true)

Description
Overview and DataExplorer blade will keep the current query tab open state in portal to communicate it to the Azure Copilot.

How Has This Been Tested?
By updating the DE contracts manually locally and testing it in portal