### PR TITLE
[Bug #3061738] Unclobber some Monaco styles we clobber

### DIFF
--- a/less/documentDB.less
+++ b/less/documentDB.less
@@ -2296,6 +2296,17 @@ a:link {
   display: none !important;
 }
 
+.monaco-editor .quick-input-list-label {
+  /* Restore some of Monaco's default styles that are clobbered by our global styles */
+  padding: 0;
+  line-height: 22px;
+}
+
+.monaco-editor .quick-input-list .highlight {
+  /* Padding in highlighted text within the quick input list breaks the flow of the text */
+  padding: 0;
+}
+
 td a {
   color: #393939;
 }


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1784?feature.someFeatureFlagYouMightNeed=true)

The Monaco Editor we're using for editing queries has a built-in "Quick Actions" panel, opened with the F1 key, that provides access to keyboard shortcuts and editor actions like commenting/uncommenting lines, etc. Unfortunately, some of our top-level CSS styles are clobbering styles the editor provides which makes that quick action panel look bad:

![image](https://github.com/Azure/cosmos-explorer/assets/7574/ade47101-9a97-47e3-8fbe-e06177e30903)

This PR reasserts the styles that Monaco uses with a more specific selector so that they override our global `label` and `.highlight` styles. The result is that the quick input panel now looks the same as in the [Monaco Editor Playground](https://microsoft.github.io/monaco-editor/playground.html?source=v0.47.0):

![image](https://github.com/Azure/cosmos-explorer/assets/7574/ce849192-feac-4232-81b1-d15934e85a87)

This fixes [Bug #3061738](https://dev.azure.com/msdata/CosmosDB/_workitems/edit/3061738/)
