### PR TITLE
[Task #3061771] Correct render order issues on undo

### DIFF
--- a/src/Explorer/Controls/Editor/EditorReact.tsx
+++ b/src/Explorer/Controls/Editor/EditorReact.tsx
@@ -48,15 +48,12 @@ export class EditorReact extends React.Component<EditorReactProps, EditorReactSt
 
   public componentDidUpdate() {
     if (!this.editor) {
-      // Nothing special to do if the editor doesn't exist yet
       return;
     }
 
     const existingContent = this.editor.getModel().getValue();
 
-    // Compare the new content to the editor's existing content
     if (this.props.content !== existingContent) {
-      // If it's different, push an edit to the editor, respecting the undo stack
       this.editor.pushUndoStop();
       this.editor.executeEdits("", [
         {

--- a/src/Explorer/Controls/Editor/EditorReact.tsx
+++ b/src/Explorer/Controls/Editor/EditorReact.tsx
@@ -46,7 +46,7 @@ export class EditorReact extends React.Component<EditorReactProps, EditorReactSt
     }, 100);
   }
 
-  public componentDidUpdate(previous: EditorReactProps) {
+  public componentDidUpdate() {
     if (!this.editor) {
       // Nothing special to do if the editor doesn't exist yet
       return;

--- a/src/Explorer/Controls/Editor/EditorReact.tsx
+++ b/src/Explorer/Controls/Editor/EditorReact.tsx
@@ -47,8 +47,22 @@ export class EditorReact extends React.Component<EditorReactProps, EditorReactSt
   }
 
   public componentDidUpdate(previous: EditorReactProps) {
-    if (this.props.content !== previous.content) {
-      this.editor?.setValue(this.props.content);
+    if (!this.editor) {
+      // Nothing special to do if the editor doesn't exist yet
+      return;
+    }
+
+    const existingContent = this.editor.getModel().getValue();
+
+    // Compare the new content to the editor's existing content
+    if (this.props.content !== existingContent) {
+      // If it's different, push an edit to the editor, respecting the undo stack
+      this.editor.executeEdits("", [
+        {
+          range: this.editor.getModel().getFullModelRange(),
+          text: this.props.content,
+        },
+      ]);
     }
   }
 
@@ -71,9 +85,14 @@ export class EditorReact extends React.Component<EditorReactProps, EditorReactSt
 
   protected configureEditor(editor: monaco.editor.IStandaloneCodeEditor) {
     this.editor = editor;
-    const queryEditorModel = this.editor.getModel();
     if (!this.props.isReadOnly && this.props.onContentChanged) {
-      queryEditorModel.onDidChangeContent(() => {
+      // Hooking the model's onDidChangeContent event because of some event ordering issues.
+      // If a single user input causes BOTH the editor content to change AND the cursor selection to change (which is likely),
+      // then there are some inconsistencies as to which event fires first.
+      // But the editor.onDidChangeModelContent event seems to always fire before the cursor selection event.
+      // (This is NOT true for the model's onDidChangeContent event, which sometimes fires after the cursor selection event.)
+      // If the cursor selection event fires first, then the calling component may re-render the component with old content, so we want to ensure the model content changed event always fires first.
+      this.editor.onDidChangeModelContent(() => {
         const queryEditorModel = this.editor.getModel();
         this.props.onContentChanged(queryEditorModel.getValue());
       });

--- a/src/Explorer/Controls/Editor/EditorReact.tsx
+++ b/src/Explorer/Controls/Editor/EditorReact.tsx
@@ -57,6 +57,7 @@ export class EditorReact extends React.Component<EditorReactProps, EditorReactSt
     // Compare the new content to the editor's existing content
     if (this.props.content !== existingContent) {
       // If it's different, push an edit to the editor, respecting the undo stack
+      this.editor.pushUndoStop();
       this.editor.executeEdits("", [
         {
           range: this.editor.getModel().getFullModelRange(),

--- a/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
@@ -496,13 +496,13 @@ export default class QueryTabComponent extends React.Component<IQueryTabComponen
   };
 
   public onChangeContent(newContent: string): void {
+    if (this.state.copilotActive) {
+      this.props.copilotStore?.setQuery(newContent);
+    }
     this.setState({
       sqlQueryEditorContent: newContent,
       queryCopilotGeneratedQuery: "",
     });
-    if (this.state.copilotActive) {
-      this.props.copilotStore?.setQuery(newContent);
-    }
     if (this.isPreferredApiMongoDB) {
       if (newContent.length > 0) {
         this.executeQueryButton = {
@@ -544,7 +544,7 @@ export default class QueryTabComponent extends React.Component<IQueryTabComponen
     useCommandBar.getState().setContextButtons(this.getTabsButtons());
   }
 
-  public setEditorContent(): string {
+  public getEditorContent(): string {
     if (this.isCopilotTabActive && this.state.queryCopilotGeneratedQuery) {
       return this.state.queryCopilotGeneratedQuery;
     }
@@ -601,7 +601,7 @@ export default class QueryTabComponent extends React.Component<IQueryTabComponen
                 <div className="queryEditor" style={{ height: "100%" }}>
                   <EditorReact
                     language={"sql"}
-                    content={this.setEditorContent()}
+                    content={this.getEditorContent()}
                     isReadOnly={false}
                     wordWrap={"on"}
                     ariaLabel={"Editing Query"}

--- a/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
@@ -496,6 +496,9 @@ export default class QueryTabComponent extends React.Component<IQueryTabComponen
   };
 
   public onChangeContent(newContent: string): void {
+    // The copilot store's active query takes precedence over the local state,
+    // and we can't update both states in a single operation.
+    // So, we update the copilot store's state first, then update the local state.
     if (this.state.copilotActive) {
       this.props.copilotStore?.setQuery(newContent);
     }


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1785?feature.someFeatureFlagYouMightNeed=true)

Undo/redo is another feature that's built in to the Monaco editor so we _should_ be getting it for free. However, we aren't, so something must be going wrong. After a bunch of digging, the root cause of the problem is the way we're tracking the content of the editor itself. We hook a 'content changed' event on the editor, then use that to update the internal state tracking the content of the editor. When we re-render, we use that internal state to set the content of the editor. That causes a few problems:

1. Setting the content using `setValue` will destroy the undo/redo stack.
2. Unnecessarily setting the content of the editor to it's existing content will create new, confusing, undo stack entries.
3. If the ordering of events from the editor isn't what we expect, our internal state may get out of sync with the editor's actual content.

This PR fixes all three of those issues:

First, when we **do** need to externally change the content of the editor (such as when Copilot is used), we use `executeEdits` instead of `setValue`. This has the effect of emulating a "Select All, Paste New Content" action, and properly updates the undo/redo stack.

Second, in `EditorReact`, when comparing the content in our provided props to see if we should update the Monaco editor content, we compare against the actual current value (`this.editor.getModel().getValue()`) instead of our previous props (`previous.content`). This way, if the editor updates itself (such as in an undo operation), we're still comparing against the right value.

Finally, instead of hooking `this.editor.getModel().onDidChangeContent` to trigger content changed events, we hook `this.editor.onDidChangeModelContent`. Of the three changes, this is the most... guess-y 😅 . I did a bunch of tracking of event ordering and noticed that for some user operations, particularly **undo** and **redo** operations, the `this.editor.onDidChangeCursorSelection` event fires **before** `this.editor.getModel().onDidChangeContent`. This causes us to trigger the `onContentSelected` event **before** `onContentChanged`. The `QueryTabComponent` updates it's state on `onContentSelected`, which causes a re-render. However, it _has not seen the new content yet_, which means it tries to push the **old** content into the editor. This destroys the undo operation. However, I did find that `this.editor.onDidChangeModelContent` **does** consistently fire before `this.editor.onDidChangeCursorSelection`. Switching to that event fixes the issues with undo/redo without breaking other scenarios as far as I can find.

I'm not super excited to be this coupled to event ordering, but without a more significant dive in to reworking our data model for the editor, I think it's the best option to get the immediate benefit of making undo/redo work.

Here's a video demo showing the new changes in action!


https://github.com/Azure/cosmos-explorer/assets/7574/7dba991a-5255-42b9-9bbf-95bb45c33b7d



