### PR TITLE
Post preview link as PR comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,0 @@
-[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,12 @@ jobs:
         run: az storage blob upload -c '$web' -f ./preview/config.json --account-name cosmosexplorerpreview --name "${{github.event.pull_request.head.sha || github.sha}}/config.json" --account-key="${PREVIEW_STORAGE_KEY}" --overwrite true
         env:
           PREVIEW_STORAGE_KEY: ${{ secrets.PREVIEW_STORAGE_KEY }}
+      - name: Post a comment with the preview URL
+        if: ${{ github.event_name == 'pull_request' }}
+        run: gh pr comment $PR_NUMBER --body "Build complete. You can now [preview this branch in the portal](https://cosmos-explorer-preview.azurewebsites.net/pull/$PR_NUMBER?feature.someFeatureFlagYouMightNeed=true)"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
   endtoendemulator:
     name: "End To End Emulator Tests"
     # Temporarily disabled. This test needs to be rewritten in playwright


### PR DESCRIPTION
*Draft PR because the only way to test GitHub Actions is to open a PR* 😅

This change updates our GitHub Action to post the preview link as a PR comment, after the preview site is deployed. As a result, you no longer have to remember to update the link in the template, and it only gets posted when it will work (so you don't get Blob Not Found errors from clicking it too "early").

If you need to set feature flags in the preview link, there are two options:

1. I believe contributors can edit the comment GitHub Actions posted, so you can add the feature flag there
2. You can also always still post your own link

Because this is now automated, I removed the PR template, but I'm happy to keep it around if folks want it. Using a comment means the link appears down in the conversation instead of up in the description, which may not be ideal, but I think automating it is very helpful. Editing the PR description is _much harder_ to automate (though I think it's possible).