### PR TITLE
add support for react dev tools to the editor

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,5 +1,5 @@
 // Import this first, to ensure that the dev tools hook is copied before React is loaded.
-import './ReactDevTools';
+import "./ReactDevTools";
 
 // CSS Dependencies
 import { initializeIcons, loadTheme } from "@fluentui/react";

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,3 +1,6 @@
+// Import this first, to ensure that the dev tools hook is copied before React is loaded.
+import './ReactDevTools';
+
 // CSS Dependencies
 import { initializeIcons, loadTheme } from "@fluentui/react";
 import { QuickstartCarousel } from "Explorer/Quickstart/QuickstartCarousel";

--- a/src/ReactDevTools.ts
+++ b/src/ReactDevTools.ts
@@ -1,3 +1,7 @@
 if (window.parent !== window) {
-  (window as any).__REACT_DEVTOOLS_GLOBAL_HOOK__ = (window.parent as any).__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  try {
+    (window as any).__REACT_DEVTOOLS_GLOBAL_HOOK__ = (window.parent as any).__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  } catch {
+    // No-op. We can throw here if the parent is not the same origin (such as in the Azure portal).
+  }
 }


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1788?feature.someFeatureFlagYouMightNeed=true)

I was going to use the [React Dev Tools extension](https://react.dev/learn/react-developer-tools) to get some information about the Components hierarchy in the explorer. Unfortunately, since we host the explorer inside an iframe, it doesn't Just Work ™️ . To make it work, [we need to inject a little code to copy the `__REACT_DEVTOOLS_GLOBAL_HOOK__ ` value from the parent frame to the child frame](https://github.com/facebook/react-devtools/issues/76#issuecomment-128091900). This has to be done _before_ React is loaded, so it takes a little bit of trickery.

I noticed that this code already exists in `ReactDevTools.ts`, but it isn't imported anywhere. So, I've added it to `Main.tsx`, right at the top. This means it'll always run before the main explorer UI loads, even in production builds. That should be safe though since the React Dev Tools don't give any more information than a user couldn't already acquire through the standard browser dev tools. It's just easier to view.

Once this is in place, the dev tools show the full Component hierarchy!

![Screenshot 2024-04-03 112003](https://github.com/Azure/cosmos-explorer/assets/7574/0df64aff-b64d-42ab-938e-3af81aae9b4c)
