### PR TITLE
[Task 3061766] Global Keyboard Shortcuts, implemented through the Command Bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
         "styled-components": "5.0.1",
         "swr": "0.4.0",
         "terser-webpack-plugin": "5.3.9",
+        "tinykeys": "2.1.0",
         "underscore": "1.9.1",
         "utility-types": "3.10.0",
         "zustand": "3.5.0"
@@ -37785,6 +37786,11 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+    },
+    "node_modules/tinykeys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinykeys/-/tinykeys-2.1.0.tgz",
+      "integrity": "sha512-/MESnqBD1xItZJn5oGQ4OsNORQgJfPP96XSGoyu4eLpwpL0ifO0SYR5OD76u0YMhMXsqkb0UqvI9+yXTh4xv8Q=="
     },
     "node_modules/tinyqueue": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "styled-components": "5.0.1",
     "swr": "0.4.0",
     "terser-webpack-plugin": "5.3.9",
+    "tinykeys": "2.1.0",
     "underscore": "1.9.1",
     "utility-types": "3.10.0",
     "zustand": "3.5.0"

--- a/src/Explorer/Controls/CommandButton/CommandButtonComponent.tsx
+++ b/src/Explorer/Controls/CommandButton/CommandButtonComponent.tsx
@@ -1,6 +1,7 @@
 /**
  * React component for Command button component.
  */
+import { KeyboardAction } from "KeyboardShortcuts";
 import * as React from "react";
 import CollapseChevronDownIcon from "../../../../images/QueryBuilder/CollapseChevronDown_16x.png";
 import { KeyCodes } from "../../../Common/Constants";
@@ -30,7 +31,7 @@ export interface CommandButtonComponentProps {
   /**
    * Click handler for command button click
    */
-  onCommandClick: (e: React.SyntheticEvent) => void;
+  onCommandClick: (e: React.SyntheticEvent | KeyboardEvent) => void;
 
   /**
    * Label for the button
@@ -107,10 +108,17 @@ export interface CommandButtonComponentProps {
    * Vertical bar to divide buttons
    */
   isDivider?: boolean;
+
   /**
    * Aria-label for the button
    */
   ariaLabel: string;
+
+  /**
+   * If specified, a keyboard action that should trigger this button's onCommandClick handler when activated.
+   * If not specified, the button will not be triggerable by keyboard shortcuts.
+   */
+  keyboardAction?: KeyboardAction;
 }
 
 export class CommandButtonComponent extends React.Component<CommandButtonComponentProps> {

--- a/src/Explorer/Menus/CommandBar/CommandBarComponentAdapter.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarComponentAdapter.tsx
@@ -5,6 +5,7 @@
  */
 import { CommandBar as FluentCommandBar, ICommandBarItemProps } from "@fluentui/react";
 import { useNotebook } from "Explorer/Notebook/useNotebook";
+import { useKeyboardActionHandlers } from "KeyboardShortcuts";
 import { userContext } from "UserContext";
 import * as React from "react";
 import create, { UseStore } from "zustand";
@@ -40,6 +41,7 @@ export const CommandBar: React.FC<Props> = ({ container }: Props) => {
   const buttons = useCommandBar((state) => state.contextButtons);
   const isHidden = useCommandBar((state) => state.isHidden);
   const backgroundColor = StyleConstants.BaseLight;
+  const setKeyboardShortcutHandlers = useKeyboardActionHandlers((state) => state.setHandlers);
 
   if (userContext.apiType === "Postgres" || userContext.apiType === "VCoreMongo") {
     const buttons =
@@ -104,6 +106,10 @@ export const CommandBar: React.FC<Props> = ({ container }: Props) => {
             backgroundColor: backgroundColor,
           },
         };
+
+  const allButtons = staticButtons.concat(contextButtons).concat(controlButtons);
+  const keyboardHandlers = CommandBarUtil.createKeyboardHandlers(allButtons);
+  setKeyboardShortcutHandlers(keyboardHandlers);
 
   return (
     <div className="commandBarContainer" style={{ display: isHidden ? "none" : "initial" }}>

--- a/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
@@ -1,3 +1,4 @@
+import { KeyboardAction } from "KeyboardShortcuts";
 import { ReactTabKind, useTabs } from "hooks/useTabs";
 import * as React from "react";
 import AddCollectionIcon from "../../../../images/AddCollection.svg";
@@ -297,6 +298,7 @@ function createNewSQLQueryButton(selectedNodeState: SelectedNodeState): CommandB
       id: "newQueryBtn",
       iconSrc: AddSqlQueryIcon,
       iconAlt: label,
+      keyboardAction: KeyboardAction.NEW_QUERY,
       onCommandClick: () => {
         const selectedCollection: ViewModels.Collection = selectedNodeState.findSelectedCollection();
         selectedCollection && selectedCollection.onNewQueryClick(selectedCollection);
@@ -312,6 +314,7 @@ function createNewSQLQueryButton(selectedNodeState: SelectedNodeState): CommandB
       id: "newQueryBtn",
       iconSrc: AddSqlQueryIcon,
       iconAlt: label,
+      keyboardAction: KeyboardAction.NEW_QUERY,
       onCommandClick: () => {
         const selectedCollection: ViewModels.Collection = selectedNodeState.findSelectedCollection();
         selectedCollection && selectedCollection.onNewMongoQueryClick(selectedCollection);
@@ -397,6 +400,7 @@ function createOpenQueryButton(container: Explorer): CommandButtonComponentProps
   return {
     iconSrc: BrowseQueriesIcon,
     iconAlt: label,
+    keyboardAction: KeyboardAction.OPEN_QUERY,
     onCommandClick: () =>
       useSidePanel.getState().openSidePanel("Open Saved Queries", <BrowseQueriesPane explorer={container} />),
     commandButtonLabel: label,
@@ -411,6 +415,7 @@ function createOpenQueryFromDiskButton(): CommandButtonComponentProps {
   return {
     iconSrc: OpenQueryFromDiskIcon,
     iconAlt: label,
+    keyboardAction: KeyboardAction.OPEN_QUERY_FROM_DISK,
     onCommandClick: () => useSidePanel.getState().openSidePanel("Load Query", <LoadQueryPane />),
     commandButtonLabel: label,
     ariaLabel: label,

--- a/src/Explorer/Menus/CommandBar/CommandBarUtil.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarUtil.tsx
@@ -7,6 +7,7 @@ import {
   IDropdownStyles,
 } from "@fluentui/react";
 import { useQueryCopilot } from "hooks/useQueryCopilot";
+import { KeyboardHandlerMap } from "KeyboardShortcuts";
 import * as React from "react";
 import _ from "underscore";
 import ChevronDownIcon from "../../../../images/Chevron_down.svg";
@@ -233,3 +234,28 @@ export const createConnectionStatus = (container: Explorer, poolId: PoolIdType, 
     onRender: () => <ConnectionStatus container={container} poolId={poolId} />,
   };
 };
+
+export function createKeyboardHandlers(allButtons: CommandButtonComponentProps[]): KeyboardHandlerMap {
+  const handlers: KeyboardHandlerMap = {};
+
+  function createHandlers(buttons: CommandButtonComponentProps[]) {
+    buttons.forEach((button) => {
+      if(button.disabled !== true && button.keyboardAction) {
+        handlers[button.keyboardAction] = (e) => {
+          button.onCommandClick(e);
+
+          // If the handler is bound, it means the button is visible and enabled, so we should prevent the default action
+          return true;
+        }
+      }
+
+      if (button.children && button.children.length > 0) {
+        createHandlers(button.children);
+      }
+    });
+  }
+
+  createHandlers(allButtons);
+
+  return handlers;
+}

--- a/src/Explorer/Menus/CommandBar/CommandBarUtil.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarUtil.tsx
@@ -240,7 +240,7 @@ export function createKeyboardHandlers(allButtons: CommandButtonComponentProps[]
 
   function createHandlers(buttons: CommandButtonComponentProps[]) {
     buttons.forEach((button) => {
-      if (button.disabled !== true && button.keyboardAction) {
+      if (!button.disabled && button.keyboardAction) {
         handlers[button.keyboardAction] = (e) => {
           button.onCommandClick(e);
 

--- a/src/Explorer/Menus/CommandBar/CommandBarUtil.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarUtil.tsx
@@ -240,13 +240,13 @@ export function createKeyboardHandlers(allButtons: CommandButtonComponentProps[]
 
   function createHandlers(buttons: CommandButtonComponentProps[]) {
     buttons.forEach((button) => {
-      if(button.disabled !== true && button.keyboardAction) {
+      if (button.disabled !== true && button.keyboardAction) {
         handlers[button.keyboardAction] = (e) => {
           button.onCommandClick(e);
 
           // If the handler is bound, it means the button is visible and enabled, so we should prevent the default action
           return true;
-        }
+        };
       }
 
       if (button.children && button.children.length > 0) {

--- a/src/Explorer/Tabs/DocumentsTab.ts
+++ b/src/Explorer/Tabs/DocumentsTab.ts
@@ -1,6 +1,7 @@
 import { ItemDefinition, PartitionKey, PartitionKeyDefinition, QueryIterator, Resource } from "@azure/cosmos";
 import { Platform, configContext } from "ConfigContext";
 import { querySampleDocuments, readSampleDocument } from "Explorer/QueryCopilot/QueryCopilotUtilities";
+import { KeyboardAction } from "KeyboardShortcuts";
 import { QueryConstants } from "Shared/Constants";
 import { LocalStorageUtility, StorageKey } from "Shared/StorageUtility";
 import * as ko from "knockout";
@@ -907,6 +908,7 @@ export default class DocumentsTab extends TabsBase {
       buttons.push({
         iconSrc: SaveIcon,
         iconAlt: label,
+        keyboardAction: KeyboardAction.SAVE_ITEM,
         onCommandClick: this.onSaveNewDocumentClick,
         commandButtonLabel: label,
         ariaLabel: label,
@@ -936,6 +938,7 @@ export default class DocumentsTab extends TabsBase {
       buttons.push({
         iconSrc: SaveIcon,
         iconAlt: label,
+        keyboardAction: KeyboardAction.SAVE_ITEM,
         onCommandClick: this.onSaveExistingDocumentClick,
         commandButtonLabel: label,
         ariaLabel: label,

--- a/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
@@ -10,6 +10,7 @@ import { OnExecuteQueryClick, QueryDocumentsPerPage } from "Explorer/QueryCopilo
 import { QueryCopilotSidebar } from "Explorer/QueryCopilot/V2/Sidebar/QueryCopilotSidebar";
 import { QueryResultSection } from "Explorer/Tabs/QueryTab/QueryResultSection";
 import { useSelectedNode } from "Explorer/useSelectedNode";
+import { KeyboardAction } from "KeyboardShortcuts";
 import { QueryConstants } from "Shared/Constants";
 import { LocalStorageUtility, StorageKey, getRUThreshold, ruThresholdEnabled } from "Shared/StorageUtility";
 import { Action } from "Shared/Telemetry/TelemetryConstants";
@@ -393,6 +394,7 @@ export default class QueryTabComponent extends React.Component<IQueryTabComponen
       buttons.push({
         iconSrc: ExecuteQueryIcon,
         iconAlt: label,
+        keyboardAction: KeyboardAction.EXECUTE_ITEM,
         onCommandClick: this.props.isSampleCopilotActive
           ? () => OnExecuteQueryClick(this.props.copilotStore)
           : this.onExecuteQueryClick,
@@ -408,6 +410,7 @@ export default class QueryTabComponent extends React.Component<IQueryTabComponen
       buttons.push({
         iconSrc: SaveQueryIcon,
         iconAlt: label,
+        keyboardAction: KeyboardAction.SAVE_ITEM,
         onCommandClick: this.onSaveQueryClick,
         commandButtonLabel: label,
         ariaLabel: label,
@@ -468,6 +471,7 @@ export default class QueryTabComponent extends React.Component<IQueryTabComponen
       buttons.push({
         iconSrc: CancelQueryIcon,
         iconAlt: label,
+        keyboardAction: KeyboardAction.CANCEL_QUERY,
         onCommandClick: () => this.queryAbortController.abort(),
         commandButtonLabel: label,
         ariaLabel: label,

--- a/src/Explorer/Tabs/StoredProcedureTab/StoredProcedureTabComponent.tsx
+++ b/src/Explorer/Tabs/StoredProcedureTab/StoredProcedureTabComponent.tsx
@@ -1,5 +1,6 @@
 import { Resource, StoredProcedureDefinition } from "@azure/cosmos";
 import { Pivot, PivotItem } from "@fluentui/react";
+import { KeyboardAction } from "KeyboardShortcuts";
 import React from "react";
 import ExecuteQueryIcon from "../../../../images/ExecuteQuery.svg";
 import DiscardIcon from "../../../../images/discard.svg";
@@ -321,6 +322,7 @@ export default class StoredProcedureTabComponent extends React.Component<
       buttons.push({
         iconSrc: SaveIcon,
         iconAlt: label,
+        keyboardAction: KeyboardAction.SAVE_ITEM,
         onCommandClick: this.onSaveClick,
         commandButtonLabel: label,
         ariaLabel: label,
@@ -334,6 +336,7 @@ export default class StoredProcedureTabComponent extends React.Component<
       buttons.push({
         iconSrc: SaveIcon,
         iconAlt: label,
+        keyboardAction: KeyboardAction.SAVE_ITEM,
         onCommandClick: this.onUpdateClick,
         commandButtonLabel: label,
         ariaLabel: label,
@@ -360,6 +363,7 @@ export default class StoredProcedureTabComponent extends React.Component<
       buttons.push({
         iconSrc: ExecuteQueryIcon,
         iconAlt: label,
+        keyboardAction: KeyboardAction.EXECUTE_ITEM,
         onCommandClick: () => {
           this.collection.container.openExecuteSprocParamsPanel(this.node);
         },

--- a/src/Explorer/Tabs/TriggerTabContent.tsx
+++ b/src/Explorer/Tabs/TriggerTabContent.tsx
@@ -1,5 +1,6 @@
 import { TriggerDefinition } from "@azure/cosmos";
 import { Dropdown, IDropdownOption, Label, TextField } from "@fluentui/react";
+import { KeyboardAction } from "KeyboardShortcuts";
 import React, { Component } from "react";
 import DiscardIcon from "../../../images/discard.svg";
 import SaveIcon from "../../../images/save-cosmos.svg";
@@ -227,6 +228,7 @@ export class TriggerTabContent extends Component<TriggerTab, ITriggerTabContentS
         ...this,
         iconSrc: SaveIcon,
         iconAlt: label,
+        keyboardAction: KeyboardAction.SAVE_ITEM,
         onCommandClick: this.onSaveClick,
         commandButtonLabel: label,
         ariaLabel: label,
@@ -241,6 +243,7 @@ export class TriggerTabContent extends Component<TriggerTab, ITriggerTabContentS
         ...this,
         iconSrc: SaveIcon,
         iconAlt: label,
+        keyboardAction: KeyboardAction.SAVE_ITEM,
         onCommandClick: this.onUpdateClick,
         commandButtonLabel: label,
         ariaLabel: label,

--- a/src/Explorer/Tabs/UserDefinedFunctionTabContent.tsx
+++ b/src/Explorer/Tabs/UserDefinedFunctionTabContent.tsx
@@ -1,12 +1,13 @@
 import { UserDefinedFunctionDefinition } from "@azure/cosmos";
 import { Label, TextField } from "@fluentui/react";
+import { KeyboardAction } from "KeyboardShortcuts";
 import React, { Component } from "react";
 import DiscardIcon from "../../../images/discard.svg";
 import SaveIcon from "../../../images/save-cosmos.svg";
 import * as Constants from "../../Common/Constants";
+import { getErrorMessage, getErrorStack } from "../../Common/ErrorHandlingUtils";
 import { createUserDefinedFunction } from "../../Common/dataAccess/createUserDefinedFunction";
 import { updateUserDefinedFunction } from "../../Common/dataAccess/updateUserDefinedFunction";
-import { getErrorMessage, getErrorStack } from "../../Common/ErrorHandlingUtils";
 import * as ViewModels from "../../Contracts/ViewModels";
 import { Action } from "../../Shared/Telemetry/TelemetryConstants";
 import * as TelemetryProcessor from "../../Shared/Telemetry/TelemetryProcessor";
@@ -80,6 +81,7 @@ export default class UserDefinedFunctionTabContent extends Component<
         setState: this.setState,
         iconSrc: SaveIcon,
         iconAlt: label,
+        keyboardAction: KeyboardAction.SAVE_ITEM,
         onCommandClick: this.onSaveClick,
         commandButtonLabel: label,
         ariaLabel: label,
@@ -94,6 +96,7 @@ export default class UserDefinedFunctionTabContent extends Component<
         ...this,
         iconSrc: SaveIcon,
         iconAlt: label,
+        keyboardAction: KeyboardAction.SAVE_ITEM,
         onCommandClick: this.onUpdateClick,
         commandButtonLabel: label,
         ariaLabel: label,

--- a/src/KeyboardShortcuts.tsx
+++ b/src/KeyboardShortcuts.tsx
@@ -85,5 +85,5 @@ export function KeyboardShortcutRoot({ children }: PropsWithChildren<unknown>) {
     tinykeys(document.body, allHandlers);
   }, []);
 
-  return <>{children}</>
+  return <>{children}</>;
 }

--- a/src/KeyboardShortcuts.tsx
+++ b/src/KeyboardShortcuts.tsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+import { HTMLProps, useEffect, useRef } from "react";
+import { KeyBindingMap, tinykeys } from "tinykeys";
+import create, { UseStore } from "zustand";
+
+/**
+ * Represents a keyboard shortcut handler.
+ * Return `true` to prevent the default action of the keyboard shortcut.
+ * Any other return value will allow the default action to proceed.
+ */
+export type KeyboardActionHandler = (e: KeyboardEvent) => boolean | void;
+
+export type KeyboardHandlerMap = Partial<Record<KeyboardAction, KeyboardActionHandler>>;
+
+/**
+ * The possible actions that can be triggered by keyboard shortcuts.
+ */
+export enum KeyboardAction {
+  NEW_QUERY = "NEW_QUERY",
+  EXECUTE_ITEM = "EXECUTE_ITEM",
+  CANCEL_QUERY = "CANCEL_QUERY",
+  SAVE_ITEM = "SAVE_ITEM",
+  OPEN_QUERY = "OPEN_QUERY",
+  OPEN_QUERY_FROM_DISK = "OPEN_QUERY_FROM_DISK",
+}
+
+/**
+ * The keyboard shortcuts for the application.
+ * This record maps each action to the keyboard shortcuts that trigger the action.
+ * Even if an action is specified here, it will not be triggered unless a handler is set for it.
+ */
+const bindings: Record<KeyboardAction, string[]> = {
+  // NOTE: The "$mod" special value is used to represent the "Control" key on Windows/Linux and the "Command" key on macOS.
+  // See https://www.npmjs.com/package/tinykeys#commonly-used-keys-and-codes for more information on the expected values for keyboard shortcuts.
+
+  [KeyboardAction.NEW_QUERY]: ["$mod+J"],
+  [KeyboardAction.EXECUTE_ITEM]: ["Shift+Enter"],
+  [KeyboardAction.CANCEL_QUERY]: ["Escape"],
+  [KeyboardAction.SAVE_ITEM]: ["$mod+S"],
+  [KeyboardAction.OPEN_QUERY]: ["$mod+O"],
+  [KeyboardAction.OPEN_QUERY_FROM_DISK]: ["$mod+Shift+O"],
+};
+
+interface KeyboardShortcutState {
+  /**
+   * A set of all the keyboard shortcuts handlers.
+   */
+  allHandlers: KeyboardHandlerMap;
+
+  /**
+   * Sets the keyboard shortcut handlers.
+   */
+  setHandlers: (handlers: KeyboardHandlerMap) => void;
+} 
+
+export const useKeyboardActionHandlers: UseStore<KeyboardShortcutState> = create((set, get) => ({
+  allHandlers: {},
+  setHandlers: (handlers: Partial<Record<KeyboardAction, KeyboardActionHandler>>) => {
+    set({ allHandlers: handlers })
+  }
+}));
+
+function createHandler(action: KeyboardAction): KeyboardActionHandler {
+  return (e) => {
+    const state = useKeyboardActionHandlers.getState();
+    const handler = state.allHandlers[action];
+    if (handler && handler(e)) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+}
+
+const allHandlers: KeyBindingMap = {};
+(Object.keys(bindings) as KeyboardAction[]).forEach((action) => {
+  const shortcuts = bindings[action];
+  shortcuts.forEach((shortcut) => {
+    allHandlers[shortcut] = createHandler(action);
+  });
+});
+
+export function KeyboardShortcutRoot(props: HTMLProps<HTMLDivElement>) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    tinykeys(ref.current, allHandlers);
+  }, [ref]); // We only need to re-render the component when the ref changes.
+
+  return <div ref={ref} {...props}>
+  </div>;
+}

--- a/src/KeyboardShortcuts.tsx
+++ b/src/KeyboardShortcuts.tsx
@@ -51,13 +51,13 @@ interface KeyboardShortcutState {
    * Sets the keyboard shortcut handlers.
    */
   setHandlers: (handlers: KeyboardHandlerMap) => void;
-} 
+}
 
-export const useKeyboardActionHandlers: UseStore<KeyboardShortcutState> = create((set, get) => ({
+export const useKeyboardActionHandlers: UseStore<KeyboardShortcutState> = create((set) => ({
   allHandlers: {},
   setHandlers: (handlers: Partial<Record<KeyboardAction, KeyboardActionHandler>>) => {
-    set({ allHandlers: handlers })
-  }
+    set({ allHandlers: handlers });
+  },
 }));
 
 function createHandler(action: KeyboardAction): KeyboardActionHandler {
@@ -85,6 +85,5 @@ export function KeyboardShortcutRoot(props: HTMLProps<HTMLDivElement>) {
     tinykeys(ref.current, allHandlers);
   }, [ref]); // We only need to re-render the component when the ref changes.
 
-  return <div ref={ref} {...props}>
-  </div>;
+  return <div ref={ref} {...props}></div>;
 }

--- a/src/KeyboardShortcuts.tsx
+++ b/src/KeyboardShortcuts.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { HTMLProps, useEffect, useRef } from "react";
+import { PropsWithChildren, useEffect } from "react";
 import { KeyBindingMap, tinykeys } from "tinykeys";
 import create, { UseStore } from "zustand";
 
@@ -79,11 +79,11 @@ const allHandlers: KeyBindingMap = {};
   });
 });
 
-export function KeyboardShortcutRoot(props: HTMLProps<HTMLDivElement>) {
-  const ref = useRef<HTMLDivElement>(null);
+export function KeyboardShortcutRoot({ children }: PropsWithChildren<unknown>) {
   useEffect(() => {
-    tinykeys(ref.current, allHandlers);
-  }, [ref]); // We only need to re-render the component when the ref changes.
+    // We bind to the body because Fluent UI components sometimes shift focus to the body, which is above the root React component.
+    tinykeys(document.body, allHandlers);
+  }, []);
 
-  return <div ref={ref} {...props}></div>;
+  return <>{children}</>
 }

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -21,6 +21,7 @@ import "../externals/jquery.typeahead.min.js";
 // Image Dependencies
 import { Platform } from "ConfigContext";
 import { QueryCopilotCarousel } from "Explorer/QueryCopilot/CopilotCarousel";
+import { KeyboardShortcutRoot } from "KeyboardShortcuts";
 import "../images/CosmosDB_rgb_ui_lighttheme.ico";
 import hdeConnectImage from "../images/HdeConnectCosmosDB.svg";
 import "../images/favicon.ico";
@@ -91,7 +92,7 @@ const App: React.FunctionComponent = () => {
   }
 
   return (
-    <div className="flexContainer" aria-hidden="false">
+    <KeyboardShortcutRoot className="flexContainer" aria-hidden="false">
       <div id="divExplorer" className="flexContainer hideOverflows">
         <div id="freeTierTeachingBubble"> </div>
         {/* Main Command Bar - Start */}
@@ -136,7 +137,7 @@ const App: React.FunctionComponent = () => {
       {<SQLQuickstartTutorial />}
       {<MongoQuickstartTutorial />}
       {<QueryCopilotCarousel isOpen={isCopilotCarouselOpen} explorer={explorer} />}
-    </div>
+    </KeyboardShortcutRoot>
   );
 };
 

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -92,51 +92,53 @@ const App: React.FunctionComponent = () => {
   }
 
   return (
-    <KeyboardShortcutRoot className="flexContainer" aria-hidden="false">
-      <div id="divExplorer" className="flexContainer hideOverflows">
-        <div id="freeTierTeachingBubble"> </div>
-        {/* Main Command Bar - Start */}
-        <CommandBar container={explorer} />
-        {/* Collections Tree and Tabs - Begin */}
-        <div className="resourceTreeAndTabs">
-          {/* Collections Tree - Start */}
-          {userContext.apiType !== "Postgres" && userContext.apiType !== "VCoreMongo" && (
-            <div id="resourcetree" data-test="resourceTreeId" className="resourceTree">
-              <div className="collectionsTreeWithSplitter">
-                {/* Collections Tree Expanded - Start */}
-                <ResourceTreeContainer
-                  container={explorer}
-                  toggleLeftPaneExpanded={toggleLeftPaneExpanded}
-                  isLeftPaneExpanded={isLeftPaneExpanded}
-                />
-                {/* Collections Tree Expanded - End */}
-                {/* Collections Tree Collapsed - Start */}
-                <CollapsedResourceTree
-                  toggleLeftPaneExpanded={toggleLeftPaneExpanded}
-                  isLeftPaneExpanded={isLeftPaneExpanded}
-                />
-                {/* Collections Tree Collapsed - End */}
+    <KeyboardShortcutRoot>
+      <div className="flexContainer" aria-hidden="false">
+        <div id="divExplorer" className="flexContainer hideOverflows">
+          <div id="freeTierTeachingBubble"> </div>
+          {/* Main Command Bar - Start */}
+          <CommandBar container={explorer} />
+          {/* Collections Tree and Tabs - Begin */}
+          <div className="resourceTreeAndTabs">
+            {/* Collections Tree - Start */}
+            {userContext.apiType !== "Postgres" && userContext.apiType !== "VCoreMongo" && (
+              <div id="resourcetree" data-test="resourceTreeId" className="resourceTree">
+                <div className="collectionsTreeWithSplitter">
+                  {/* Collections Tree Expanded - Start */}
+                  <ResourceTreeContainer
+                    container={explorer}
+                    toggleLeftPaneExpanded={toggleLeftPaneExpanded}
+                    isLeftPaneExpanded={isLeftPaneExpanded}
+                  />
+                  {/* Collections Tree Expanded - End */}
+                  {/* Collections Tree Collapsed - Start */}
+                  <CollapsedResourceTree
+                    toggleLeftPaneExpanded={toggleLeftPaneExpanded}
+                    isLeftPaneExpanded={isLeftPaneExpanded}
+                  />
+                  {/* Collections Tree Collapsed - End */}
+                </div>
               </div>
-            </div>
-          )}
-          <Tabs explorer={explorer} />
+            )}
+            <Tabs explorer={explorer} />
+          </div>
+          {/* Collections Tree and Tabs - End */}
+          <div
+            className="dataExplorerErrorConsoleContainer"
+            role="contentinfo"
+            aria-label="Notification console"
+            id="explorerNotificationConsole"
+          >
+            <NotificationConsole />
+          </div>
         </div>
-        {/* Collections Tree and Tabs - End */}
-        <div
-          className="dataExplorerErrorConsoleContainer"
-          role="contentinfo"
-          aria-label="Notification console"
-          id="explorerNotificationConsole"
-        >
-          <NotificationConsole />
-        </div>
+        <SidePanel />
+        <Dialog />
+        {<QuickstartCarousel isOpen={isCarouselOpen} />}
+        {<SQLQuickstartTutorial />}
+        {<MongoQuickstartTutorial />}
+        {<QueryCopilotCarousel isOpen={isCopilotCarouselOpen} explorer={explorer} />}
       </div>
-      <SidePanel />
-      <Dialog />
-      {<QuickstartCarousel isOpen={isCarouselOpen} />}
-      {<SQLQuickstartTutorial />}
-      {<MongoQuickstartTutorial />}
-      {<QueryCopilotCarousel isOpen={isCopilotCarouselOpen} explorer={explorer} />}
     </KeyboardShortcutRoot>
   );
 };


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1789?feature.someFeatureFlagYouMightNeed=true)

**This PR introduces a new dependency on `tinykeys`** I'm not 100% clear on what process, if any, is needed for that but I'm happy to follow whatever is needed.

This PR adds Keyboard Shortcuts by allowing Command Bar Buttons to specify a keyboard shortcut that should be used to activate the command. Upon pressing the keyboard shortcut, the existing `onCommandClick` handler will be executed. The following shortcuts are bound:

| Shortcut | Context | Action |
| - | - | - |
| `Ctrl+J`/`Cmd+J` [^1] | A collection is selected | Open a new Query Tab for the selected collection |
| `Shift+Enter` | A query tab is active | Execute the query (or the selection, if there is one) in the current query tab |
| `Esc` | A query is executing | Cancel the currently-executing query |
| `Ctrl+S`/`Cmd+S` | A query tab is active | Open the Save Query side-panel |
| `Ctrl+O`/`Cmd+O` | Anywhere the Open Query commands appear | Open the Open Query side-panel |
| `Ctrl+Shift+O`/`Cmd+Shift+O` | Anywhere the Open Query commands appear | Open the Open Query from Disk side-panel |
| `Ctrl+S`/`Cmd+S` | Editing a Document, SPROC, UDF, or Trigger | Saves the relevant item |
| ~~`Esc`~~ | ~~Editing a Document, SPROC, UDF, or Trigger~~ | ~~Discard changes to the relevant item~~ **Removed for this PR, still looking at finding the right keybind for this** |
| `Shift+Enter` | Editing a SPROC | Open the Execute SPROC side panel |

The shortcuts are implemented through `tinykeys`. At the root of the app, we have a new `KeyboardShortcutRoot` component. In this component, we define a mapping of an "Action Name" to a list of shortcuts that can trigger it (multiple shortcuts can be registered for a single action, and any of the registered shortcuts will work). For example:

```typescript
const bindings: Record<KeyboardAction, string[]> = {
  [KeyboardAction.NEW_QUERY]: ["$mod+J"],
  [KeyboardAction.EXECUTE_ITEM]: ["Shift+Enter"],
  // ...
};
```

*Note: The syntax `$mod` in tinykeys is replaced with `Control` on Windows/Linux and `Command` on macOS, matching user expectations for these kinds of shortcuts*

The `KeyboardAction` enum defines all the actions we specify in the app. When the root component is mounted, it will register a `keydown` handler on it's root element that handles each of these shortcuts (using tinykeys). When any of the shortcuts are pressed, the named "Action" will be triggered.

However, the Actions are not always available and their handlers change based on the context of the app. For example, `EXECUTE_ITEM` on a Query Tab executes the query. But on a SPROC tab it opens the side panel to execute the SPROC. To handle this, we have a new Zustand global state store[^2] called `useKeyboardActionHandlers`. Whenever a keyboard action is triggered, we check a map of `KeyboardAction` to handler function. If there's a handler registered for an action, we run it (and it usually stops propagation of the event). If not, we no-op and the event will propagate as normal.

Right now, the only place that updates handlers is the `CommandBarComponentAdapter`. The buttons we create can designate an option `KeyboardAction` that can be used to trigger the button. **If** the button is present and enabled, the adapter registers it's handler. If it's not present or disabled, the handler is not registered. This allows us to use all our existing logic for managing those command bar buttons to also manage their keyboard actions. Once we have actions that don't map directly to command bar buttons, we'll need a bit of refactoring here, but I have an idea how that will work and don't want to overcomplicate things in this PR since all the shortcuts added here are from the command bar [^3].

This PR completes [ADO task #3061766](https://msdata.visualstudio.com/CosmosDB/_workitems/edit/3061766/)

[^1]: It's not possible to bind Ctrl+N in the browser, so we can't use that.
[^2]: I could also use a React Context here, but it seems our existing practice is to use Zustand so I'm happy to do so.
[^3]: Basically, the problem is that the `CommandBarComponentAdaptor` replaces the entire handler map every time. This is necessary so it doesn't have to worry about removing old handlers when the button disappears. I intend to fix this by storing multiple sets of handler mappings and allowing each part of the application that provides handlers to replace it's set entirely without affecting the others.