### PR TITLE
Cassandra API create table error messages swallowed by the Portal and shown as "undefined".

### DIFF
--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -173,11 +173,11 @@ export class CassandraAPIDataClient extends TableDataClient {
         },
         (error) => {
           handleError(
-            error.responseJSON.message,
+            error.responseJSON?.message ?? JSON.stringify(error),
             "AddRowCassandra",
             `Error while adding new row to table ${collection.id()}`,
           );
-          deferred.reject(error.responseJSON.message);
+          deferred.reject(error.responseJSON?.message ?? JSON.stringify(error));
         },
       )
       .finally(clearInProgressMessage);
@@ -411,11 +411,11 @@ export class CassandraAPIDataClient extends TableDataClient {
         },
         (error) => {
           handleError(
-            error.responseJSON.message,
+            error.responseJSON?.message ?? JSON.stringify(error),
             "CreateKeyspaceCassandra",
             `Error while creating a keyspace with query ${createKeyspaceQuery}`,
           );
-          deferred.reject(error.responseJSON.message);
+          deferred.reject(error.responseJSON?.message ?? JSON.stringify(error));
         },
       )
       .finally(clearInProgressMessage);
@@ -449,11 +449,11 @@ export class CassandraAPIDataClient extends TableDataClient {
             },
             (error) => {
               handleError(
-                error.responseJSON.message,
+                error.responseJSON?.message ?? JSON.stringify(error),
                 "CreateTableCassandra",
                 `Error while creating a table with query ${createTableQuery}`,
               );
-              deferred.reject(error.responseJSON.message);
+              deferred.reject(error.responseJSON?.message ?? JSON.stringify(error));
             },
           )
           .finally(clearInProgressMessage);
@@ -502,11 +502,11 @@ export class CassandraAPIDataClient extends TableDataClient {
         },
         (error: any) => {
           handleError(
-            error.responseJSON.message,
+            error.responseJSON?.message ?? JSON.stringify(error),
             "FetchKeysCassandra",
             `Error fetching keys for table ${collection.id()}`,
           );
-          deferred.reject(error.responseJSON.message);
+          deferred.reject(error);
         },
       )
       .done(clearInProgressMessage);
@@ -546,11 +546,11 @@ export class CassandraAPIDataClient extends TableDataClient {
         },
         (error: any) => {
           handleError(
-            error.responseJSON.message,
+            error.responseJSON?.message ?? JSON.stringify(error),
             "FetchKeysCassandra",
             `Error fetching keys for table ${collection.id()}`,
           );
-          deferred.reject(error.responseJSON.message);
+          deferred.reject(error.responseJSON?.message ?? JSON.stringify(error));
         },
       )
       .done(clearInProgressMessage);
@@ -595,11 +595,11 @@ export class CassandraAPIDataClient extends TableDataClient {
         },
         (error: any) => {
           handleError(
-            error.responseJSON.message,
+            error.responseJSON?.message ?? JSON.stringify(error),
             "FetchSchemaCassandra",
             `Error fetching schema for table ${collection.id()}`,
           );
-          deferred.reject(error.responseJSON.message);
+          deferred.reject(error.responseJSON?.message ?? JSON.stringify(error));
         },
       )
       .done(clearInProgressMessage);
@@ -639,11 +639,11 @@ export class CassandraAPIDataClient extends TableDataClient {
         },
         (error: any) => {
           handleError(
-            error.responseJSON.message,
+            error.responseJSON?.message ?? JSON.stringify(error),
             "FetchSchemaCassandra",
             `Error fetching schema for table ${collection.id()}`,
           );
-          deferred.reject(error.responseJSON.message);
+          deferred.reject(error.responseJSON?.message ?? JSON.stringify(error));
         },
       )
       .done(clearInProgressMessage);

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -172,8 +172,12 @@ export class CassandraAPIDataClient extends TableDataClient {
           deferred.resolve(entity);
         },
         (error) => {
-          handleError(error, "AddRowCassandra", `Error while adding new row to table ${collection.id()}`);
-          deferred.reject(error);
+          handleError(
+            error.responseJSON.message,
+            "AddRowCassandra",
+            `Error while adding new row to table ${collection.id()}`,
+          );
+          deferred.reject(error.responseJSON.message);
         },
       )
       .finally(clearInProgressMessage);
@@ -407,11 +411,11 @@ export class CassandraAPIDataClient extends TableDataClient {
         },
         (error) => {
           handleError(
-            error,
+            error.responseJSON.message,
             "CreateKeyspaceCassandra",
             `Error while creating a keyspace with query ${createKeyspaceQuery}`,
           );
-          deferred.reject(error);
+          deferred.reject(error.responseJSON.message);
         },
       )
       .finally(clearInProgressMessage);
@@ -497,8 +501,12 @@ export class CassandraAPIDataClient extends TableDataClient {
           deferred.resolve(data);
         },
         (error: any) => {
-          handleError(error, "FetchKeysCassandra", `Error fetching keys for table ${collection.id()}`);
-          deferred.reject(error);
+          handleError(
+            error.responseJSON.message,
+            "FetchKeysCassandra",
+            `Error fetching keys for table ${collection.id()}`,
+          );
+          deferred.reject(error.responseJSON.message);
         },
       )
       .done(clearInProgressMessage);
@@ -537,8 +545,12 @@ export class CassandraAPIDataClient extends TableDataClient {
           deferred.resolve(data);
         },
         (error: any) => {
-          handleError(error, "FetchKeysCassandra", `Error fetching keys for table ${collection.id()}`);
-          deferred.reject(error);
+          handleError(
+            error.responseJSON.message,
+            "FetchKeysCassandra",
+            `Error fetching keys for table ${collection.id()}`,
+          );
+          deferred.reject(error.responseJSON.message);
         },
       )
       .done(clearInProgressMessage);
@@ -582,8 +594,12 @@ export class CassandraAPIDataClient extends TableDataClient {
           deferred.resolve(data.columns);
         },
         (error: any) => {
-          handleError(error, "FetchSchemaCassandra", `Error fetching schema for table ${collection.id()}`);
-          deferred.reject(error);
+          handleError(
+            error.responseJSON.message,
+            "FetchSchemaCassandra",
+            `Error fetching schema for table ${collection.id()}`,
+          );
+          deferred.reject(error.responseJSON.message);
         },
       )
       .done(clearInProgressMessage);
@@ -622,8 +638,12 @@ export class CassandraAPIDataClient extends TableDataClient {
           deferred.resolve(data.columns);
         },
         (error: any) => {
-          handleError(error, "FetchSchemaCassandra", `Error fetching schema for table ${collection.id()}`);
-          deferred.reject(error);
+          handleError(
+            error.responseJSON.message,
+            "FetchSchemaCassandra",
+            `Error fetching schema for table ${collection.id()}`,
+          );
+          deferred.reject(error.responseJSON.message);
         },
       )
       .done(clearInProgressMessage);

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -172,12 +172,9 @@ export class CassandraAPIDataClient extends TableDataClient {
           deferred.resolve(entity);
         },
         (error) => {
-          handleError(
-            error.responseJSON?.message ?? JSON.stringify(error),
-            "AddRowCassandra",
-            `Error while adding new row to table ${collection.id()}`,
-          );
-          deferred.reject(error.responseJSON?.message ?? JSON.stringify(error));
+          const errorText = error.responseJSON?.message ?? JSON.stringify(error);
+          handleError(errorText, "AddRowCassandra", `Error while adding new row to table ${collection.id()}`);
+          deferred.reject(errorText);
         },
       )
       .finally(clearInProgressMessage);
@@ -410,12 +407,13 @@ export class CassandraAPIDataClient extends TableDataClient {
           deferred.resolve();
         },
         (error) => {
+          const errorText = error.responseJSON?.message ?? JSON.stringify(error);
           handleError(
-            error.responseJSON?.message ?? JSON.stringify(error),
+            errorText,
             "CreateKeyspaceCassandra",
             `Error while creating a keyspace with query ${createKeyspaceQuery}`,
           );
-          deferred.reject(error.responseJSON?.message ?? JSON.stringify(error));
+          deferred.reject(errorText);
         },
       )
       .finally(clearInProgressMessage);
@@ -448,12 +446,13 @@ export class CassandraAPIDataClient extends TableDataClient {
               deferred.resolve();
             },
             (error) => {
+              const errorText = error.responseJSON?.message ?? JSON.stringify(error);
               handleError(
-                error.responseJSON?.message ?? JSON.stringify(error),
+                errorText,
                 "CreateTableCassandra",
                 `Error while creating a table with query ${createTableQuery}`,
               );
-              deferred.reject(error.responseJSON?.message ?? JSON.stringify(error));
+              deferred.reject(errorText);
             },
           )
           .finally(clearInProgressMessage);
@@ -501,12 +500,9 @@ export class CassandraAPIDataClient extends TableDataClient {
           deferred.resolve(data);
         },
         (error: any) => {
-          handleError(
-            error.responseJSON?.message ?? JSON.stringify(error),
-            "FetchKeysCassandra",
-            `Error fetching keys for table ${collection.id()}`,
-          );
-          deferred.reject(error);
+          const errorText = error.responseJSON?.message ?? JSON.stringify(error);
+          handleError(errorText, "FetchKeysCassandra", `Error fetching keys for table ${collection.id()}`);
+          deferred.reject(errorText);
         },
       )
       .done(clearInProgressMessage);
@@ -545,12 +541,9 @@ export class CassandraAPIDataClient extends TableDataClient {
           deferred.resolve(data);
         },
         (error: any) => {
-          handleError(
-            error.responseJSON?.message ?? JSON.stringify(error),
-            "FetchKeysCassandra",
-            `Error fetching keys for table ${collection.id()}`,
-          );
-          deferred.reject(error.responseJSON?.message ?? JSON.stringify(error));
+          const errorText = error.responseJSON?.message ?? JSON.stringify(error);
+          handleError(errorText, "FetchKeysCassandra", `Error fetching keys for table ${collection.id()}`);
+          deferred.reject(errorText);
         },
       )
       .done(clearInProgressMessage);
@@ -594,12 +587,9 @@ export class CassandraAPIDataClient extends TableDataClient {
           deferred.resolve(data.columns);
         },
         (error: any) => {
-          handleError(
-            error.responseJSON?.message ?? JSON.stringify(error),
-            "FetchSchemaCassandra",
-            `Error fetching schema for table ${collection.id()}`,
-          );
-          deferred.reject(error.responseJSON?.message ?? JSON.stringify(error));
+          const errorText = error.responseJSON?.message ?? JSON.stringify(error);
+          handleError(errorText, "FetchSchemaCassandra", `Error fetching schema for table ${collection.id()}`);
+          deferred.reject(errorText);
         },
       )
       .done(clearInProgressMessage);
@@ -638,12 +628,9 @@ export class CassandraAPIDataClient extends TableDataClient {
           deferred.resolve(data.columns);
         },
         (error: any) => {
-          handleError(
-            error.responseJSON?.message ?? JSON.stringify(error),
-            "FetchSchemaCassandra",
-            `Error fetching schema for table ${collection.id()}`,
-          );
-          deferred.reject(error.responseJSON?.message ?? JSON.stringify(error));
+          const errorText = error.responseJSON?.message ?? JSON.stringify(error);
+          handleError(errorText, "FetchSchemaCassandra", `Error fetching schema for table ${collection.id()}`);
+          deferred.reject(errorText);
         },
       )
       .done(clearInProgressMessage);

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -3,6 +3,7 @@ import * as ko from "knockout";
 import Q from "q";
 import { AuthType } from "../../AuthType";
 import * as Constants from "../../Common/Constants";
+import { CassandraProxyAPIs, CassandraProxyEndpoints } from "../../Common/Constants";
 import { handleError } from "../../Common/ErrorHandlingUtils";
 import * as HeadersUtility from "../../Common/HeadersUtility";
 import { createDocument } from "../../Common/dataAccess/createDocument";
@@ -19,7 +20,6 @@ import Explorer from "../Explorer";
 import * as TableConstants from "./Constants";
 import * as Entities from "./Entities";
 import * as TableEntityProcessor from "./TableEntityProcessor";
-import { CassandraProxyAPIs, CassandraProxyEndpoints } from "../../Common/Constants";
 
 export interface CassandraTableKeys {
   partitionKeys: CassandraTableKey[];
@@ -444,8 +444,12 @@ export class CassandraAPIDataClient extends TableDataClient {
               deferred.resolve();
             },
             (error) => {
-              handleError(error, "CreateTableCassandra", `Error while creating a table with query ${createTableQuery}`);
-              deferred.reject(error);
+              handleError(
+                error.responseJSON.message,
+                "CreateTableCassandra",
+                `Error while creating a table with query ${createTableQuery}`,
+              );
+              deferred.reject(error.responseJSON.message);
             },
           )
           .finally(clearInProgressMessage);


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1790?feature.someFeatureFlagYouMightNeed=true)

Currently errors for Cassandra DBs are being displayed as `undefined`. This is because the errors aren't being stored in `error.message` but `error.responseJSON.message`

 
Current add row error:
![image](https://github.com/Azure/cosmos-explorer/assets/144163838/fb3a5623-3d0c-42da-9c43-5d184d665f18)

Current create table error:
![image](https://github.com/Azure/cosmos-explorer/assets/144163838/8d4d3a52-6e17-4105-89eb-61b9eacf8c77)

