### PR TITLE
set the value in the editor for results

### DIFF
--- a/src/Explorer/Controls/Editor/EditorReact.tsx
+++ b/src/Explorer/Controls/Editor/EditorReact.tsx
@@ -54,13 +54,17 @@ export class EditorReact extends React.Component<EditorReactProps, EditorReactSt
     const existingContent = this.editor.getModel().getValue();
 
     if (this.props.content !== existingContent) {
-      this.editor.pushUndoStop();
-      this.editor.executeEdits("", [
-        {
-          range: this.editor.getModel().getFullModelRange(),
-          text: this.props.content,
-        },
-      ]);
+      if (this.props.isReadOnly) {
+        this.editor.setValue(this.props.content);
+      } else {
+        this.editor.pushUndoStop();
+        this.editor.executeEdits("", [
+          {
+            range: this.editor.getModel().getFullModelRange(),
+            text: this.props.content,
+          },
+        ]);
+      }
     }
   }
 


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1799?feature.someFeatureFlagYouMightNeed=true)

This is regarding the ICM(s) where query results are not updating after the initial query result showing and they run different subsequent query.
The executeEdits on the editor is being executed but for some reason, editor's internal state is not showing up correctly in the readonly monaco editor that we use in the query results panel below, until we manually re-render like going to the Query Stats tab and coming back.

So this is one way of fixing I think just to set the editor value directly and forcing rerender if it's readonly.
