### PR TITLE
Cassandra "Add Row" error hangs on isExecuting

### DIFF
--- a/src/Explorer/Panes/Tables/AddTableEntityPanel.tsx
+++ b/src/Explorer/Panes/Tables/AddTableEntityPanel.tsx
@@ -124,8 +124,8 @@ export const AddTableEntityPanel: FunctionComponent<AddTableEntityPanelProps> = 
 
     setIsExecuting(true);
     const entity: Entities.ITableEntity = entityFromAttributes(entities);
-    const newEntity: Entities.ITableEntity = await tableDataClient.createDocument(queryTablesTab.collection, entity);
     try {
+      const newEntity: Entities.ITableEntity = await tableDataClient.createDocument(queryTablesTab.collection, entity);
       await tableEntityListViewModel.addEntityToCache(newEntity);
       if (!tryInsertNewHeaders(tableEntityListViewModel, newEntity)) {
         tableEntityListViewModel.redrawTableThrottled();


### PR DESCRIPTION
Moving the CreateDocument call inside the Try statement allows the code to exit on error and eventually set setIsExecuting(false). With it being outside, the Try statement is never seen.

The only other way to prevent this would be to remove setIsExecuting(true) on line 125, which would defeat the purpose of the executing visuals while an operation is in progress. 

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1801?feature.someFeatureFlagYouMightNeed=true)
