### PR TITLE
fix copilot insertion so it doesn't wipe existing query text

### DIFF
--- a/src/Explorer/QueryCopilot/QueryCopilotPromptbar.tsx
+++ b/src/Explorer/QueryCopilot/QueryCopilotPromptbar.tsx
@@ -218,7 +218,7 @@ export const QueryCopilotPromptbar: React.FC<QueryCopilotPromptProps> = ({
             generateSQLQueryResponse.explanation ? generateSQLQueryResponse.explanation : "N/A"
           }\r\n`;
           const currentGeneratedQuery = queryExplanation + generateSQLQueryResponse.sql;
-          const lastQuery = generatedQuery && query ? `${query}\r\n` : "";
+          const lastQuery = query ? `${query}\r\n` : "";
           setQuery(`${lastQuery}${currentGeneratedQuery}`);
           setGeneratedQuery(generateSQLQueryResponse.sql);
           setGeneratedQueryComments(generateSQLQueryResponse.explanation);


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1803)

This is a fix for an issue I noticed (and that we've had some customer feedback on) with Copilot query insertion. The current version of the copilot insertion logic will replace the active query in some circumstances. It's notable that after the first result replaces the query, we do properly add the query to the end in further copilot invocations:

*Note: It's worth noting that with Undo fixed, you can undo that replacement, which you'll see me doing at the end of the video*

https://github.com/Azure/cosmos-explorer/assets/7574/b6dd21c2-5d2e-4770-b586-4b93698c45d9

With this fix, the query is now always inserted at the end of the document. It's possible we could insert it at the cursor position but that's a fair bit more work. This seems a little less surprising to me than replacing the entire query:

https://github.com/Azure/cosmos-explorer/assets/7574/c7bbc25f-3b32-45c5-ae70-e9bb9f2ae5ca

In looking into this, I noticed that we only append the copilot response to the end **if and only if** there is a previous generated query. That logic didn't seem correct to me. It seems like we should always insert the copilot response at the end. However, I don't have the history or context to understand why that choice was made originally, or if it was just an error. So if I'm misunderstanding something here, I'm happy to look in to other approaches! This fix seems to do the trick though, and ensure that we're always appending copilot responses to the end.

