### PR TITLE
Fix issues with the command bar when switching through React and Trigger tabs

### DIFF
--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -270,6 +270,7 @@ function TabPane({ tab, active }: { tab: Tab; active: boolean }) {
 
 const onKeyPressReactTab = (e: KeyboardEvent, tabKind: ReactTabKind): void => {
   if (e.key === "Enter" || e.key === "Space") {
+    useTabs.getState().activateReactTab(tabKind);
     e.stopPropagation();
   }
 };

--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -6,6 +6,7 @@ import { IpRule } from "Contracts/DataModels";
 import { MessageTypes } from "Contracts/ExplorerContracts";
 import { CollectionTabKind } from "Contracts/ViewModels";
 import Explorer from "Explorer/Explorer";
+import { useCommandBar } from "Explorer/Menus/CommandBar/CommandBarComponentAdapter";
 import { QueryCopilotTab } from "Explorer/QueryCopilot/QueryCopilotTab";
 import { SplashScreen } from "Explorer/SplashScreen/SplashScreen";
 import { ConnectTab } from "Explorer/Tabs/ConnectTab";
@@ -269,7 +270,6 @@ function TabPane({ tab, active }: { tab: Tab; active: boolean }) {
 
 const onKeyPressReactTab = (e: KeyboardEvent, tabKind: ReactTabKind): void => {
   if (e.key === "Enter" || e.key === "Space") {
-    useTabs.getState().activateReactTab(tabKind);
     e.stopPropagation();
   }
 };
@@ -297,6 +297,9 @@ const isQueryErrorThrown = (tab?: Tab, tabKind?: ReactTabKind): boolean => {
 };
 
 const getReactTabContent = (activeReactTab: ReactTabKind, explorer: Explorer): JSX.Element => {
+  // React tabs have no context buttons.
+  useCommandBar.getState().setContextButtons([]);
+
   // eslint-disable-next-line no-console
   switch (activeReactTab) {
     case ReactTabKind.Connect:

--- a/src/Explorer/Tabs/TriggerTabContent.tsx
+++ b/src/Explorer/Tabs/TriggerTabContent.tsx
@@ -219,6 +219,14 @@ export class TriggerTabContent extends Component<TriggerTab, ITriggerTabContentS
     return !!value;
   }
 
+  componentDidUpdate(_prevProps: TriggerTab, prevState: ITriggerTabContentState): void {
+    const { triggerBody, triggerId, triggerType, triggerOperation } = this.state;
+    if (triggerId !== prevState.triggerId || triggerBody !== prevState.triggerBody ||
+        triggerType !== prevState.triggerType || triggerOperation !== prevState.triggerOperation) {
+      useCommandBar.getState().setContextButtons(this.getTabsButtons());
+    }
+  }
+
   protected getTabsButtons(): CommandButtonComponentProps[] {
     const buttons: CommandButtonComponentProps[] = [];
     const label = "Save";
@@ -290,7 +298,6 @@ export class TriggerTabContent extends Component<TriggerTab, ITriggerTabContentS
   };
 
   render(): JSX.Element {
-    useCommandBar.getState().setContextButtons(this.getTabsButtons());
     const { triggerId, triggerType, triggerOperation, triggerBody, isIdEditable } = this.state;
     return (
       <div className="tab-pane flexContainer trigger-form" role="tabpanel">

--- a/src/Explorer/Tabs/TriggerTabContent.tsx
+++ b/src/Explorer/Tabs/TriggerTabContent.tsx
@@ -221,8 +221,12 @@ export class TriggerTabContent extends Component<TriggerTab, ITriggerTabContentS
 
   componentDidUpdate(_prevProps: TriggerTab, prevState: ITriggerTabContentState): void {
     const { triggerBody, triggerId, triggerType, triggerOperation } = this.state;
-    if (triggerId !== prevState.triggerId || triggerBody !== prevState.triggerBody ||
-        triggerType !== prevState.triggerType || triggerOperation !== prevState.triggerOperation) {
+    if (
+      triggerId !== prevState.triggerId ||
+      triggerBody !== prevState.triggerBody ||
+      triggerType !== prevState.triggerType ||
+      triggerOperation !== prevState.triggerOperation
+    ) {
       useCommandBar.getState().setContextButtons(this.getTabsButtons());
     }
   }


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1804?feature.someFeatureFlagYouMightNeed=true)

I noticed two bugs related to the command bar while working on some keyboard shortcuts:

1. If you have a Trigger Tab open, it takes over the command bar entries, even if it's not currently the active tab. See this video for an example:

https://github.com/Azure/cosmos-explorer/assets/7574/cb2cbf2c-16e7-4c28-8248-d323edd31fd4

2. React tabs have no context buttons. However, nothing clears the button state when you activate a React tab, so the command bar is still showing the buttons for the previously-selected tab:

https://github.com/Azure/cosmos-explorer/assets/7574/9296d35a-04f8-4554-bfba-ab9397a255a1

This PR fixes both issues, so that the command bar stays consistent. This is extra relevant with keyboard shortcuts since those are driven off of the Command Bar:

https://github.com/Azure/cosmos-explorer/assets/7574/a5ba357e-2779-40bd-b0ee-28e752bab991