### PR TITLE
[Task 3071878] Tab Navigation Keyboard Shortcuts

### DIFF
--- a/src/Explorer/Menus/CommandBar/CommandBarComponentAdapter.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarComponentAdapter.tsx
@@ -5,7 +5,7 @@
  */
 import { CommandBar as FluentCommandBar, ICommandBarItemProps } from "@fluentui/react";
 import { useNotebook } from "Explorer/Notebook/useNotebook";
-import { useKeyboardActionHandlers } from "KeyboardShortcuts";
+import { KeyboardActionGroup, useKeyboardActionGroup } from "KeyboardShortcuts";
 import { userContext } from "UserContext";
 import * as React from "react";
 import create, { UseStore } from "zustand";
@@ -41,7 +41,7 @@ export const CommandBar: React.FC<Props> = ({ container }: Props) => {
   const buttons = useCommandBar((state) => state.contextButtons);
   const isHidden = useCommandBar((state) => state.isHidden);
   const backgroundColor = StyleConstants.BaseLight;
-  const setKeyboardActionHandlers = useKeyboardActionHandlers((state) => state.setHandlers);
+  const setKeyboardHandlers = useKeyboardActionGroup(KeyboardActionGroup.COMMAND_BAR);
 
   if (userContext.apiType === "Postgres" || userContext.apiType === "VCoreMongo") {
     const buttons =
@@ -109,7 +109,7 @@ export const CommandBar: React.FC<Props> = ({ container }: Props) => {
 
   const allButtons = staticButtons.concat(contextButtons).concat(controlButtons);
   const keyboardHandlers = CommandBarUtil.createKeyboardHandlers(allButtons);
-  setKeyboardActionHandlers(keyboardHandlers);
+  setKeyboardHandlers(keyboardHandlers);
 
   return (
     <div className="commandBarContainer" style={{ display: isHidden ? "none" : "initial" }}>

--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -14,6 +14,7 @@ import { PostgresConnectTab } from "Explorer/Tabs/PostgresConnectTab";
 import { QuickstartTab } from "Explorer/Tabs/QuickstartTab";
 import { VcoreMongoConnectTab } from "Explorer/Tabs/VCoreMongoConnectTab";
 import { VcoreMongoQuickstartTab } from "Explorer/Tabs/VCoreMongoQuickstartTab";
+import { KeyboardAction, KeyboardActionGroup, useKeyboardActionGroup } from "KeyboardShortcuts";
 import { hasRUThresholdBeenConfigured } from "Shared/StorageUtility";
 import { userContext } from "UserContext";
 import { CassandraProxyOutboundIPs, MongoProxyOutboundIPs, PortalBackendIPs } from "Utils/EndpointUtils";
@@ -42,6 +43,16 @@ export const Tabs = ({ explorer }: TabsProps): JSX.Element => {
     showMongoAndCassandraProxiesNetworkSettingsWarningState,
     setShowMongoAndCassandraProxiesNetworkSettingsWarningState,
   ] = useState<boolean>(showMongoAndCassandraProxiesNetworkSettingsWarning());
+
+  const setKeyboardHandlers = useKeyboardActionGroup(KeyboardActionGroup.TABS);
+  useEffect(() => {
+    setKeyboardHandlers({
+      [KeyboardAction.SELECT_LEFT_TAB]: () => useTabs.getState().selectLeftTab(),
+      [KeyboardAction.SELECT_RIGHT_TAB]: () => useTabs.getState().selectRightTab(),
+      [KeyboardAction.CLOSE_TAB]: () => useTabs.getState().closeActiveTab(),
+    });
+  }, [setKeyboardHandlers]);
+
   return (
     <div className="tabsManagerContainer">
       {networkSettingsWarning && (

--- a/src/KeyboardShortcuts.tsx
+++ b/src/KeyboardShortcuts.tsx
@@ -94,10 +94,8 @@ interface KeyboardShortcutState {
  * @param group The group of keyboard actions to manage.
  * @returns A function that can be used to set the keyboard action handlers for the given group.
  */
-export const useKeyboardActionGroup =
-  (group: KeyboardActionGroup) =>
-    (handlers: KeyboardHandlerMap) =>
-      useKeyboardActionHandlers.getState().setHandlers(group, handlers);
+export const useKeyboardActionGroup = (group: KeyboardActionGroup) => (handlers: KeyboardHandlerMap) =>
+  useKeyboardActionHandlers.getState().setHandlers(group, handlers);
 
 const useKeyboardActionHandlers: UseStore<KeyboardShortcutState> = create((set, get) => ({
   allHandlers: {},

--- a/src/KeyboardShortcuts.tsx
+++ b/src/KeyboardShortcuts.tsx
@@ -13,6 +13,20 @@ export type KeyboardActionHandler = (e: KeyboardEvent) => boolean | void;
 export type KeyboardHandlerMap = Partial<Record<KeyboardAction, KeyboardActionHandler>>;
 
 /**
+ * The groups of keyboard actions that can be managed by the application.
+ * Each group can be updated separately, but, when updated, must be completely replaced.
+ */
+export enum KeyboardActionGroup {
+  TABS = "TABS",
+  COMMAND_BAR = "COMMAND_BAR",
+}
+
+/**
+ * The order in which the groups of keyboard actions should be applied.
+ */
+const groupOrder: KeyboardActionGroup[] = [KeyboardActionGroup.TABS, KeyboardActionGroup.COMMAND_BAR];
+
+/**
  * The possible actions that can be triggered by keyboard shortcuts.
  */
 export enum KeyboardAction {
@@ -30,6 +44,9 @@ export enum KeyboardAction {
   NEW_ITEM = "NEW_ITEM",
   DELETE_ITEM = "DELETE_ITEM",
   TOGGLE_COPILOT = "TOGGLE_COPILOT",
+  SELECT_LEFT_TAB = "SELECT_LEFT_TAB",
+  SELECT_RIGHT_TAB = "SELECT_RIGHT_TAB",
+  CLOSE_TAB = "CLOSE_TAB",
 }
 
 /**
@@ -55,6 +72,9 @@ const bindings: Record<KeyboardAction, string[]> = {
   [KeyboardAction.NEW_ITEM]: ["Alt+N I"],
   [KeyboardAction.DELETE_ITEM]: ["Alt+D"],
   [KeyboardAction.TOGGLE_COPILOT]: ["$mod+P"],
+  [KeyboardAction.SELECT_LEFT_TAB]: ["$mod+Alt+["],
+  [KeyboardAction.SELECT_RIGHT_TAB]: ["$mod+Alt+]"],
+  [KeyboardAction.CLOSE_TAB]: ["$mod+Alt+W"],
 };
 
 interface KeyboardShortcutState {
@@ -64,15 +84,39 @@ interface KeyboardShortcutState {
   allHandlers: KeyboardHandlerMap;
 
   /**
-   * Sets the keyboard shortcut handlers.
+   * A set of all the groups of keyboard shortcuts handlers.
    */
-  setHandlers: (handlers: KeyboardHandlerMap) => void;
+  groups: Partial<Record<KeyboardActionGroup, KeyboardHandlerMap>>;
+
+  /**
+   * Sets the keyboard shortcut handlers for the given group.
+   */
+  setHandlers: (group: KeyboardActionGroup, handlers: KeyboardHandlerMap) => void;
 }
 
-export const useKeyboardActionHandlers: UseStore<KeyboardShortcutState> = create((set) => ({
+/**
+ * Defines the calling component as the manager of the keyboard actions for the given group.
+ * @param group The group of keyboard actions to manage.
+ * @returns A function that can be used to set the keyboard action handlers for the given group.
+ */
+export const useKeyboardActionGroup =
+  (group: KeyboardActionGroup) =>
+    (handlers: KeyboardHandlerMap) =>
+      useKeyboardActionHandlers.getState().setHandlers(group, handlers);
+
+const useKeyboardActionHandlers: UseStore<KeyboardShortcutState> = create((set, get) => ({
   allHandlers: {},
-  setHandlers: (handlers: Partial<Record<KeyboardAction, KeyboardActionHandler>>) => {
-    set({ allHandlers: handlers });
+  groups: {},
+  setHandlers: (group: KeyboardActionGroup, handlers: KeyboardHandlerMap) => {
+    const state = get();
+    const groups = { ...state.groups, [group]: handlers };
+
+    // Combine all the handlers from all the groups in the correct order.
+    const allHandlers: KeyboardHandlerMap = {};
+    groupOrder.forEach((group) => {
+      Object.assign(allHandlers, groups[group]);
+    });
+    set({ groups, allHandlers });
   },
 }));
 


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1808?feature.someFeatureFlagYouMightNeed=true)

*Draft PR for now, since this will likely conflict with https://github.com/Azure/cosmos-explorer/pull/1805 and I want to resolve those conflicts by merging the other PR first and rebasing this one*

This adds a few new Keyboard Shortcuts for Tab Managment and Navigation:

| Shortcut | Action |
| - | - |
| `Ctrl+Alt+[`/`Command+Alt+[` [^1] | Switch to the tab on the left |
| `Ctrl+Alt+]`/`Command+Alt+]` [^1] | Switch to the tab on the right |
| `Ctrl+Alt+W`/`Command+Alt+W` [^2] | Close the current tab |

**This does not include "Reopen Last Closed Tab"**. Implementing that is a significant increase in complexity, so I think we should track it as separate from the main keyboard shortcut work. It requires figuring out how to capture the state of a tab when it is closed, and how to rehydrate the tab from that state. That work would also benefit us in restoring the user's state if they hard-refresh the page, so I think it makes sense to consider it a separate feature.

This is also the first time we have shortcuts that aren't directly mapped to the Command Bar. To support this, I added a level of nesting to the keyboard shortcut handler table. Previously it mapped Actions directly to Handlers. Now, there's a level of named "Groups", then each group contains a mapping of Actions to Handlers. This allows a component anywhere in the application to replace a single **group** at a time (whereas previously they had to replace **all** the handlers at once). The Command Bar component is responsible for its handlers, and the Tabs component is responsible for its handlers. When any group is changed, we iterate through each of the groups and merge their tables of handlers into a single set of handlers, which we use when a keyboard shortcut is activated.

The only real bit of complication here is **if** two groups ever try to map different handlers for the same action. If that happens, we'll pick the "last" handler registered (based on an order defined in the KeyboardShortcuts.tsx file). However, that's unlikely to happen as the intent is for each action to present in one and only one group. In development mode, we throw an error, because it's considered a mistake (but I wanted to avoid crashing the production app if we did make this mistake)
 
[^1]: Switching to the tab on the left/right does **not** wrap around, it just stops moving that direction when you reach the end.
[^2]: The browser does not allow you to bind to `Ctrl+W` or `Ctrl+Shift+W`, since those are mapped to closing the active **browser** tab or window (respectively)