### PR TITLE
bind F5 to execute query

### DIFF
--- a/src/KeyboardShortcuts.tsx
+++ b/src/KeyboardShortcuts.tsx
@@ -54,7 +54,7 @@ const bindings: Record<KeyboardAction, string[]> = {
   // See https://www.npmjs.com/package/tinykeys#commonly-used-keys-and-codes for more information on the expected values for keyboard shortcuts.
 
   [KeyboardAction.NEW_QUERY]: ["$mod+J", "Alt+N Q"],
-  [KeyboardAction.EXECUTE_ITEM]: ["Shift+Enter"],
+  [KeyboardAction.EXECUTE_ITEM]: ["Shift+Enter", "F5"],
   [KeyboardAction.CANCEL_OR_DISCARD]: ["Escape"],
   [KeyboardAction.SAVE_ITEM]: ["$mod+S"],
   [KeyboardAction.OPEN_QUERY]: ["$mod+O"],


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

After discussion with Meredith, we're going to bind F5 to Execute Query. This does block out the use of F5 to refresh the page, but that's also somewhat intentional. We've gotten significant customer feedback that unintentionally refreshing the page and losing your query is frustrating.

You can still refresh using Ctrl+R (the other standard browser binding for Refresh) and the refresh button. Also, pressing F5 without a query editor tab active would still refresh the page.