### PR TITLE
initialize new documents with their partition key

### DIFF
--- a/src/Explorer/Tabs/DocumentsTab.ts
+++ b/src/Explorer/Tabs/DocumentsTab.ts
@@ -464,7 +464,7 @@ export default class DocumentsTab extends TabsBase {
   private initializeNewDocument = (): void => {
     this.selectedDocumentId(null);
     const newDocument: any = {
-      id: "replace_with_new_document_id"
+      id: "replace_with_new_document_id",
     };
     this.partitionKeyProperties.forEach((partitionKeyProperty) => {
       let target = newDocument;

--- a/src/Explorer/Tabs/DocumentsTab.ts
+++ b/src/Explorer/Tabs/DocumentsTab.ts
@@ -463,7 +463,22 @@ export default class DocumentsTab extends TabsBase {
 
   private initializeNewDocument = (): void => {
     this.selectedDocumentId(null);
-    const defaultDocument: string = this.renderObjectForEditor({ id: "replace_with_new_document_id" }, null, 4);
+    const newDocument: any = {
+      id: "replace_with_new_document_id"
+    };
+    this.partitionKeyProperties.forEach((partitionKeyProperty) => {
+      let target = newDocument;
+      const keySegments = partitionKeyProperty.split(".");
+      const finalSegment = keySegments.pop();
+
+      // Initialize nested objects as needed
+      keySegments.forEach((segment) => {
+        target = target[segment] = target[segment] || {};
+      });
+
+      target[finalSegment] = "replace_with_new_partition_key_value";
+    });
+    const defaultDocument: string = this.renderObjectForEditor(newDocument, null, 4);
     this.initialDocumentContent(defaultDocument);
     this.selectedDocumentContent.setBaseline(defaultDocument);
     this.editorState(ViewModels.DocumentExplorerState.newDocumentValid);


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1815?feature.someFeatureFlagYouMightNeed=true)

This fixes some user feedback that it's difficult to create a new document that includes a value for the partition key. I noticed this myself, it's easy to miss when hand-creating documents and you may need to look up what the partition key is. This PR changes the template we use when creating a new document to include all partition keys associated with the container.

If there's a simple partition key, it gets added to the document:

<img width="759" alt="simple-pkey" src="https://github.com/Azure/cosmos-explorer/assets/7574/1f23db2d-c528-491e-9603-ec0ef7c51484">

If there are multiple (hierarchical) partition keys, they each get added:

<img width="763" alt="multiple-pkey" src="https://github.com/Azure/cosmos-explorer/assets/7574/b99dca60-3879-4cd7-8441-d0774798114e">

Finally, if the partition key is a nested property, we create nested objects as needed to get to the path for the partition key:

<img width="827" alt="nested-pkey" src="https://github.com/Azure/cosmos-explorer/assets/7574/b5f0c639-c25d-4ccc-8c79-adffdfd60cf2">

If the user wants to omit one or more of the partition keys, they still have the ability to do so by deleting the property from the template. Similar to the `id` property, we put a placeholder value in and expect the user to replace it.