### PR TITLE
[Accessibility-3100018]:[Programmatic Access - Azure Cosmos DB - Edit Property]: Text Area edit field does not have a label under 'Edit Property' pane.

### DIFF
--- a/src/Explorer/Panes/Tables/AddTableEntityPanel.tsx
+++ b/src/Explorer/Panes/Tables/AddTableEntityPanel.tsx
@@ -261,6 +261,7 @@ export const AddTableEntityPanel: FunctionComponent<AddTableEntityPanelProps> = 
         <TextField
           multiline
           rows={5}
+          ariaLabel={entityAttributeProperty}
           value={entityAttributeValue}
           onChange={(event, newInput?: string) => {
             entityChange(newInput, selectedRow, "value");


### PR DESCRIPTION
 [Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1819?feature.someFeatureFlagYouMightNeed=true)
 
We are implementing a label for the text area edit field. Now the ariaLabel prop sent to the Textfield component, we ensure that the text area edit field is appropriately labeled. This enhancement allows screen reader users to navigate and interact with the field seamlessly, improving overall accessibility within the application.