### PR TITLE
add capacityMode

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -90,6 +90,11 @@ export class CapabilityNames {
   public static readonly EnableServerless: string = "EnableServerless";
 }
 
+export class CapacityMode {
+  public static provisioned: string = "Provisioned";
+  public static serverless: string = "Serverless";
+}
+
 // flight names returned from the portal are always lowercase
 export class Flights {
   public static readonly SettingsV2 = "settingsv2";

--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -90,9 +90,9 @@ export class CapabilityNames {
   public static readonly EnableServerless: string = "EnableServerless";
 }
 
-export class CapacityMode {
-  public static provisioned: string = "Provisioned";
-  public static serverless: string = "Serverless";
+export enum CapacityMode {
+  Provisioned = "Provisioned",
+  Serverless = "Serverless",
 }
 
 // flight names returned from the portal are always lowercase

--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -1,4 +1,4 @@
-import { ConnectionStatusType, ContainerStatusType } from "../Common/Constants";
+import { CapacityMode, ConnectionStatusType, ContainerStatusType } from "../Common/Constants";
 
 export interface ArmEntity {
   id: string;
@@ -35,7 +35,7 @@ export interface DatabaseAccountExtendedProperties {
   ipRules?: IpRule[];
   privateEndpointConnections?: unknown[];
   capacity?: { totalThroughputLimit: number };
-  capacityMode?: string;
+  capacityMode?: CapacityMode;
   locations?: DatabaseAccountResponseLocation[];
   postgresqlEndpoint?: string;
   publicNetworkAccess?: string;

--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -35,6 +35,7 @@ export interface DatabaseAccountExtendedProperties {
   ipRules?: IpRule[];
   privateEndpointConnections?: unknown[];
   capacity?: { totalThroughputLimit: number };
+  capacityMode?: string;
   locations?: DatabaseAccountResponseLocation[];
   postgresqlEndpoint?: string;
   publicNetworkAccess?: string;

--- a/src/Utils/CapabilityUtils.ts
+++ b/src/Utils/CapabilityUtils.ts
@@ -12,7 +12,7 @@ export const isCapabilityEnabled = (capabilityName: string): boolean => {
 export const isServerlessAccount = (): boolean => {
   const { databaseAccount } = userContext;
   return (
-    databaseAccount?.properties?.capacityMode === Constants.CapacityMode.serverless ||
+    databaseAccount?.properties?.capacityMode === Constants.CapacityMode.Serverless ||
     isCapabilityEnabled(Constants.CapabilityNames.EnableServerless)
   );
 };

--- a/src/Utils/CapabilityUtils.ts
+++ b/src/Utils/CapabilityUtils.ts
@@ -9,4 +9,10 @@ export const isCapabilityEnabled = (capabilityName: string): boolean => {
   return false;
 };
 
-export const isServerlessAccount = (): boolean => isCapabilityEnabled(Constants.CapabilityNames.EnableServerless);
+export const isServerlessAccount = (): boolean => {
+  const { databaseAccount } = userContext;
+  return (
+    databaseAccount?.properties?.capacityMode === Constants.CapacityMode.serverless ||
+    isCapabilityEnabled(Constants.CapabilityNames.EnableServerless)
+  );
+};


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1826?feature.someFeatureFlagYouMightNeed=true)

Description
with a breaking change in RP for api version 2024-05-15-preview, contracts need to be updated in the portal.
Adding capacityMode property in database account resource where the account capacitymode is defined rather than in the capabilities.
Currently standalone DE is using fixed 2024-02-15-preview version,
the problem is when in-portal DE loads the databaseaccount from the portal with the latest API and passed into the DE, which breaks the contract for serverless accounts. 

How Has This Been Tested?
Tested locally with sideloaded portal where the databaseaccount is fetched from 2024-05-15-preview API

