### PR TITLE
add shortcuts for the Items tab

### DIFF
--- a/src/Explorer/Tabs/DocumentsTab.html
+++ b/src/Explorer/Tabs/DocumentsTab.html
@@ -80,7 +80,8 @@
                                     placeholder:isPreferredApiMongoDB?'Type a query predicate (e.g., {´a´:´foo´}), or choose one from the drop down list, or leave empty to query all documents.':'Type a query predicate (e.g., WHERE c.id=´1´), or choose one from the drop down list, or leave empty to query all documents.'
                                 },
                                 css: { placeholderVisible: filterContent().length === 0 },
-                                textInput: filterContent"
+                                textInput: filterContent,
+                                event: { keydown: onFilterKeyDown }"
           />
 
           <datalist

--- a/src/Explorer/Tabs/TabsBase.ts
+++ b/src/Explorer/Tabs/TabsBase.ts
@@ -1,3 +1,4 @@
+import { KeyboardActionGroup, clearKeyboardActionGroup } from "KeyboardShortcuts";
 import * as ko from "knockout";
 import * as Constants from "../../Common/Constants";
 import * as ThemeUtility from "../../Common/ThemeUtility";
@@ -107,6 +108,7 @@ export default class TabsBase extends WaitsForTemplateViewModel {
   }
 
   public onActivate(): void {
+    clearKeyboardActionGroup(KeyboardActionGroup.ACTIVE_TAB);
     this.updateSelectedNode();
     this.collection?.selectedSubnodeKind(this.tabKind);
     this.database?.selectedSubnodeKind(this.tabKind);

--- a/src/KeyboardShortcuts.tsx
+++ b/src/KeyboardShortcuts.tsx
@@ -17,8 +17,17 @@ export type KeyboardHandlerMap = Partial<Record<KeyboardAction, KeyboardActionHa
  * Each group can be updated separately, but, when updated, must be completely replaced.
  */
 export enum KeyboardActionGroup {
+  /** Keyboard actions related to tab navigation. */
   TABS = "TABS",
+
+  /** Keyboard actions managed by the global command bar. */
   COMMAND_BAR = "COMMAND_BAR",
+
+  /**
+   * Keyboard actions specific to the active tab.
+   * This group is automatically cleared when the active tab changes.
+   */
+  ACTIVE_TAB = "ACTIVE_TAB",
 }
 
 /**
@@ -43,6 +52,7 @@ export enum KeyboardAction {
   SELECT_LEFT_TAB = "SELECT_LEFT_TAB",
   SELECT_RIGHT_TAB = "SELECT_RIGHT_TAB",
   CLOSE_TAB = "CLOSE_TAB",
+  SEARCH = "SEARCH",
 }
 
 /**
@@ -72,6 +82,7 @@ const bindings: Record<KeyboardAction, string[]> = {
   [KeyboardAction.SELECT_LEFT_TAB]: ["$mod+Alt+[", "$mod+Shift+F6"],
   [KeyboardAction.SELECT_RIGHT_TAB]: ["$mod+Alt+]", "$mod+F6"],
   [KeyboardAction.CLOSE_TAB]: ["$mod+Alt+W"],
+  [KeyboardAction.SEARCH]: ["$mod+Shift+F"],
 };
 
 interface KeyboardShortcutState {
@@ -91,13 +102,24 @@ interface KeyboardShortcutState {
   setHandlers: (group: KeyboardActionGroup, handlers: KeyboardHandlerMap) => void;
 }
 
+export type KeyboardHandlerSetter = (handlers: KeyboardHandlerMap) => void;
+
 /**
  * Defines the calling component as the manager of the keyboard actions for the given group.
  * @param group The group of keyboard actions to manage.
  * @returns A function that can be used to set the keyboard action handlers for the given group.
  */
-export const useKeyboardActionGroup = (group: KeyboardActionGroup) => (handlers: KeyboardHandlerMap) =>
-  useKeyboardActionHandlers.getState().setHandlers(group, handlers);
+export const useKeyboardActionGroup: (group: KeyboardActionGroup) => KeyboardHandlerSetter =
+  (group: KeyboardActionGroup) => (handlers: KeyboardHandlerMap) =>
+    useKeyboardActionHandlers.getState().setHandlers(group, handlers);
+
+/**
+ * Clears the keyboard action handlers for the given group.
+ * @param group The group of keyboard actions to clear.
+ */
+export const clearKeyboardActionGroup = (group: KeyboardActionGroup) => {
+  useKeyboardActionHandlers.getState().setHandlers(group, {});
+};
 
 const useKeyboardActionHandlers: UseStore<KeyboardShortcutState> = create((set, get) => ({
   allHandlers: {},


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Adds a couple keyboard shortcuts for the Items page. I expect these will need to be adjusted a bit in the refactor @languy is working on in #1770 but it should be fairly straightforward.

| Shortcut | Context | Action |
| - | - | - |
| `Ctrl/Cmd+Shift+F` | On the items list with the filter text box hidden | Open the filter text box and set keyboard focus to it |
| `Ctrl/Cmd+Shift+F` | On the items list with the filter text box **open** | Set keyboard focus to the filter text box |
| `Enter` | Cursor in the filter text box | Apply the updated filter (equivalent to the `Apply Filter` button) |
| `Esc` | Cursor in the filter text box | Undo changes to the filter and revert to the previous value (equivalent to the `x` button on the right) |
| `Down Arrow` | Cursor in the filter text box | Open dropdown and selection from filter suggestions (built-in dropdown functionality) |
| `Ctrl+Shift+O` | Cursor in the Monaco editor editing an item | Open a list of JSON symbols (built-in functionality, but confirmed this and it will be added to docs) |