### PR TITLE
Port item editor shortcuts to improved Items tab branch

### DIFF
--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -1132,20 +1132,17 @@ const DocumentsTabComponent: React.FunctionComponent<{
     }
   };
 
-  const onFilterKeyDown = (model: unknown, e: KeyboardEvent): boolean => {
+  const onFilterKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
     if (e.key === "Enter") {
       refreshDocumentsGrid(true);
 
       // Suppress the default behavior of the key
-      return false;
+      e.preventDefault();
     } else if (e.key === "Escape") {
       onHideFilterClick();
 
       // Suppress the default behavior of the key
-      return false;
-    } else {
-      // Allow the default behavior of the key
-      return true;
+      e.preventDefault();
     }
   };
 
@@ -1657,7 +1654,7 @@ const DocumentsTabComponent: React.FunctionComponent<{
 
         // collapse filter
         setAppliedFilter(filterContent);
-        setIsFilterExpanded(applyFilterButtonPressed);
+        setIsFilterExpanded(!applyFilterButtonPressed);
         document.getElementById("errorStatusIcon")?.focus();
       } catch (error) {
         console.error();
@@ -1709,6 +1706,8 @@ const DocumentsTabComponent: React.FunctionComponent<{
                           : "Type a query predicate (e.g., WHERE c.id=´1´), or choose one from the drop down list, or leave empty to query all documents."
                       }
                       value={filterContent}
+                      autoFocus={true}
+                      onKeyDown={onFilterKeyDown}
                       onChange={(e) => setFilterContent(e.target.value)}
                       onBlur={() => setIsFilterFocused(false)}
                     />

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -448,10 +448,12 @@ const DocumentsTabComponent: React.FunctionComponent<{
 }) => {
   const [isFilterCreated, setIsFilterCreated] = useState<boolean>(true);
   const [isFilterExpanded, setIsFilterExpanded] = useState<boolean>(false);
+  const [isFilterFocused, setIsFilterFocused] = useState<boolean>(false);
   const [appliedFilter, setAppliedFilter] = useState<string>("");
   const [filterContent, setFilterContent] = useState<string>("");
   const [documentIds, setDocumentIds] = useState<DocumentId[]>([]);
   const [isExecuting, setIsExecuting] = useState<boolean>(false);
+  const filterInput = useRef<HTMLInputElement>(null);
 
   // Query
   const [documentsIterator, setDocumentsIterator] = useState<{
@@ -486,6 +488,15 @@ const DocumentsTabComponent: React.FunctionComponent<{
   const [continuationToken, setContinuationToken] = useState<string>(undefined);
 
   const setKeyboardActions = useKeyboardActionGroup(KeyboardActionGroup.ACTIVE_TAB);
+
+  useEffect(() => {
+    if (isFilterFocused) {
+      console.log("focus filter input");
+      filterInput.current?.focus();
+    } else {
+      console.log("blur filter input");
+    }
+  }, [isFilterFocused]);
 
   let lastFilterContents = ['WHERE c.id = "foo"', "ORDER BY c._ts DESC", 'WHERE c.id = "foo" ORDER BY c._ts DESC'];
 
@@ -925,6 +936,8 @@ const DocumentsTabComponent: React.FunctionComponent<{
   const onShowFilterClick = () => {
     setIsFilterCreated(true);
     setIsFilterExpanded(true);
+    setIsFilterFocused(true);
+    console.log("onShowFilterClick");
   };
 
   const queryTimeoutEnabled = useCallback(
@@ -1684,6 +1697,7 @@ const DocumentsTabComponent: React.FunctionComponent<{
                   <div className="editFilterContainer">
                     {!isPreferredApiMongoDB && <span className="filterspan"> SELECT * FROM c </span>}
                     <Input
+                      ref={filterInput}
                       type="text"
                       list="filtersList"
                       className={`${filterContent.length === 0 ? "placeholderVisible" : ""}`}
@@ -1696,6 +1710,7 @@ const DocumentsTabComponent: React.FunctionComponent<{
                       }
                       value={filterContent}
                       onChange={(e) => setFilterContent(e.target.value)}
+                      onBlur={() => setIsFilterFocused(false)}
                     />
 
                     <datalist id="filtersList">

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -491,10 +491,7 @@ const DocumentsTabComponent: React.FunctionComponent<{
 
   useEffect(() => {
     if (isFilterFocused) {
-      console.log("focus filter input");
       filterInput.current?.focus();
-    } else {
-      console.log("blur filter input");
     }
   }, [isFilterFocused]);
 
@@ -937,7 +934,6 @@ const DocumentsTabComponent: React.FunctionComponent<{
     setIsFilterCreated(true);
     setIsFilterExpanded(true);
     setIsFilterFocused(true);
-    console.log("onShowFilterClick");
   };
 
   const queryTimeoutEnabled = useCallback(


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1831?feature.someFeatureFlagYouMightNeed=true)

**Note:** This PR isn't targeting `master`, it's targeting the branch for #1770 . Merging it will just squash these commits into a new commit on that branch.

I'm opening this primarily just so @languy can review the adjustments I'm proposing to his existing branch, rather than me just adding commits to it :). All are welcome to take a look and provide feedback though.

This updates #1770 with a few changes to fix up the keyboard shortcuts on the Items tab. A few elements:

1. I wired up the `onKeyDown` for the filter input to the `onFilterKeyDown` callback that was ported over so it now works.
2. I had to implement the keyboard focus adjustments from the existing tab in React. I did this by introducing a new state tracking if the filter text box is focused, and an effect that "applies" that state by focusing the element.