### PR TITLE
[accessibility-3102916]:[Keyboard Navigation - Azure CosmosDB - Data …

### DIFF
--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -924,10 +924,9 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                       }
                     />
                     <Text variant="small">
-                      <Icon iconName="InfoSolid" className="removeIcon" tabIndex={0} /> To ensure compatibility with
-                      older SDKs, the created container will use a legacy partitioning scheme that supports partition
-                      key values of size only up to 101 bytes. If this is enabled, you will not be able to use
-                      hierarchical partition keys.{" "}
+                      <Icon iconName="InfoSolid" className="removeIcon" /> To ensure compatibility with older SDKs, the
+                      created container will use a legacy partitioning scheme that supports partition key values of size
+                      only up to 101 bytes. If this is enabled, you will not be able to use hierarchical partition keys.{" "}
                       <Link href="https://aka.ms/cosmos-large-pk" target="_blank">
                         Learn more
                       </Link>

--- a/src/Explorer/Panes/__snapshots__/AddCollectionPanel.test.tsx.snap
+++ b/src/Explorer/Panes/__snapshots__/AddCollectionPanel.test.tsx.snap
@@ -466,7 +466,6 @@ exports[`AddCollectionPanel should render Default properly 1`] = `
             <Icon
               className="removeIcon"
               iconName="InfoSolid"
-              tabIndex={0}
             />
              To ensure compatibility with older SDKs, the created container will use a legacy partitioning scheme that supports partition key values of size only up to 101 bytes. If this is enabled, you will not be able to use hierarchical partition keys.
              


### PR DESCRIPTION
**Description**:
This PR addresses an issue in Azure CosmosDB Data Explorer where keyboard focus was erroneously moving to a non-interactive control after interacting with the checkbox control of the Advanced button. The problem stemmed from the unnecessary tabindex="0" attribute, causing focus to be directed to a non-interactive element.

**Changes Made**:

Removed tabindex="0" from the affected element, ensuring that non-interactive elements no longer receive focus, thus improving keyboard navigation within the Data Explorer.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1834?feature.someFeatureFlagYouMightNeed=true)
