### PR TITLE
add link to keyboard shortcuts doc to home tab

### DIFF
--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -680,11 +680,20 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
       title: "Learn the Fundamentals",
       description: "Watch Azure Cosmos DB Live TV show introductory and how to videos.",
     };
-    let items: item[];
+
+    const commonItems: item[] = [
+      {
+        link: "https://learn.microsoft.com/azure/cosmos-db/data-explorer-shortcuts",
+        title: "Data Explorer keyboard shortcuts",
+        description: "Learn keyboard shortcuts to navigate Data Explorer.",
+      },
+    ];
+
+    let apiItems: item[];
     switch (userContext.apiType) {
       case "SQL":
       case "Postgres":
-        items = [
+        apiItems = [
           {
             link: "https://aka.ms/msl-sdk-connect",
             title: "Get Started using an SDK",
@@ -699,7 +708,7 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
         ];
         break;
       case "Mongo":
-        items = [
+        apiItems = [
           {
             link: "https://aka.ms/mongonodejs",
             title: "Build an app with Node.js",
@@ -714,7 +723,7 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
         ];
         break;
       case "Cassandra":
-        items = [
+        apiItems = [
           {
             link: "https://aka.ms/cassandracontainer",
             title: "Create a Container",
@@ -729,7 +738,7 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
         ];
         break;
       case "Gremlin":
-        items = [
+        apiItems = [
           {
             link: "https://aka.ms/graphquickstart",
             title: "Get Started ",
@@ -744,7 +753,7 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
         ];
         break;
       case "Tables":
-        items = [
+        apiItems = [
           {
             link: "https://aka.ms/tabledotnet",
             title: "Build a .NET App",
@@ -761,6 +770,9 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
       default:
         break;
     }
+
+    const items = [...commonItems, ...apiItems];
+
     return (
       <Stack>
         {items.map((item, i) => (


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1836?feature.someFeatureFlagYouMightNeed=true)

This just adds a link to the new keyboard shortcuts doc to the Home tab. The link appears no matter what API you're connected to:

<img width="870" alt="Screenshot 2024-05-06 105351" src="https://github.com/Azure/cosmos-explorer/assets/7574/99123dcd-2566-48b9-85b2-7f126bdcfa32">

