### PR TITLE
'Recents', 'Top 3 things you need to know' and 'Learning Resources' text appears as a heading but is not defined programmatically under 'Data Explorer' pane.

### DIFF
--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -355,15 +355,15 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
               ) : (
                 <div className="moreStuffContainer">
                   <div className="moreStuffColumn commonTasks">
-                    <div className="title">Recents</div>
+                    <h2 className="title">Recents</h2>
                     {this.getRecentItems()}
                   </div>
                   <div className="moreStuffColumn">
-                    <div className="title">Top 3 things you need to know</div>
+                    <h2 className="title">Top 3 things you need to know</h2>
                     {this.top3Items()}
                   </div>
                   <div className="moreStuffColumn tipsContainer">
-                    <div className="title">Learning Resources</div>
+                    <h2 className="title">Learning Resources</h2>
                     {this.getLearningResourceItems()}
                   </div>
                 </div>


### PR DESCRIPTION
This PR addresses an issue where the headings 'Recents', 'Top 3 things you need to know', and 'Learning Resources' were not defined programmatically under the 'Data Explorer' pane in Programmatic Access of Azure Cosmos DB. The headings were fixed using "h2" tags to ensure proper semantic structuring.

Added "h2" tags to the headings 'Recents', 'Top 3 things you need to know', and 'Learning Resources' under the 'Data Explorer' pane in Programmatic Access of Azure Cosmos DB.
Ensured that the headings are programmatically defined for improved accessibility and semantic clarity.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1845?feature.someFeatureFlagYouMightNeed=true)
