### PR TITLE
Luminosity ratio of 'Learn More' link with surrounding text is less than required 3:1 under 'Data Explorer' pane.  

### DIFF
--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -92,6 +92,7 @@ export const Tabs = ({ explorer }: TabsProps): JSX.Element => {
           {`To prevent queries from using excessive RUs, Data Explorer has a 5,000 RU default limit. To modify or remove
           the limit, go to the Settings cog on the right and find "RU Threshold".`}
           <Link
+            className="underlinedLink"
             href="https://review.learn.microsoft.com/en-us/azure/cosmos-db/data-explorer?branch=main#configure-request-unit-threshold"
             target="_blank"
           >


### PR DESCRIPTION
This PR addresses an accessibility issue where low vision users and individuals sensitive to colors may encounter difficulty in recognizing controls and differentiating between surrounding text and links if the luminosity ratio is less than 3:1. To enhance accessibility and improve usability for these users, we have implemented underlining for links, providing a visual cue that enhances link visibility and ensures better differentiation from surrounding text.
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1847?feature.someFeatureFlagYouMightNeed=true)
