### PR TITLE
Fix delete newly created mongo documents bug

### DIFF
--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -845,8 +845,8 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
       _deleteDocuments(toDeleteDocumentIds)
         .then(
           (deletedIds: DocumentId[]) => {
-            const deletedRids = new Set(deletedIds.map((documentId) => documentId.rid));
-            const newDocumentIds = [...documentIds.filter((documentId) => !deletedRids.has(documentId.rid))];
+            const deletedIdsSet = new Set(deletedIds.map((documentId) => documentId.id));
+            const newDocumentIds = [...documentIds.filter((documentId) => !deletedIdsSet.has(documentId.id))];
             setDocumentIds(newDocumentIds);
 
             setSelectedDocumentContent(undefined);


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1852)

#### How to repro bug:
* Open Mongo RU account, open database, open collection, click on "Items"
* create new document "aaa". Save.
* refresh collection (e.g. reload the page and re-open collection Items)
* create more documents "bbb" and "ccc".
* Select and delete just "bbb"

#### Actual result:
Only "aaa" will show up. All the newly created documents don't appear on the list. Refreshing the collection will show them.

Unlike NoSql, the remote call to create a new mongo document does not return an object with an `rid` field. The `rid` field is present when listing documents from a collection.
The delete documents logic that removed the deleted documents from the current list was based on this `rid` field and therefore did not show any of the newly created documents after deleting documents.

We now use the `id` field which will work for all api's.