### PR TITLE
Fix Refresh button behaving like Load More bug

### DIFF
--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -1627,6 +1627,7 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
     async (applyFilterButtonPressed?: boolean): Promise<void> => {
       // clear documents grid
       setDocumentIds([]);
+      setContinuationToken(undefined); // For mongo
       try {
         // reset iterator which will autoload documents (in useEffect)
         setDocumentsIterator({


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Both the Refresh button and Load More button use `loadNextPage`. The only difference is the continuation token which must be reset for Refresh.