### PR TITLE
[accessibility-2819505]:[Programmatic access - Cosmos DB Query Copilot - Copilot]: "Read preview terms" link does not meet minimum contrast ratio 3:1 with the surrounding text.

### DIFF
--- a/src/Explorer/QueryCopilot/QueryCopilotPromptbar.tsx
+++ b/src/Explorer/QueryCopilot/QueryCopilotPromptbar.tsx
@@ -504,7 +504,12 @@ export const QueryCopilotPromptbar: React.FC<QueryCopilotPromptProps> = ({
               {!showFeedbackBar && (
                 <Text style={{ fontSize: 12 }}>
                   AI-generated content can have mistakes. Make sure it&apos;s accurate and appropriate before using it.{" "}
-                  <Link href="https://aka.ms/cdb-copilot-preview-terms" target="_blank" style={{ color: "#0072D4" }}>
+                  <Link
+                    href="https://aka.ms/cdb-copilot-preview-terms"
+                    target="_blank"
+                    style={{ color: "#0072D4" }}
+                    className="underlinedLink"
+                  >
                     Read preview terms
                   </Link>
                   {showErrorMessageBar && (


### PR DESCRIPTION
Description:
In response to an accessibility concern, this PR addresses the issue where the "Read preview terms" link did not meet the minimum contrast ratio of 3:1 with the surrounding text. To enhance readability and ensure compliance with accessibility standards, we have made the necessary adjustment by adding an underline to the link. This change improves visibility and ensures that all users, regardless of visual ability, can easily identify and interact with the link.

Changes Made:
Added underline to the "Read preview terms" link to improve the contrast ratio with the surrounding text.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1858?feature.someFeatureFlagYouMightNeed=true)
