### PR TITLE
stop tree nodes from expanding to full height, causing overlap

### DIFF
--- a/src/Explorer/Controls/TreeComponent/TreeNodeComponent.tsx
+++ b/src/Explorer/Controls/TreeComponent/TreeNodeComponent.tsx
@@ -150,7 +150,6 @@ export const TreeNodeComponent: React.FC<TreeNodeComponentProps> = ({
       data-test={`TreeNodeContainer:${treeNodeId}`}
       value={treeNodeId}
       itemType={isBranch ? "branch" : "leaf"}
-      style={{ height: "100%" }}
       onOpenChange={onOpenChange}
     >
       <TreeItemLayout

--- a/src/Explorer/Controls/TreeComponent/__snapshots__/TreeNodeComponent.test.tsx.snap
+++ b/src/Explorer/Controls/TreeComponent/__snapshots__/TreeNodeComponent.test.tsx.snap
@@ -5,11 +5,6 @@ exports[`TreeNodeComponent does not render children if the node is loading 1`] =
   data-test="TreeNodeContainer:root"
   itemType="branch"
   onOpenChange={[Function]}
-  style={
-    Object {
-      "height": "100%",
-    }
-  }
   value="root"
 >
   <TreeItemLayout
@@ -118,11 +113,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
     data-test="TreeNodeContainer:root"
     itemType="branch"
     onOpenChange={[Function]}
-    style={
-      Object {
-        "height": "100%",
-      }
-    }
     value="root"
   >
     <div
@@ -136,11 +126,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
       onClick={[Function]}
       onKeyDown={[Function]}
       role="treeitem"
-      style={
-        Object {
-          "height": "100%",
-        }
-      }
       tabIndex={-1}
     >
       <ContextSelector.Provider
@@ -233,7 +218,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                 data-fui-tree-item-value="root"
                 data-test="TreeNodeContainer:root"
                 role="treeitem"
-                style="height: 100%;"
                 tabindex="-1"
               >
                 <div
@@ -288,7 +272,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                     data-fui-tree-item-value="root/child1Label"
                     data-test="TreeNodeContainer:root/child1Label"
                     role="treeitem"
-                    style="height: 100%;"
                     tabindex="0"
                   >
                     <div
@@ -340,7 +323,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                     data-fui-tree-item-value="root/child2LoadingLabel"
                     data-test="TreeNodeContainer:root/child2LoadingLabel"
                     role="treeitem"
-                    style="height: 100%;"
                     tabindex="-1"
                   >
                     <div
@@ -391,7 +373,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                     data-fui-tree-item-value="root/child3ExpandingLabel"
                     data-test="TreeNodeContainer:root/child3ExpandingLabel"
                     role="treeitem"
-                    style="height: 100%;"
                     tabindex="-1"
                   >
                     <div
@@ -647,11 +628,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                     data-test="TreeNodeContainer:root/child1Label"
                     itemType="branch"
                     onOpenChange={[Function]}
-                    style={
-                      Object {
-                        "height": "100%",
-                      }
-                    }
                     value="root/child1Label"
                   >
                     <div
@@ -665,11 +641,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="treeitem"
-                      style={
-                        Object {
-                          "height": "100%",
-                        }
-                      }
                       tabIndex={-1}
                     >
                       <ContextSelector.Provider
@@ -762,7 +733,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                                 data-fui-tree-item-value="root/child1Label"
                                 data-test="TreeNodeContainer:root/child1Label"
                                 role="treeitem"
-                                style="height: 100%;"
                                 tabindex="0"
                               >
                                 <div
@@ -945,11 +915,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                     data-test="TreeNodeContainer:root/child2LoadingLabel"
                     itemType="branch"
                     onOpenChange={[Function]}
-                    style={
-                      Object {
-                        "height": "100%",
-                      }
-                    }
                     value="root/child2LoadingLabel"
                   >
                     <div
@@ -963,11 +928,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="treeitem"
-                      style={
-                        Object {
-                          "height": "100%",
-                        }
-                      }
                       tabIndex={-1}
                     >
                       <ContextSelector.Provider
@@ -1060,7 +1020,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                                 data-fui-tree-item-value="root/child2LoadingLabel"
                                 data-test="TreeNodeContainer:root/child2LoadingLabel"
                                 role="treeitem"
-                                style="height: 100%;"
                                 tabindex="-1"
                               >
                                 <div
@@ -1228,11 +1187,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                     data-test="TreeNodeContainer:root/child3ExpandingLabel"
                     itemType="leaf"
                     onOpenChange={[Function]}
-                    style={
-                      Object {
-                        "height": "100%",
-                      }
-                    }
                     value="root/child3ExpandingLabel"
                   >
                     <div
@@ -1245,11 +1199,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="treeitem"
-                      style={
-                        Object {
-                          "height": "100%",
-                        }
-                      }
                       tabIndex={-1}
                     >
                       <ContextSelector.Provider
@@ -1349,7 +1298,6 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                                 data-fui-tree-item-value="root/child3ExpandingLabel"
                                 data-test="TreeNodeContainer:root/child3ExpandingLabel"
                                 role="treeitem"
-                                style="height: 100%;"
                                 tabindex="-1"
                               >
                                 <div
@@ -1474,11 +1422,6 @@ exports[`TreeNodeComponent renders a loading spinner if the node is loading: loa
   data-test="TreeNodeContainer:root"
   itemType="leaf"
   onOpenChange={[Function]}
-  style={
-    Object {
-      "height": "100%",
-    }
-  }
   value="root"
 >
   <TreeItemLayout
@@ -1513,11 +1456,6 @@ exports[`TreeNodeComponent renders a loading spinner if the node is loading: loa
   data-test="TreeNodeContainer:root"
   itemType="leaf"
   onOpenChange={[Function]}
-  style={
-    Object {
-      "height": "100%",
-    }
-  }
   value="root"
 >
   <TreeItemLayout
@@ -1554,13 +1492,9 @@ exports[`TreeNodeComponent renders a loading spinner if the node is loading: loa
 
 exports[`TreeNodeComponent renders a node as expandable if it has empty, but defined, children array 1`] = `
 <TreeItem
+  data-test="TreeNodeContainer:root"
   itemType="branch"
   onOpenChange={[Function]}
-  style={
-    Object {
-      "height": "100%",
-    }
-  }
   value="root"
 >
   <TreeItemLayout
@@ -1603,11 +1537,6 @@ exports[`TreeNodeComponent renders a node with a menu 1`] = `
       data-test="TreeNodeContainer:root"
       itemType="leaf"
       onOpenChange={[Function]}
-      style={
-        Object {
-          "height": "100%",
-        }
-      }
       value="root"
     >
       <TreeItemLayout
@@ -1697,11 +1626,6 @@ exports[`TreeNodeComponent renders a single node 1`] = `
   data-test="TreeNodeContainer:root"
   itemType="leaf"
   onOpenChange={[Function]}
-  style={
-    Object {
-      "height": "100%",
-    }
-  }
   value="root"
 >
   <TreeItemLayout
@@ -1736,11 +1660,6 @@ exports[`TreeNodeComponent renders an icon if the node has one 1`] = `
   data-test="TreeNodeContainer:root"
   itemType="leaf"
   onOpenChange={[Function]}
-  style={
-    Object {
-      "height": "100%",
-    }
-  }
   value="root"
 >
   <TreeItemLayout
@@ -1775,11 +1694,6 @@ exports[`TreeNodeComponent renders selected parent node as selected if no descen
   data-test="TreeNodeContainer:root"
   itemType="branch"
   onOpenChange={[Function]}
-  style={
-    Object {
-      "height": "100%",
-    }
-  }
   value="root"
 >
   <TreeItemLayout
@@ -1864,11 +1778,6 @@ exports[`TreeNodeComponent renders selected parent node as unselected if any des
   data-test="TreeNodeContainer:root"
   itemType="branch"
   onOpenChange={[Function]}
-  style={
-    Object {
-      "height": "100%",
-    }
-  }
   value="root"
 >
   <TreeItemLayout
@@ -1954,11 +1863,6 @@ exports[`TreeNodeComponent renders single selected leaf node as selected 1`] = `
   data-test="TreeNodeContainer:root"
   itemType="leaf"
   onOpenChange={[Function]}
-  style={
-    Object {
-      "height": "100%",
-    }
-  }
   value="root"
 >
   <TreeItemLayout

--- a/src/Explorer/Tree/ResourceTree.tsx
+++ b/src/Explorer/Tree/ResourceTree.tsx
@@ -166,7 +166,7 @@ export const ResourceTree: React.FC<ResourceTreeProps> = ({ container }: Resourc
 
   return (
     <>
-      <FluentProvider theme={lightTheme} style={{ overflow: "hidden" }}>
+      <FluentProvider theme={lightTheme} style={{ overflow: "auto" }}>
         <Tree
           aria-label="CosmosDB resources"
           openItems={openItems}


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1861?feature.someFeatureFlagYouMightNeed=true)

This fixes an issue discovered after deploying the new resource tree (#1841) to MPAC. The tree nodes were set to `height: 100%`, and the containing Fluent Provider was set to `overflow: hidden`. A FluentUI Tree is a nested set of `Tree`s containing `TreeItem`s which contain `Tree`s containing `TreeItem`s, etc. Setting a `TreeItem` to `height: 100%` forced them to expand to fit all their children. Removing this avoids the overlap. However, because the containing Fluent Provider is `overflow: hidden`, doing that means overflow off the bottom is truncated, so we just need to switch the container to `overflow: auto` to get scrollbars back.

Here's the _broken_ behavior in `master`. I'm shrinking the browser quite a bit to make it happen, but it gets much worse as you have more and more items in a tree node, so if you have a DB with a lot more containers (I don't) then this would happen at "normal" vertical window sizes too:

https://github.com/Azure/cosmos-explorer/assets/7574/16d03f8c-0208-439b-b51d-731c3d91d30d

With these changes, there's no overlap in similar situations:

https://github.com/Azure/cosmos-explorer/assets/7574/6a0ebd4a-e9b4-437c-bf3d-e94b5c3006b0

I have plans to build an E2E test to protect against other overlap issues, but it's blocked on #1857 so I'll work on that separately and bring it in a separate PR.

I've also verified this when hosted in the portal, and it's fixed there too.