### PR TITLE
show an expand icon for nodes with non-null children array

### DIFF
--- a/src/Explorer/Controls/TreeComponent/TreeNodeComponent.test.tsx
+++ b/src/Explorer/Controls/TreeComponent/TreeNodeComponent.test.tsx
@@ -124,6 +124,20 @@ describe("TreeNodeComponent", () => {
     expect(component).toMatchSnapshot();
   });
 
+  it("renders a node as expandable if it has empty, but defined, children array", () => {
+    const node = generateTestNode("root", {
+      isLoading: true,
+      children: [
+        generateTestNode("child1", {
+          children: [],
+        }),
+        generateTestNode("child2"),
+      ],
+    });
+    const component = shallow(<TreeNodeComponent node={node} treeNodeId={node.id} />);
+    expect(component).toMatchSnapshot();
+  });
+
   it("does not render children if the node is loading", () => {
     const node = generateTestNode("root", {
       isLoading: true,

--- a/src/Explorer/Controls/TreeComponent/TreeNodeComponent.tsx
+++ b/src/Explorer/Controls/TreeComponent/TreeNodeComponent.tsx
@@ -100,7 +100,8 @@ export const TreeNodeComponent: React.FC<TreeNodeComponentProps> = ({
     return unsortedChildren;
   };
 
-  const isBranch = node.children?.length > 0;
+  // A branch node is any node with a defined children array, even if the array is empty.
+  const isBranch = !!node.children;
 
   const onOpenChange = useCallback(
     (_: TreeOpenChangeEvent, data: TreeOpenChangeData) => {

--- a/src/Explorer/Controls/TreeComponent/__snapshots__/TreeNodeComponent.test.tsx.snap
+++ b/src/Explorer/Controls/TreeComponent/__snapshots__/TreeNodeComponent.test.tsx.snap
@@ -1534,6 +1534,44 @@ exports[`TreeNodeComponent renders a loading spinner if the node is loading: loa
 </TreeItem>
 `;
 
+exports[`TreeNodeComponent renders a node as expandable if it has empty, but defined, children array 1`] = `
+<TreeItem
+  itemType="branch"
+  onOpenChange={[Function]}
+  style={
+    Object {
+      "height": "100%",
+    }
+  }
+  value="root"
+>
+  <TreeItemLayout
+    actions={false}
+    className="rootClass"
+    data-test="TreeNode:root"
+    iconBefore={
+      <img
+        alt=""
+        src="rootIcon"
+        style={
+          Object {
+            "height": 16,
+            "width": 16,
+          }
+        }
+      />
+    }
+    style={
+      Object {
+        "backgroundColor": undefined,
+      }
+    }
+  >
+    rootLabel
+  </TreeItemLayout>
+</TreeItem>
+`;
+
 exports[`TreeNodeComponent renders a node with a menu 1`] = `
 <Menu
   onOpenChange={[Function]}


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1862?feature.someFeatureFlagYouMightNeed=true)

This fixes a small rendering bug in the new resource tree, that I noticed while investigating #1861 . When merging the Fabric resource tree, I made a seemingly benign refactoring. I changed the definition of the `itemType` prop on `TreeItem` from this:

https://github.com/Azure/cosmos-explorer/blob/cebf044803e58a56710adbecaf1bcf05587b8627/src/Explorer/Controls/TreeComponent2/TreeNode2Component.tsx#L100-L102

To this:

```
const isBranch = node.children?.length > 0;
<TreeItem
      value={treeNodeId}
      itemType={isBranch ? "branch" : "leaf"}
```

There's a subtle difference there! The old logic considered an empty, but non-`undefined`, `children` array as indicating a branch node. This is important because many nodes lazy-load children when expanded. We indicate that a node _might_ have children when expanded by setting the `children` property to `[]`. So, my refactoring actually broke that. You can still expand the node by clicking on it, at which time it will load children and expand properly, but you don't see the `>` icon to prompt you to try expanding it to find children.

This PR just restores the intent of the original logic. Any defined value for `children` will cause us to render an expand icon. I added a snapshot test for this new case to protect against regressions in the future.