### PR TITLE
Remove unnecessary vertical scrollbar on tabs container

### DIFF
--- a/less/documentDB.less
+++ b/less/documentDB.less
@@ -2366,9 +2366,9 @@ a:link {
 .tabsManagerContainer {
   height: 100%;
   flex-grow: 1;
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
   min-height: 300px;
-  overflow-y: scroll;
 }
 
 .tabs {
@@ -2671,7 +2671,7 @@ a:link {
   width: @ActiveTabWidth;
 }
 
-.nav-tabs > li.active > .tabNavContentContainer > .tab_Content > .contentWrapper> .tabNavText {
+.nav-tabs > li.active > .tabNavContentContainer > .tab_Content > .contentWrapper > .tabNavText {
   font-weight: bolder;
   border-bottom: 2px solid rgba(0, 120, 212, 1);
 }
@@ -2708,67 +2708,67 @@ a:link {
     border-right: @ButtonBorderWidth solid @BaseMedium;
     white-space: nowrap;
     .contentWrapper {
-        .flex-display();
-        width: @ContentWrapper;
-    
-        .statusIconContainer {
-          width: @StatusIconContainerSize;
-          height: @StatusIconContainerSize;
-          margin-left: @SmallSpace;
-          display: inline-flex;
-    
-          .errorIconContainer {
-            width: @ErrorIconContainer;
-            height: @ErrorIconContainer;
-            margin-top: 1px;
-    
-            .errorIcon {
-              width: @ErrorIconWidth;
-              height: @LoadingErrorIconSize;
-              background-image: url(../images/error_no_outline.svg);
-              background-repeat: no-repeat;
-              background-position: center;
-              background-size: 3px;
-              display: block;
-              margin: 1px 0px 0px 6px;
-            }
-          }
-    
-          .errorIconContainer.actionsEnabled {
-            &:hover {
-              .hover();
-            }
-    
-            &:focus {
-              .focus();
-            }
-    
-            &:active {
-              .active();
-            }
-          }
-    
-          .errorIconContainer[tabindex]:active {
-            outline: none;
-          }
-    
-          .loadingIcon {
-            width: @LoadingErrorIconSize;
+      .flex-display();
+      width: @ContentWrapper;
+
+      .statusIconContainer {
+        width: @StatusIconContainerSize;
+        height: @StatusIconContainerSize;
+        margin-left: @SmallSpace;
+        display: inline-flex;
+
+        .errorIconContainer {
+          width: @ErrorIconContainer;
+          height: @ErrorIconContainer;
+          margin-top: 1px;
+
+          .errorIcon {
+            width: @ErrorIconWidth;
             height: @LoadingErrorIconSize;
-            margin: 0px 0px @SmallSpace @SmallSpace;
+            background-image: url(../images/error_no_outline.svg);
+            background-repeat: no-repeat;
+            background-position: center;
+            background-size: 3px;
+            display: block;
+            margin: 1px 0px 0px 6px;
           }
         }
-    
-        .tabNavText {
-          margin-left: @SmallSpace;
-          margin-right: 2px;
-          color: @BaseDark;
-          text-overflow: ellipsis;
-          overflow: hidden;
-          white-space: nowrap;
-          flex-grow: 1;
+
+        .errorIconContainer.actionsEnabled {
+          &:hover {
+            .hover();
+          }
+
+          &:focus {
+            .focus();
+          }
+
+          &:active {
+            .active();
+          }
+        }
+
+        .errorIconContainer[tabindex]:active {
+          outline: none;
+        }
+
+        .loadingIcon {
+          width: @LoadingErrorIconSize;
+          height: @LoadingErrorIconSize;
+          margin: 0px 0px @SmallSpace @SmallSpace;
         }
       }
+
+      .tabNavText {
+        margin-left: @SmallSpace;
+        margin-right: 2px;
+        color: @BaseDark;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+        flex-grow: 1;
+      }
+    }
 
     .tabIconSection {
       width: 29px;


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1867)

This change removes the extra vertical scrollbar caused by the top default limit RU message (or any other message that can appear at the top).
<img width="1457" alt="image" src="https://github.com/Azure/cosmos-explorer/assets/21954022/80c41b47-845d-4f3b-b6db-8315d7770a34">
It becomes problematic when the current tab contains a vertical scrollbar on its own.
<img width="1401" alt="image" src="https://github.com/Azure/cosmos-explorer/assets/21954022/0eb02461-bf12-4f0f-a2be-7e70a60c6cd9">

With this change, the tab container adapts its size to the content with flex. Scrollbar will appear only if the content cannot fit inside the container height. For example here on laptop screen:
![image](https://github.com/Azure/cosmos-explorer/assets/21954022/152041de-d3bb-4395-9c90-521c44e04ff3)

