### PR TITLE
pagination loading of subscription and databaseaccounts

### DIFF
--- a/src/hooks/useDatabaseAccounts.tsx
+++ b/src/hooks/useDatabaseAccounts.tsx
@@ -52,11 +52,17 @@ export async function fetchDatabaseAccountsFromGraph(
     const body = {
       query: databaseAccountsQuery,
       subscriptions: [subscriptionId],
-      ...(skipToken && {
-        options: {
-          $skipToken: skipToken,
-        } as QueryRequestOptions,
-      }),
+      ...(skipToken
+        ? {
+            options: {
+              $skipToken: skipToken,
+            } as QueryRequestOptions,
+          }
+        : {
+            options: {
+              $top: 150,
+            } as QueryRequestOptions,
+          }),
     };
 
     const response = await fetch(managementResourceGraphAPIURL, {

--- a/src/hooks/useSubscriptions.tsx
+++ b/src/hooks/useSubscriptions.tsx
@@ -51,11 +51,17 @@ export async function fetchSubscriptionsFromGraph(accessToken: string): Promise<
   do {
     const body = {
       query: subscriptionsQuery,
-      ...(skipToken && {
-        options: {
-          $skipToken: skipToken,
-        } as QueryRequestOptions,
-      }),
+      ...(skipToken
+        ? {
+            options: {
+              $skipToken: skipToken,
+            } as QueryRequestOptions,
+          }
+        : {
+            options: {
+              $top: 150,
+            } as QueryRequestOptions,
+          }),
     };
 
     const response = await fetch(managementResourceGraphAPIURL, {


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1877?feature.someFeatureFlagYouMightNeed=true)

To get around error from Azure Graph

{
    "error": {
        "code": "BadRequest",
        "message": "Please provide below info when asking for support: timestamp = 2024-06-14T17:30:09.6771530Z, correlationId = 81fdb7d2-3833-49a3-9cb0-b9421e6a0430.",
        "details": [
            {
                "code": "ResponsePayloadTooLarge",
                "message": "Response payload size is 29972004, and has exceeded the limit of 16777216. Please consider querying less data at a time and make paginated call if needed."
            }
        ]
    }
    
Making subscriptions and databaseaccounts RP call paginated.
