### PR TITLE
Cassandra: Delete a row for a table that has multiple partition keys

### DIFF
--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -363,7 +363,7 @@ export class CassandraAPIDataClient extends TableDataClient {
     entitiesToDelete: Entities.ITableEntity[],
   ): Promise<any> {
     const query = `DELETE FROM ${collection.databaseId}.${collection.id()} WHERE `;
-    const partitionKeys: CassandraTableKey[] = this.getCassandraPartitionKeys(collection);
+    const partitionKeys: CassandraTableKey[] = collection.cassandraKeys.partitionKeys;
     await Promise.all(
       entitiesToDelete.map(async (currEntityToDelete: Entities.ITableEntity) => {
         const clearMessage = NotificationConsoleUtils.logConsoleProgress(`Deleting row ${currEntityToDelete.RowKey._}`);
@@ -746,10 +746,6 @@ export class CassandraAPIDataClient extends TableDataClient {
 
   private getCassandraPartitionKeyProperty(collection: ViewModels.Collection): string {
     return collection.cassandraKeys.partitionKeys[0].property;
-  }
-
-  private getCassandraPartitionKeys(collection: ViewModels.Collection): CassandraTableKey[] {
-    return collection.cassandraKeys.partitionKeys;
   }
 
   private useCassandraProxyEndpoint(api: string): boolean {


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1879)

Currently, Data Explorer Cassandra experience does not handle row deletion when a table has multiple partition keys. More details can be found in this CRI. https://portal.microsofticm.com/imp/v5/incidents/details/514315661/summary