### PR TITLE
Temporarily disable bulk Delete for old non-partitioned NoSQL containers 

### DIFF
--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.test.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.test.tsx
@@ -340,7 +340,7 @@ describe("Documents tab (noSql API)", () => {
       isPreferredApiMongoDB: false,
       documentIds: [],
       collection: undefined,
-      partitionKey: undefined,
+      partitionKey: { kind: "Hash", paths: ["/foo"], version: 2 },
       onLoadStartKey: 0,
       tabTitle: "",
       onExecutionErrorChange: (isExecutionError: boolean): void => {

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -196,6 +196,7 @@ type UiKeyboardEvent = (e: KeyboardEvent | React.SyntheticEvent<Element, Event>)
 
 // Export to expose to unit tests
 export type ButtonsDependencies = {
+  isPartitionSystemKey: boolean;
   _collection: ViewModels.CollectionBase;
   selectedRows: Set<TableRowId>;
   editorState: ViewModels.DocumentExplorerState;
@@ -237,6 +238,7 @@ export const UPLOAD_BUTTON_ID = "uploadItemBtn";
 
 // Export to expose in unit tests
 export const getTabsButtons = ({
+  isPartitionSystemKey,
   _collection,
   selectedRows,
   editorState,
@@ -339,7 +341,7 @@ export const getTabsButtons = ({
     });
   }
 
-  if (selectedRows.size > 0) {
+  if (selectedRows.size > 0 && (!isPartitionSystemKey || isPreferredApiMongoDB)) {
     const label = "Delete";
     buttons.push({
       iconSrc: DeleteDocumentIcon,
@@ -592,6 +594,7 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
     }
 
     updateNavbarWithTabsButtons(isTabActive, {
+      isPartitionSystemKey: partitionKey.systemKey,
       _collection,
       selectedRows,
       editorState,
@@ -925,6 +928,7 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
   useEffect(
     () =>
       updateNavbarWithTabsButtons(isTabActive, {
+        isPartitionSystemKey: partitionKey.systemKey,
         _collection,
         selectedRows,
         editorState,
@@ -1800,7 +1804,8 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
                   size={tableContainerSizePx}
                   columnHeaders={columnHeaders}
                   isSelectionDisabled={
-                    configContext.platform === Platform.Fabric && userContext.fabricContext?.isReadOnly
+                    (partitionKey.systemKey && !isPreferredApiMongoDB) ||
+                    (configContext.platform === Platform.Fabric && userContext.fabricContext?.isReadOnly)
                   }
                 />
                 {tableItems.length > 0 && (


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1880)

Temporary workaround for a Cosmos DB JS SDK bug. For the affected legacy containers, in the DocumentsTab:
* disable multiple document selection
* call the single document delete API (which works. Since we disabled multiple selection, only document is selected at a time and can therefore be deleted)

This is only problematic with non partitioned collection and doing delete operation with bulk operation API from JS SDK. https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/migrate-containers-partitioned-to-nonpartitioned?tabs=dotnetv3 When partitionKeyDefinition.systemKey === true Backend expects [] as partitionKey but bulk delete operation through SDK sends {[]} value to the backend as a request.

We will revert when JS SDK releases the fix.