### PR TITLE
[Programmatic Access-Try Cosmos DB-Welcome! What is Cosmos DB?]: 'Welcome! What is Cosmos DB?' is not defined programmatically as heading.

### DIFF
--- a/src/Explorer/Quickstart/QuickstartCarousel.tsx
+++ b/src/Explorer/Quickstart/QuickstartCarousel.tsx
@@ -24,7 +24,9 @@ export const QuickstartCarousel: React.FC<QuickstartCarouselProps> = ({
     >
       <Stack>
         <Stack horizontal horizontalAlign="space-between" style={{ padding: 16 }}>
-          <Text variant="xLarge">{getHeaderText(page)}</Text>
+          <Text role="heading" aria-level={1} variant="xLarge">
+            {getHeaderText(page)}
+          </Text>
           <IconButton iconProps={{ iconName: "Cancel" }} onClick={() => setPage(4)} ariaLabel="Close" />
         </Stack>
         {getContent(page)}


### PR DESCRIPTION
Added heading level one to 'Welcome! What is Cosmos DB?' for programmatically defined heading.

This change ensures that the heading 'Welcome! What is Cosmos DB?' is programmatically defined at heading level one, addressing the need for consistency and clarity in our documentation structure.

![image](https://github.com/Azure/cosmos-explorer/assets/107645008/53de66f9-49ec-4669-a43c-5be59f891a06)


[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1882?feature.someFeatureFlagYouMightNeed=true)
