### PR TITLE
swap splitter directions in query results view

### DIFF
--- a/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
@@ -681,10 +681,18 @@ export default class QueryTabComponent extends React.Component<IQueryTabComponen
           )}
           <div className="tabPaneContentContainer">
             <SplitterLayout
-              vertical={this.state.queryResultsView === SplitterDirection.Vertical}
               primaryIndex={0}
-              primaryMinSize={100}
-              secondaryMinSize={200}
+              primaryMinSize={20}
+              secondaryMinSize={20}
+
+              // Percentage is a bit better when the splitter flips from vertical to horizontal.
+              percentage={true}
+
+              // NOTE: It is intentional that this looks reversed!
+              // The 'vertical' property refers to the stacking of the panes so is the opposite of the orientation of the splitter itself
+              // (vertically stacked => horizontal splitter)
+              // Our setting refers to the orientation of the splitter, so we need to reverse it here.
+              vertical={this.state.queryResultsView === SplitterDirection.Horizontal}
             >
               <Fragment>
                 <div className="queryEditor" style={{ height: "100%" }}>

--- a/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
@@ -684,10 +684,8 @@ export default class QueryTabComponent extends React.Component<IQueryTabComponen
               primaryIndex={0}
               primaryMinSize={20}
               secondaryMinSize={20}
-
               // Percentage is a bit better when the splitter flips from vertical to horizontal.
               percentage={true}
-
               // NOTE: It is intentional that this looks reversed!
               // The 'vertical' property refers to the stacking of the panes so is the opposite of the orientation of the splitter itself
               // (vertically stacked => horizontal splitter)


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1896?feature.someFeatureFlagYouMightNeed=true)

When I rolled out the query results view vertical/horizontal toggle (https://github.com/Azure/cosmos-explorer/pull/1833) I used Vertical/Horizontal to refer to the stacking direction of the panes (Vertical -> Top to Bottom, Horizontal -> Left to Right). This aligned with how react-splitter-view's `vertical` property worked. However, after discussions with Meredith and Doug, we realized this was inverted from what a user would expect.

This PR is a simple change to flip Vertical and Horizontal to refer to the direction of the splitter. So, now the options look like this:

| Vertical | Horizontal |
| - | - |
| ![image](https://github.com/Azure/cosmos-explorer/assets/7574/2738948e-ec59-48e6-96cf-2dfd66679ba2) | ![image](https://github.com/Azure/cosmos-explorer/assets/7574/e1c3dba8-51d1-44d1-9987-2ec878c98a02) |

In addition, I changed the `react-split-view` component to use percentage-based sizes, since this works better when the user is able to toggle between orientations (before this, it was possible that one pane would be completely collapsed when you toggled from vertical to horizontal or back, depending on the splitter position before you toggle).