### PR TITLE
Prevent tabsManagerContainer width to grow beyond parent's width

### DIFF
--- a/less/documentDB.less
+++ b/less/documentDB.less
@@ -2369,6 +2369,7 @@ a:link {
   display: flex;
   flex-direction: column;
   min-height: 300px;
+  min-width: 0; // This prevents it to grow past the parent's width if its content is too wide
 }
 
 .tabs {


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1911)

Here is an example where the filter is too wide and the `tabsManagerContainer` div width grows beyond it's parent.
![image](https://github.com/user-attachments/assets/61880116-fca3-4a91-8c14-8c1320f156f6)

With this change:
![image](https://github.com/user-attachments/assets/d77d2dfd-9f69-44f8-95a8-4c27542ebf84)

Underneath the command bar are two flex items: the resource tree and the `tabsManagerContainer`. The problem is that by default, flex items won’t shrink below their minimum content size. Setting [`min-width:0` or `overflow:hidden`](https://stackoverflow.com/a/36247448) solves this.
