### PR TITLE
[Screen reader - Cosmos DB - Data Explorer -> Entities -> Add entity]: Screen reader announces incorrect role when focus lands on the "Edit" and "Delete" buttons.

### DIFF
--- a/src/Explorer/Graph/GraphExplorerComponent/NodePropertiesComponent.tsx
+++ b/src/Explorer/Graph/GraphExplorerComponent/NodePropertiesComponent.tsx
@@ -348,8 +348,9 @@ export class NodePropertiesComponent extends React.Component<
           as="span"
           onActivated={this.setIsDeleteConfirm.bind(this, true)}
           aria-label="Delete this vertex"
+          role="button"
         >
-          <img src={DeleteIcon} alt="Delete" role="button" />
+          <img src={DeleteIcon} alt="Delete" aria-label="hidden" />
         </AccessibleElement>
       );
     } else {
@@ -405,8 +406,9 @@ export class NodePropertiesComponent extends React.Component<
               as="span"
               aria-label="Edit properties"
               onActivated={expandClickHandler}
+              role="button"
             >
-              <img src={EditIcon} alt="Edit" role="button" />
+              <img src={EditIcon} alt="Edit" aria-label="hidden" />
             </AccessibleElement>
           )}
 


### PR DESCRIPTION
Description:

This PR addresses the issue where screen readers announce incorrect roles when focus lands on the "Edit" and "Delete" buttons within the interface. Previously, these buttons were not properly labeled, resulting in inaccurate role announcements by screen readers. With this update, appropriate labels and ARIA attributes have been added to ensure that the buttons are correctly identified and announced by assistive technologies. This enhancement aims to improve accessibility and user experience for individuals relying on screen readers, ensuring that they receive accurate and meaningful information when interacting with the interface.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1923?feature.someFeatureFlagYouMightNeed=true)
