### PR TITLE
Allow connection string users to add database to their Mongo serverless account

### DIFF
--- a/src/Common/dataAccess/createDatabase.ts
+++ b/src/Common/dataAccess/createDatabase.ts
@@ -4,6 +4,7 @@ import * as DataModels from "../../Contracts/DataModels";
 import { useDatabases } from "../../Explorer/useDatabases";
 import { userContext } from "../../UserContext";
 import { getDatabaseName } from "../../Utils/APITypeUtils";
+import { logConsoleInfo, logConsoleProgress } from "../../Utils/NotificationConsoleUtils";
 import { createUpdateCassandraKeyspace } from "../../Utils/arm/generatedClients/cosmos/cassandraResources";
 import { createUpdateGremlinDatabase } from "../../Utils/arm/generatedClients/cosmos/gremlinResources";
 import { createUpdateMongoDBDatabase } from "../../Utils/arm/generatedClients/cosmos/mongoDBResources";
@@ -15,7 +16,6 @@ import {
   MongoDBDatabaseCreateUpdateParameters,
   SqlDatabaseCreateUpdateParameters,
 } from "../../Utils/arm/generatedClients/cosmos/types";
-import { logConsoleInfo, logConsoleProgress } from "../../Utils/NotificationConsoleUtils";
 import { client } from "../CosmosClient";
 import { handleError } from "../ErrorHandlingUtils";
 
@@ -143,6 +143,7 @@ async function createGremlineDatabase(params: DataModels.CreateDatabaseParams): 
 }
 
 async function createDatabaseWithSDK(params: DataModels.CreateDatabaseParams): Promise<DataModels.Database> {
+  console.log("got here")
   const createBody: DatabaseRequest = { id: params.databaseId };
 
   if (params.databaseLevelThroughput) {
@@ -152,8 +153,18 @@ async function createDatabaseWithSDK(params: DataModels.CreateDatabaseParams): P
       createBody.throughput = params.offerThroughput;
     }
   }
-
-  const response: DatabaseResponse = await client().databases.create(createBody);
+  let response: DatabaseResponse;
+  try {
+    response = await client().databases.create(createBody);
+  } catch(error) {
+    if (error.message.includes("Shared throughput database creation is not supported for serverless accounts")) {
+      createBody.maxThroughput = undefined;
+      createBody.throughput = undefined;
+      response = await client().databases.create(createBody);
+    } else {
+      throw error;
+    }
+  }
   return response.resource;
 }
 

--- a/src/Common/dataAccess/createDatabase.ts
+++ b/src/Common/dataAccess/createDatabase.ts
@@ -143,7 +143,6 @@ async function createGremlineDatabase(params: DataModels.CreateDatabaseParams): 
 }
 
 async function createDatabaseWithSDK(params: DataModels.CreateDatabaseParams): Promise<DataModels.Database> {
-  console.log("got here")
   const createBody: DatabaseRequest = { id: params.databaseId };
 
   if (params.databaseLevelThroughput) {

--- a/src/Common/dataAccess/createDatabase.ts
+++ b/src/Common/dataAccess/createDatabase.ts
@@ -155,7 +155,7 @@ async function createDatabaseWithSDK(params: DataModels.CreateDatabaseParams): P
   let response: DatabaseResponse;
   try {
     response = await client().databases.create(createBody);
-  } catch(error) {
+  } catch (error) {
     if (error.message.includes("Shared throughput database creation is not supported for serverless accounts")) {
       createBody.maxThroughput = undefined;
       createBody.throughput = undefined;


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1924)

We got an [ICM ](https://portal.microsofticm.com/imp/v5/incidents/details/523269465/summary) where connectionstring users couldn't create collections for the mongo serverless accounts. After this was resolved via backend changes, they raised to our attention that they were not able to create a database when using connection string. This fix addresses that.