### PR TITLE
Fix resource tree styling

### DIFF
--- a/src/Explorer/Sidebar.tsx
+++ b/src/Explorer/Sidebar.tsx
@@ -249,9 +249,11 @@ export const SidebarContainer: React.FC<SidebarProps> = ({ explorer }) => {
     setLoading(false);
   }, [setLoading]);
 
-  const hasGlobalCommands = !(configContext.platform === Platform.Fabric ||
+  const hasGlobalCommands = !(
+    configContext.platform === Platform.Fabric ||
     userContext.apiType === "Postgres" ||
-    userContext.apiType === "VCoreMongo");
+    userContext.apiType === "VCoreMongo"
+  );
 
   return (
     <Allotment ref={allotment} onChange={onChange} onDragEnd={onDragEnd} className="resourceTreeAndTabs">
@@ -289,7 +291,10 @@ export const SidebarContainer: React.FC<SidebarProps> = ({ explorer }) => {
                       </button>
                     </div>
                   </div>
-                  <div className={styles.expandedContent} style={(!hasGlobalCommands) && { gridTemplateRows: '1fr' }}>
+                  <div
+                    className={styles.expandedContent}
+                    style={!hasGlobalCommands ? { gridTemplateRows: "1fr" } : undefined}
+                  >
                     {hasGlobalCommands && <GlobalCommands explorer={explorer} />}
                     <ResourceTree explorer={explorer} />
                   </div>

--- a/src/Explorer/Sidebar.tsx
+++ b/src/Explorer/Sidebar.tsx
@@ -249,6 +249,10 @@ export const SidebarContainer: React.FC<SidebarProps> = ({ explorer }) => {
     setLoading(false);
   }, [setLoading]);
 
+  const hasGlobalCommands = !(configContext.platform === Platform.Fabric ||
+    userContext.apiType === "Postgres" ||
+    userContext.apiType === "VCoreMongo");
+
   return (
     <Allotment ref={allotment} onChange={onChange} onDragEnd={onDragEnd} className="resourceTreeAndTabs">
       {/* Collections Tree - Start */}
@@ -285,8 +289,8 @@ export const SidebarContainer: React.FC<SidebarProps> = ({ explorer }) => {
                       </button>
                     </div>
                   </div>
-                  <div className={styles.expandedContent}>
-                    <GlobalCommands explorer={explorer} />
+                  <div className={styles.expandedContent} style={(!hasGlobalCommands) && { gridTemplateRows: '1fr' }}>
+                    {hasGlobalCommands && <GlobalCommands explorer={explorer} />}
                     <ResourceTree explorer={explorer} />
                   </div>
                 </>


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1926)

In some cases, the "Create Container" button is not present, so the 2nd element (resource tree) incorrectly takes the size of the button.

![image](https://github.com/user-attachments/assets/ae9a2132-6304-46a7-a412-8162b48580ed)

The `makestyles()` method seems to create styles statically (I couldn't pass an argument to conditionally create a style for each option).
So this fix overrides the css `gridTemplateRows` property at runtime based on whether the "Create Container" button is displayed.
