### PR TITLE
Removing check for value when populating partition key values

### DIFF
--- a/src/Utils/QueryUtils.test.ts
+++ b/src/Utils/QueryUtils.test.ts
@@ -108,6 +108,7 @@ describe("Query Utils", () => {
       },
       Elevation: 3742,
       Type: "Stratovolcano",
+      Category: "",
       Status: "Tephrochronology",
       "Last Known Eruption": "Last known eruption from A.D. 1-1499, inclusive",
       id: "9e3c494e-8367-3f50-1f56-8c6fcb961363",
@@ -145,6 +146,22 @@ describe("Query Utils", () => {
       expect(partitionKeyValues.length).toBe(2);
       expect(expectedPartitionKeyValues).toContain(documentContent["Type"]);
       expect(expectedPartitionKeyValues).toContain(documentContent["Status"]);
+    });
+
+    it("should extract three partition key values", () => {
+      const multiPartitionKeyDefinition: PartitionKeyDefinition = {
+        kind: PartitionKeyKind.MultiHash,
+        paths: ["/Country", "/Region", "/Category"],
+      };
+      const expectedPartitionKeyValues: string[] = ["United States", "US-Washington", ""];
+      const partitioinKeyValues: PartitionKey[] = extractPartitionKeyValues(
+        documentContent,
+        multiPartitionKeyDefinition,
+      );
+      expect(partitioinKeyValues.length).toBe(3);
+      expect(expectedPartitionKeyValues).toContain(documentContent["Country"]);
+      expect(expectedPartitionKeyValues).toContain(documentContent["Region"]);
+      expect(expectedPartitionKeyValues).toContain(documentContent["Category"]);
     });
   });
 });

--- a/src/Utils/QueryUtils.test.ts
+++ b/src/Utils/QueryUtils.test.ts
@@ -146,19 +146,5 @@ describe("Query Utils", () => {
       expect(expectedPartitionKeyValues).toContain(documentContent["Type"]);
       expect(expectedPartitionKeyValues).toContain(documentContent["Status"]);
     });
-
-    it("should extract no partition key values", () => {
-      const singlePartitionKeyDefinition: PartitionKeyDefinition = {
-        kind: PartitionKeyKind.Hash,
-        paths: ["/InvalidPartitionKeyPath"],
-      };
-
-      const partitionKeyValues: PartitionKey[] = extractPartitionKeyValues(
-        documentContent,
-        singlePartitionKeyDefinition,
-      );
-
-      expect(partitionKeyValues.length).toBe(0);
-    });
   });
 });

--- a/src/Utils/QueryUtils.ts
+++ b/src/Utils/QueryUtils.ts
@@ -96,9 +96,7 @@ export const extractPartitionKeyValues = (
   const partitionKeyValues: PartitionKey[] = [];
   partitionKeyDefinition.paths.forEach((partitionKeyPath: string) => {
     const partitionKeyPathWithoutSlash: string = partitionKeyPath.substring(1);
-    if (documentContent[partitionKeyPathWithoutSlash]) {
-      partitionKeyValues.push(documentContent[partitionKeyPathWithoutSlash]);
-    }
+    partitionKeyValues.push(documentContent[partitionKeyPathWithoutSlash]);
   });
   return partitionKeyValues;
 };


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1928)

There was a check where, when updating a document, it would only populate a partition key value if there was a non-empty value for that field in the document to begin with. This is incorrect behavior as a document in a container with hierarchical partitions can have an empty value for one of those partition key fields. The result of this would be the document would be sent with x number of partition key fields but only x - 1 partition key values which would fail backend validation.

This PR simply allows whatever was in that field to be passed on to the "partitionKeyValues" property. If that value is "" then so be it. Updating documents with empty values for partition key fields should now work as expected.
