### PR TITLE
fix #1929 by using flex instead of grid to lay out the tabs view

### DIFF
--- a/less/documentDB.less
+++ b/less/documentDB.less
@@ -2352,8 +2352,8 @@ a:link {
 
 .tabsManagerContainer {
   height: 100%;
-  display: grid;
-  grid-template-rows: 36px 36px 1fr;
+  display: flex;
+  flex-direction: column;
   min-width: 0; // This prevents it to grow past the parent's width if its content is too wide
 }
 
@@ -2610,9 +2610,8 @@ a:link {
 }
 
 .tabPanesContainer {
-  grid-row: span 2; // Fill the remaining space
   display: flex;
-  height: 100%;
+  flex-grow: 1;
   overflow: hidden;
 }
 

--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -57,7 +57,8 @@ export const Tabs = ({ explorer }: TabsProps): JSX.Element => {
   const defaultMessageBarStyles: IMessageBarStyles = {
     root: {
       height: `${LayoutConstants.rowHeight}px`,
-      overflow: "auto",
+      overflow: "hidden",
+      flexDirection: "row",
     },
   };
 


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1930?feature.someFeatureFlagYouMightNeed=true)

Fixes #1929 

This fixes an issue that arose after #1865 was merged. I used a grid layout there, but when there are multiple MessageBars we have more elements than rows and one of the MessageBars or Tab Nave ends up in the `1fr`-sized last row and takes up the rest of the space, covering the actual tab content. This can be worked around by closing MessageBars, but it's definitely not intended.

I did plan for a MessageBar to be present when designing that. However, I neglected to validate the behavior with _multiple_ MessageBars, which can often happen when firewall rules are not configured and you have the RU Threshold warning message up. I wanted to use a Grid because I wanted each fixed size "row" (MessageBars, Tab Bar) to be the same height). However, using a grid layout limits us to a fixed number of "rows", which doesn't scale well to multiple MessageBars. So, instead, I've switched to a Column Flex layout and just set the height of MessageBars, and the Tab Nav bar to the appropriate size. This has the same effect without causing weird layout issues when the number of elements exceeds the number of rows.

Now, with two MessageBars (using a simulated network error message) the layout is correct:

<img width="1404" alt="image" src="https://github.com/user-attachments/assets/96b4c294-d5cd-4e8b-a8a0-9f76b9f2ac4e">
