### PR TITLE
Improve sidebar UI layout when narrow

### DIFF
--- a/src/Explorer/Controls/TreeComponent/Styles.ts
+++ b/src/Explorer/Controls/TreeComponent/Styles.ts
@@ -25,7 +25,9 @@ export const useTreeStyles = makeStyles({
     height: `var(${treeIconWidth})`,
   },
   treeItem: {},
-  nodeLabel: {},
+  nodeLabel: {
+    whiteSpace: "nowrap", // Don't wrap text, there will be a scrollbar.
+  },
   treeItemLayout: {
     fontSize: tokens.fontSizeBase300,
     height: tokens.layoutRowHeight,

--- a/src/Explorer/Controls/TreeComponent/__snapshots__/TreeNodeComponent.test.tsx.snap
+++ b/src/Explorer/Controls/TreeComponent/__snapshots__/TreeNodeComponent.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`TreeNodeComponent does not render children if the node is loading 1`] =
     }
   >
     <span
-      className=""
+      className="___1h29e9h_0000000 fz5stix"
     >
       rootLabel
     </span>
@@ -183,7 +183,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                   class="fui-TreeItemLayout__main rklbe47"
                 >
                   <span
-                    class=""
+                    class="___1h29e9h_0000000 fz5stix"
                   >
                     rootLabel
                   </span>
@@ -235,7 +235,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                     class="fui-TreeItemLayout__main rklbe47"
                   >
                     <span
-                      class=""
+                      class="___1h29e9h_0000000 fz5stix"
                     >
                       rootLabel
                     </span>
@@ -283,7 +283,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                         class="fui-TreeItemLayout__main rklbe47"
                       >
                         <span
-                          class=""
+                          class="___1h29e9h_0000000 fz5stix"
                         >
                           child1Label
                         </span>
@@ -327,7 +327,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                         class="fui-TreeItemLayout__main rklbe47"
                       >
                         <span
-                          class=""
+                          class="___1h29e9h_0000000 fz5stix"
                         >
                           child2LoadingLabel
                         </span>
@@ -367,7 +367,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                         class="fui-TreeItemLayout__main rklbe47"
                       >
                         <span
-                          class=""
+                          class="___1h29e9h_0000000 fz5stix"
                         >
                           child3ExpandingLabel
                         </span>
@@ -423,7 +423,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
               className="fui-TreeItemLayout__main rklbe47"
             >
               <span
-                className=""
+                className="___1h29e9h_0000000 fz5stix"
               >
                 rootLabel
               </span>
@@ -614,7 +614,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                                   class="fui-TreeItemLayout__main rklbe47"
                                 >
                                   <span
-                                    class=""
+                                    class="___1h29e9h_0000000 fz5stix"
                                   >
                                     child1Label
                                   </span>
@@ -666,7 +666,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                                     class="fui-TreeItemLayout__main rklbe47"
                                   >
                                     <span
-                                      class=""
+                                      class="___1h29e9h_0000000 fz5stix"
                                     >
                                       child1Label
                                     </span>
@@ -720,7 +720,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                               className="fui-TreeItemLayout__main rklbe47"
                             >
                               <span
-                                className=""
+                                className="___1h29e9h_0000000 fz5stix"
                               >
                                 child1Label
                               </span>
@@ -848,7 +848,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                                   class="fui-TreeItemLayout__main rklbe47"
                                 >
                                   <span
-                                    class=""
+                                    class="___1h29e9h_0000000 fz5stix"
                                   >
                                     child2LoadingLabel
                                   </span>
@@ -900,7 +900,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                                     class="fui-TreeItemLayout__main rklbe47"
                                   >
                                     <span
-                                      class=""
+                                      class="___1h29e9h_0000000 fz5stix"
                                     >
                                       child2LoadingLabel
                                     </span>
@@ -954,7 +954,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                               className="fui-TreeItemLayout__main rklbe47"
                             >
                               <span
-                                className=""
+                                className="___1h29e9h_0000000 fz5stix"
                               >
                                 child2LoadingLabel
                               </span>
@@ -1063,7 +1063,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                                   class="fui-TreeItemLayout__main rklbe47"
                                 >
                                   <span
-                                    class=""
+                                    class="___1h29e9h_0000000 fz5stix"
                                   >
                                     child3ExpandingLabel
                                   </span>
@@ -1111,7 +1111,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                                     class="fui-TreeItemLayout__main rklbe47"
                                   >
                                     <span
-                                      class=""
+                                      class="___1h29e9h_0000000 fz5stix"
                                     >
                                       child3ExpandingLabel
                                     </span>
@@ -1153,7 +1153,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
                               className="fui-TreeItemLayout__main rklbe47"
                             >
                               <span
-                                className=""
+                                className="___1h29e9h_0000000 fz5stix"
                               >
                                 child3ExpandingLabel
                               </span>
@@ -1195,7 +1195,7 @@ exports[`TreeNodeComponent renders a loading spinner if the node is loading: loa
     }
   >
     <span
-      className=""
+      className="___1h29e9h_0000000 fz5stix"
     >
       rootLabel
     </span>
@@ -1222,7 +1222,7 @@ exports[`TreeNodeComponent renders a loading spinner if the node is loading: loa
     }
   >
     <span
-      className=""
+      className="___1h29e9h_0000000 fz5stix"
     >
       rootLabel
     </span>
@@ -1249,7 +1249,7 @@ exports[`TreeNodeComponent renders a node as expandable if it has empty, but def
     }
   >
     <span
-      className=""
+      className="___1h29e9h_0000000 fz5stix"
     >
       rootLabel
     </span>
@@ -1324,7 +1324,7 @@ exports[`TreeNodeComponent renders a node with a menu 1`] = `
         }
       >
         <span
-          className=""
+          className="___1h29e9h_0000000 fz5stix"
         >
           rootLabel
         </span>
@@ -1374,7 +1374,7 @@ exports[`TreeNodeComponent renders a single node 1`] = `
     }
   >
     <span
-      className=""
+      className="___1h29e9h_0000000 fz5stix"
     >
       rootLabel
     </span>
@@ -1403,7 +1403,7 @@ exports[`TreeNodeComponent renders an icon if the node has one 1`] = `
     }
   >
     <span
-      className=""
+      className="___1h29e9h_0000000 fz5stix"
     >
       rootLabel
     </span>
@@ -1430,7 +1430,7 @@ exports[`TreeNodeComponent renders selected parent node as selected if no descen
     }
   >
     <span
-      className=""
+      className="___1h29e9h_0000000 fz5stix"
     >
       rootLabel
     </span>
@@ -1506,7 +1506,7 @@ exports[`TreeNodeComponent renders selected parent node as unselected if any des
     }
   >
     <span
-      className=""
+      className="___1h29e9h_0000000 fz5stix"
     >
       rootLabel
     </span>
@@ -1585,7 +1585,7 @@ exports[`TreeNodeComponent renders single selected leaf node as selected 1`] = `
     }
   >
     <span
-      className=""
+      className="___1h29e9h_0000000 fz5stix"
     >
       rootLabel
     </span>

--- a/src/Explorer/Sidebar.tsx
+++ b/src/Explorer/Sidebar.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Menu,
+  MenuButton,
   MenuButtonProps,
   MenuItem,
   MenuList,
@@ -60,6 +61,7 @@ const useSidebarStyles = makeStyles({
     alignItems: "center",
     justifyItems: "center",
     width: "100%",
+    containerType: "size", // Use this container for "@container" queries below this.
     ...cosmosShorthands.borderBottom(),
   },
   loadingProgressBar: {
@@ -81,6 +83,18 @@ const useSidebarStyles = makeStyles({
       "100%": {
         opacity: ".2",
       },
+    },
+  },
+  globalCommandsMenuButton: {
+    display: "initial",
+    "@container (min-width: 250px)": {
+      display: "none",
+    },
+  },
+  globalCommandsSplitButton: {
+    display: "none",
+    "@container (min-width: 250px)": {
+      display: "flex",
     },
   },
 });
@@ -171,13 +185,19 @@ const GlobalCommands: React.FC<GlobalCommandsProps> = ({ explorer }) => {
         <Menu positioning="below-end">
           <MenuTrigger disableButtonEnhancement>
             {(triggerProps: MenuButtonProps) => (
-              <SplitButton
-                menuButton={{ ...triggerProps, "aria-label": "More commands" }}
-                primaryActionButton={{ onClick: onPrimaryActionClick }}
-                icon={primaryAction.icon}
-              >
-                {primaryAction.label}
-              </SplitButton>
+              <>
+                <SplitButton
+                  menuButton={{ ...triggerProps, "aria-label": "More commands" }}
+                  primaryActionButton={{ onClick: onPrimaryActionClick }}
+                  className={styles.globalCommandsSplitButton}
+                  icon={primaryAction.icon}
+                >
+                  {primaryAction.label}
+                </SplitButton>
+                <MenuButton {...triggerProps} icon={primaryAction.icon} className={styles.globalCommandsMenuButton}>
+                  New...
+                </MenuButton>
+              </>
             )}
           </MenuTrigger>
           <MenuPopover>
@@ -199,7 +219,7 @@ interface SidebarProps {
   explorer: Explorer;
 }
 
-const CollapseThreshold = 50;
+const CollapseThreshold = 140;
 
 export const SidebarContainer: React.FC<SidebarProps> = ({ explorer }) => {
   const styles = useSidebarStyles();

--- a/src/Explorer/Sidebar.tsx
+++ b/src/Explorer/Sidebar.tsx
@@ -334,7 +334,7 @@ export const SidebarContainer: React.FC<SidebarProps> = ({ explorer }) => {
           </CosmosFluentProvider>
         </Allotment.Pane>
       )}
-      <Allotment.Pane minSize={800}>
+      <Allotment.Pane minSize={200}>
         <Tabs explorer={explorer} />
       </Allotment.Pane>
     </Allotment>


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1938)

@MeredithMooreUX got some feedback that the new resource tree layout doesn't react well at really narrow sizes. I did some work on the narrow layout in the initial PR but this PR iterates further on that with a few improvements:

1. When the sidebar is narrower than 150px (which is the point at which the "New Container" split button starts to wrap), the "Global Command" split button becomes a pure menu (i.e. instead of having a primary action and a dropdown menu, it just always drops down the menu) with the title "New...". Since the menu can overhang the sidebar, this makes it easier to see what operations are available. This behavior depends on CSS Container Queries which [are available in modern browsers](https://caniuse.com/css-container-queries). Without that functionality, the **menu button** (which is the smaller option) will always show.

2. The tree node text no longer wraps. Since we have horizontal scrolling enabled, and the wrapping significantly messes with the layout, I decided there was no need to wrap the text.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/5d487858-3adb-4c22-afb2-c02e97b33feb) | ![image](https://github.com/user-attachments/assets/8e73cc85-1db8-4594-8134-11de81a1b98e) |

> [!NOTE]
> Due to the way I cropped the screenshots, the horizontal scrollbar isn't visible, but there is one at the bottom of the tree view.

3. Finally, I increased the "Collapse" threshold on the splitter. Now, when the sidebar goes below 140px (which is now too small even for the "New..." menu button to render properly), the sidebar collapses automatically. This behavior already existed, but had a much lower threshold (50px)

https://github.com/user-attachments/assets/0b341ac8-8195-4404-8d37-b2bccf72a345

Any of these changes can be easily tweaked and adjusted. Give it a look and let me know what you think!
