### PR TITLE
Remove Database context menu for Fabric read-only configuration

### DIFF
--- a/src/Explorer/ContextMenuButtonFactory.tsx
+++ b/src/Explorer/ContextMenuButtonFactory.tsx
@@ -41,6 +41,10 @@ export interface DatabaseContextMenuButtonParams {
  * New resource tree (in ReactJS)
  */
 export const createDatabaseContextMenu = (container: Explorer, databaseId: string): TreeNodeMenuItem[] => {
+  if (configContext.platform === Platform.Fabric && userContext.fabricContext?.isReadOnly) {
+    return undefined;
+  }
+
   const items: TreeNodeMenuItem[] = [
     {
       iconSrc: AddCollectionIcon,


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1939)

Remove this menu which contains "New Container" and "Delete Database" which is not applicable for read-only Fabric.
<img width="557" alt="image" src="https://github.com/user-attachments/assets/83d64379-5398-4824-b997-405918b19ad4">
