### PR TITLE
disable query error tests due to backend issue

### DIFF
--- a/test/sql/query.spec.ts
+++ b/test/sql/query.spec.ts
@@ -71,6 +71,8 @@ test("Query stats", async () => {
 });
 
 test("Query errors", async () => {
+  test.skip(true, "Disabled due to an issue with error reporting in the backend.");
+
   await queryEditor.locator.click();
   await queryEditor.setText("SELECT\n  glarb(c.id),\n  blarg(c.id)\nFROM c");
 


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

The E2E playwright tests for query errors depend on getting accurate error details from the backend. However, there's an issue that causes some accounts to suddenly stop reporting error details. The query team is working on this, but until it's resolved I'm disabling the affected tests.