### PR TITLE
Change persistence format for column width in DocumentsTab

### DIFF
--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabStateUtil.ts
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabStateUtil.ts
@@ -14,7 +14,7 @@ export enum SubComponentName {
 }
 
 export type ColumnSizesMap = { [columnId: string]: WidthDefinition };
-export type WidthDefinition = { idealWidth?: number; minWidth?: number };
+export type WidthDefinition = { widthPx: number };
 export type TabDivider = { leftPaneWidthPercent: number };
 
 /**


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1944)

The Documents tab currently saves the column width as:
```javascript
{
  idealWidth: 10
  minWidth: 50
}
```
which is the data structure returned by the fluent UI table.

We're only interested in persisting `idealWidth`, so we're changing the format to:
```javascript
{
  widthPx: 10
}
```

The change is backward compatible and will ignore (and overwrite) any data in the previous format.