### PR TITLE
Improve SettingsPane

### DIFF
--- a/src/Common/Tooltip/InfoTooltip.tsx
+++ b/src/Common/Tooltip/InfoTooltip.tsx
@@ -3,11 +3,12 @@ import * as React from "react";
 
 export interface TooltipProps {
   children: string;
+  className?: string;
 }
 
-export const InfoTooltip: React.FunctionComponent<TooltipProps> = ({ children }: TooltipProps) => {
+export const InfoTooltip: React.FunctionComponent<TooltipProps> = ({ children, className }: TooltipProps) => {
   return (
-    <span>
+    <span className={className}>
       <TooltipHost content={children}>
         <Icon iconName="Info" ariaLabel={children} className="panelInfoIcon" tabIndex={0} />
       </TooltipHost>

--- a/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
+++ b/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
@@ -5,13 +5,11 @@ import {
   IChoiceGroupOption,
   ISpinButtonStyles,
   IToggleStyles,
-  Icon,
   MessageBar,
   MessageBarType,
   Position,
   SpinButton,
   Toggle,
-  TooltipHost,
 } from "@fluentui/react";
 import { Accordion, AccordionHeader, AccordionItem, AccordionPanel, makeStyles } from "@fluentui/react-components";
 import { AuthType } from "AuthType";
@@ -74,8 +72,12 @@ const useStyles = makeStyles({
     paddingTop: "4px",
     cursor: "pointer",
   },
-  settingsSectionPart: {
+  settingsSectionContainer: {
     paddingLeft: "15px",
+  },
+  settingsSectionDescription: {
+    paddingBottom: "10px",
+    fontSize: "12px",
   },
   subHeader: {
     marginRight: "5px",
@@ -472,13 +474,13 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
             <AccordionItem value="1">
               <AccordionHeader>
                 <div className={styles.header}>Page Options</div>
-                <InfoTooltip className={styles.headerIcon}>
-                  Choose Custom to specify a fixed amount of query results to show, or choose Unlimited to show as many
-                  query results per page.
-                </InfoTooltip>
               </AccordionHeader>
               <AccordionPanel>
-                <div className={styles.settingsSectionPart}>
+                <div className={styles.settingsSectionContainer}>
+                  <div className={styles.settingsSectionDescription}>
+                    Choose Custom to specify a fixed amount of query results to show, or choose Unlimited to show as
+                    many query results per page.
+                  </div>
                   <ChoiceGroup
                     ariaLabelledBy="pageOptions"
                     selectedKey={pageOption}
@@ -487,11 +489,11 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                     onChange={handleOnPageOptionChange}
                   />
                 </div>
-                <div className={`tabs ${styles.settingsSectionPart}`}>
+                <div className={`tabs ${styles.settingsSectionContainer}`}>
                   {isCustomPageOptionSelected() && (
                     <div className="tabcontent">
-                      <div className="settingsSectionLabel">
-                        Query results per page
+                      <div className={styles.settingsSectionDescription}>
+                        Query results per page{" "}
                         <InfoTooltip className={styles.headerIcon}>
                           Enter the number of query results that should be shown per page.
                         </InfoTooltip>
@@ -523,32 +525,9 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
               <AccordionItem value="2">
                 <AccordionHeader>
                   <div className={styles.header}>Enable Entra ID RBAC</div>
-                  <TooltipHost
-                    content={
-                      <>
-                        Choose Automatic to enable Entra ID RBAC automatically. True/False to force enable/disable Entra
-                        ID RBAC.
-                        <a
-                          href="https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-rbac#use-data-explorer"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          {" "}
-                          Learn more{" "}
-                        </a>
-                      </>
-                    }
-                  >
-                    <Icon
-                      iconName="Info"
-                      ariaLabel="Info tooltip"
-                      className={`panelInfoIcon ${styles.headerIcon}`}
-                      tabIndex={0}
-                    />
-                  </TooltipHost>
                 </AccordionHeader>
                 <AccordionPanel>
-                  <div className={styles.settingsSectionPart}>
+                  <div className={styles.settingsSectionContainer}>
                     {showDataPlaneRBACWarning && configContext.platform === Platform.Portal && (
                       <MessageBar
                         messageBarType={MessageBarType.warning}
@@ -560,6 +539,18 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                         operations
                       </MessageBar>
                     )}
+                    <div className={styles.settingsSectionDescription}>
+                      Choose Automatic to enable Entra ID RBAC automatically. True/False to force enable/disable Entra
+                      ID RBAC.
+                      <a
+                        href="https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-rbac#use-data-explorer"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {" "}
+                        Learn more{" "}
+                      </a>
+                    </div>
                     <ChoiceGroup
                       ariaLabelledBy="enableDataPlaneRBACOptions"
                       options={dataPlaneRBACOptionsList}
@@ -577,13 +568,13 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
               <AccordionItem value="3">
                 <AccordionHeader>
                   <div className={styles.header}>Query Timeout</div>
-                  <InfoTooltip className={styles.headerIcon}>
-                    When a query reaches a specified time limit, a popup with an option to cancel the query will show
-                    unless automatic cancellation has been enabled
-                  </InfoTooltip>
                 </AccordionHeader>
                 <AccordionPanel>
-                  <div className={styles.settingsSectionPart}>
+                  <div className={styles.settingsSectionContainer}>
+                    <div className={styles.settingsSectionDescription}>
+                      When a query reaches a specified time limit, a popup with an option to cancel the query will show
+                      unless automatic cancellation has been enabled.
+                    </div>
                     <Toggle
                       styles={toggleStyles}
                       label="Enable query timeout"
@@ -592,7 +583,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                     />
                   </div>
                   {queryTimeoutEnabled && (
-                    <div className={styles.settingsSectionPart}>
+                    <div className={styles.settingsSectionContainer}>
                       <SpinButton
                         label="Query timeout (ms)"
                         labelPosition={Position.top}
@@ -618,12 +609,12 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
               <AccordionItem value="4">
                 <AccordionHeader>
                   <div className={styles.header}>RU Threshold</div>
-                  <InfoTooltip className={styles.headerIcon}>
-                    If a query exceeds a configured RU threshold, the query will be aborted.
-                  </InfoTooltip>
                 </AccordionHeader>
                 <AccordionPanel>
-                  <div className={styles.settingsSectionPart}>
+                  <div className={styles.settingsSectionContainer}>
+                    <div className={styles.settingsSectionDescription}>
+                      If a query exceeds a configured RU threshold, the query will be aborted.
+                    </div>
                     <Toggle
                       styles={toggleStyles}
                       label="Enable RU threshold"
@@ -632,7 +623,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                     />
                   </div>
                   {ruThresholdEnabled && (
-                    <div className={styles.settingsSectionPart}>
+                    <div className={styles.settingsSectionContainer}>
                       <SpinButton
                         label="RU Threshold (RU)"
                         labelPosition={Position.top}
@@ -652,12 +643,12 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
               <AccordionItem value="5">
                 <AccordionHeader>
                   <div className={styles.header}>Default Query Results View</div>
-                  <InfoTooltip className={styles.headerIcon}>
-                    Select the default view to use when displaying query results.
-                  </InfoTooltip>
                 </AccordionHeader>
                 <AccordionPanel>
-                  <div className={styles.settingsSectionPart}>
+                  <div className={styles.settingsSectionContainer}>
+                    <div className={styles.settingsSectionDescription}>
+                      Select the default view to use when displaying query results.
+                    </div>
                     <ChoiceGroup
                       ariaLabelledBy="defaultQueryResultsView"
                       selectedKey={defaultQueryResultsView}
@@ -673,13 +664,13 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
 
           <AccordionItem value="6">
             <AccordionHeader>
-              <div className={styles.header}> Retry Settings</div>
-              <InfoTooltip className={styles.headerIcon}>
-                Retry policy associated with throttled requests during CosmosDB queries.
-              </InfoTooltip>
+              <div className={styles.header}>Retry Settings</div>
             </AccordionHeader>
             <AccordionPanel>
-              <div className={styles.settingsSectionPart}>
+              <div className={styles.settingsSectionContainer}>
+                <div className={styles.settingsSectionDescription}>
+                  Retry policy associated with throttled requests during CosmosDB queries.
+                </div>
                 <div>
                   <span className={styles.subHeader}>Max retry attempts</span>
                   <InfoTooltip className={styles.headerIcon}>
@@ -746,12 +737,12 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
           <AccordionItem value="7">
             <AccordionHeader>
               <div className={styles.header}>Enable container pagination</div>
-              <InfoTooltip className={styles.headerIcon}>
-                Load 50 containers at a time. Currently, containers are not pulled in alphanumeric order.
-              </InfoTooltip>
             </AccordionHeader>
             <AccordionPanel>
-              <div className={styles.settingsSectionPart}>
+              <div className={styles.settingsSectionContainer}>
+                <div className={styles.settingsSectionDescription}>
+                  Load 50 containers at a time. Currently, containers are not pulled in alphanumeric order.
+                </div>
                 <Checkbox
                   styles={{
                     label: { padding: 0 },
@@ -760,6 +751,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                   ariaLabel="Enable container pagination"
                   checked={containerPaginationEnabled}
                   onChange={() => setContainerPaginationEnabled(!containerPaginationEnabled)}
+                  label="Enable container pagination"
                 />
               </div>
             </AccordionPanel>
@@ -769,13 +761,13 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
             <AccordionItem value="8">
               <AccordionHeader>
                 <div className={styles.header}>Enable cross-partition query</div>
-                <InfoTooltip className={styles.headerIcon}>
-                  Send more than one request while executing a query. More than one request is necessary if the query is
-                  not scoped to single partition key value.
-                </InfoTooltip>
               </AccordionHeader>
               <AccordionPanel>
-                <div className={styles.settingsSectionPart}>
+                <div className={styles.settingsSectionContainer}>
+                  <div className={styles.settingsSectionDescription}>
+                    Send more than one request while executing a query. More than one request is necessary if the query
+                    is not scoped to single partition key value.
+                  </div>
                   <Checkbox
                     styles={{
                       label: { padding: 0 },
@@ -784,6 +776,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                     ariaLabel="Enable cross partition query"
                     checked={crossPartitionQueryEnabled}
                     onChange={() => setCrossPartitionQueryEnabled(!crossPartitionQueryEnabled)}
+                    label="Enable cross-partition query"
                   />
                 </div>
               </AccordionPanel>
@@ -794,14 +787,14 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
             <AccordionItem value="9">
               <AccordionHeader>
                 <div className={styles.header}>Max degree of parallelism</div>
-                <InfoTooltip className={styles.headerIcon}>
-                  Gets or sets the number of concurrent operations run client side during parallel query execution. A
-                  positive property value limits the number of concurrent operations to the set value. If it is set to
-                  less than 0, the system automatically decides the number of concurrent operations to run.
-                </InfoTooltip>
               </AccordionHeader>
               <AccordionPanel>
-                <div className={styles.settingsSectionPart}>
+                <div className={styles.settingsSectionContainer}>
+                  <div className={styles.settingsSectionDescription}>
+                    Gets or sets the number of concurrent operations run client side during parallel query execution. A
+                    positive property value limits the number of concurrent operations to the set value. If it is set to
+                    less than 0, the system automatically decides the number of concurrent operations to run.
+                  </div>
                   <SpinButton
                     min={-1}
                     step={1}
@@ -817,6 +810,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                     }
                     onValidate={(newValue) => setMaxDegreeOfParallelism(parseInt(newValue) || maxDegreeOfParallelism)}
                     ariaLabel="Max degree of parallelism"
+                    label="Max degree of parallelism"
                   />
                 </div>
               </AccordionPanel>
@@ -827,14 +821,14 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
             <AccordionItem value="10">
               <AccordionHeader>
                 <div className={styles.header}>Priority Level</div>
-                <InfoTooltip className={styles.headerIcon}>
-                  Sets the priority level for data-plane requests from Data Explorer when using Priority-Based
-                  Execution. If &quot;None&quot; is selected, Data Explorer will not specify priority level, and the
-                  server-side default priority level will be used.
-                </InfoTooltip>
               </AccordionHeader>
               <AccordionPanel>
-                <div className={styles.settingsSectionPart}>
+                <div className={styles.settingsSectionContainer}>
+                  <div className={styles.settingsSectionDescription}>
+                    Sets the priority level for data-plane requests from Data Explorer when using Priority-Based
+                    Execution. If &quot;None&quot; is selected, Data Explorer will not specify priority level, and the
+                    server-side default priority level will be used.
+                  </div>
                   <ChoiceGroup
                     ariaLabelledBy="priorityLevel"
                     selectedKey={priorityLevel}
@@ -851,13 +845,13 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
             <AccordionItem value="11">
               <AccordionHeader>
                 <div className={styles.header}>Display Gremlin query results as:&nbsp;</div>
-                <InfoTooltip className={styles.headerIcon}>
-                  Select Graph to automatically visualize the query results as a Graph or JSON to display the results as
-                  JSON.
-                </InfoTooltip>
               </AccordionHeader>
               <AccordionPanel>
-                <div className={styles.settingsSectionPart}>
+                <div className={styles.settingsSectionContainer}>
+                  <div className={styles.settingsSectionDescription}>
+                    Select Graph to automatically visualize the query results as a Graph or JSON to display the results
+                    as JSON.
+                  </div>
                   <ChoiceGroup
                     selectedKey={graphAutoVizDisabled}
                     options={graphAutoOptionList}
@@ -873,14 +867,14 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
             <AccordionItem value="12">
               <AccordionHeader>
                 <div className={styles.header}>Enable sample database</div>
-                <InfoTooltip className={styles.headerIcon}>
-                  This is a sample database and collection with synthetic product data you can use to explore using
-                  NoSQL queries and Query Advisor. This will appear as another database in the Data Explorer UI, and is
-                  created by, and maintained by Microsoft at no cost to you.
-                </InfoTooltip>
               </AccordionHeader>
               <AccordionPanel>
-                <div className={styles.settingsSectionPart}>
+                <div className={styles.settingsSectionContainer}>
+                  <div className={styles.settingsSectionDescription}>
+                    This is a sample database and collection with synthetic product data you can use to explore using
+                    NoSQL queries and Query Advisor. This will appear as another database in the Data Explorer UI, and
+                    is created by, and maintained by Microsoft at no cost to you.
+                  </div>
                   <Checkbox
                     styles={{
                       label: { padding: 0 },
@@ -889,6 +883,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                     ariaLabel="Enable sample db for Query Advisor"
                     checked={copilotSampleDBEnabled}
                     onChange={handleSampleDatabaseChange}
+                    label="Enable sample database"
                   />
                 </div>
               </AccordionPanel>

--- a/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
+++ b/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
@@ -72,6 +72,7 @@ const useStyles = makeStyles({
   },
   headerIcon: {
     paddingTop: "4px",
+    cursor: "pointer",
   },
   settingsSectionPart: {
     paddingLeft: "15px",
@@ -676,9 +677,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
             <AccordionPanel>
               <div className={styles.settingsSectionPart}>
                 <div>
-                  <legend id="queryRetryAttemptsLabel" className="settingsSectionLabel legendLabel">
-                    Max retry attempts
-                  </legend>
+                  <span className={styles.header}>Max retry attempts</span>
                   <InfoTooltip className={styles.headerIcon}>
                     Max number of retries to be performed for a request. Default value 9.
                   </InfoTooltip>
@@ -697,9 +696,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                   styles={spinButtonStyles}
                 />
                 <div>
-                  <legend id="queryRetryAttemptsLabel" className="settingsSectionLabel legendLabel">
-                    Fixed retry interval (ms)
-                  </legend>
+                  <span className={styles.header}>Fixed retry interval (ms)</span>
                   <InfoTooltip className={styles.headerIcon}>
                     Fixed retry interval in milliseconds to wait between each retry ignoring the retryAfter returned as
                     part of the response. Default value is 0 milliseconds.
@@ -719,9 +716,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                   styles={spinButtonStyles}
                 />
                 <div>
-                  <legend id="queryRetryAttemptsLabel" className="settingsSectionLabel legendLabel">
-                    Max wait time (s)
-                  </legend>
+                  <span className={styles.header}>Max wait time (s)</span>
                   <InfoTooltip className={styles.headerIcon}>
                     Max wait time in seconds to wait for a request while the retries are happening. Default value 30
                     seconds.

--- a/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
+++ b/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
@@ -77,6 +77,10 @@ const useStyles = makeStyles({
   settingsSectionPart: {
     paddingLeft: "15px",
   },
+  subHeader: {
+    marginRight: "5px",
+    fontSize: "12px",
+  },
 });
 
 export const useDataPlaneRbac: DataPlaneRbacStore = create(() => ({
@@ -677,7 +681,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
             <AccordionPanel>
               <div className={styles.settingsSectionPart}>
                 <div>
-                  <span className={styles.header}>Max retry attempts</span>
+                  <span className={styles.subHeader}>Max retry attempts</span>
                   <InfoTooltip className={styles.headerIcon}>
                     Max number of retries to be performed for a request. Default value 9.
                   </InfoTooltip>
@@ -696,7 +700,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                   styles={spinButtonStyles}
                 />
                 <div>
-                  <span className={styles.header}>Fixed retry interval (ms)</span>
+                  <span className={styles.subHeader}>Fixed retry interval (ms)</span>
                   <InfoTooltip className={styles.headerIcon}>
                     Fixed retry interval in milliseconds to wait between each retry ignoring the retryAfter returned as
                     part of the response. Default value is 0 milliseconds.
@@ -716,7 +720,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                   styles={spinButtonStyles}
                 />
                 <div>
-                  <span className={styles.header}>Max wait time (s)</span>
+                  <span className={styles.subHeader}>Max wait time (s)</span>
                   <InfoTooltip className={styles.headerIcon}>
                     Max wait time in seconds to wait for a request while the retries are happening. Default value 30
                     seconds.

--- a/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
+++ b/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
@@ -271,7 +271,8 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
 
     if (shouldShowGraphAutoVizOption) {
       logConsoleInfo(
-        `Graph result will be displayed as ${LocalStorageUtility.getEntryBoolean(StorageKey.IsGraphAutoVizDisabled) ? "JSON" : "Graph"
+        `Graph result will be displayed as ${
+          LocalStorageUtility.getEntryBoolean(StorageKey.IsGraphAutoVizDisabled) ? "JSON" : "Graph"
         }`,
       );
     }
@@ -486,7 +487,9 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                     <div className="tabcontent">
                       <div className="settingsSectionLabel">
                         Query results per page
-                        <InfoTooltip className={styles.headerIcon}>Enter the number of query results that should be shown per page.</InfoTooltip>
+                        <InfoTooltip className={styles.headerIcon}>
+                          Enter the number of query results that should be shown per page.
+                        </InfoTooltip>
                       </div>
 
                       <SpinButton
@@ -518,8 +521,8 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                   <TooltipHost
                     content={
                       <>
-                        Choose Automatic to enable Entra ID RBAC automatically. True/False to force enable/disable
-                        Entra ID RBAC.
+                        Choose Automatic to enable Entra ID RBAC automatically. True/False to force enable/disable Entra
+                        ID RBAC.
                         <a
                           href="https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-rbac#use-data-explorer"
                           target="_blank"
@@ -531,7 +534,12 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                       </>
                     }
                   >
-                    <Icon iconName="Info" ariaLabel="Info tooltip" className={`panelInfoIcon ${styles.headerIcon}`} tabIndex={0} />
+                    <Icon
+                      iconName="Info"
+                      ariaLabel="Info tooltip"
+                      className={`panelInfoIcon ${styles.headerIcon}`}
+                      tabIndex={0}
+                    />
                   </TooltipHost>
                 </AccordionHeader>
                 <AccordionPanel>
@@ -559,103 +567,111 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
               </AccordionItem>
             )}
 
-
-          {userContext.apiType === "SQL" && (<>
-            <AccordionItem value="3">
-              <AccordionHeader>
-                <div className={styles.header}>Query Timeout</div>
-                <InfoTooltip className={styles.headerIcon}>
-                  When a query reaches a specified time limit, a popup with an option to cancel the query will show
-                  unless automatic cancellation has been enabled
-                </InfoTooltip>
-              </AccordionHeader>
-              <AccordionPanel>
-                <div className={styles.settingsSectionPart}>
-                  <Toggle
-                    styles={toggleStyles}
-                    label="Enable query timeout"
-                    onChange={handleOnQueryTimeoutToggleChange}
-                    defaultChecked={queryTimeoutEnabled}
-                  />
-                </div>
-                {queryTimeoutEnabled && (
+          {userContext.apiType === "SQL" && (
+            <>
+              <AccordionItem value="3">
+                <AccordionHeader>
+                  <div className={styles.header}>Query Timeout</div>
+                  <InfoTooltip className={styles.headerIcon}>
+                    When a query reaches a specified time limit, a popup with an option to cancel the query will show
+                    unless automatic cancellation has been enabled
+                  </InfoTooltip>
+                </AccordionHeader>
+                <AccordionPanel>
                   <div className={styles.settingsSectionPart}>
-                    <SpinButton
-                      label="Query timeout (ms)"
-                      labelPosition={Position.top}
-                      defaultValue={(queryTimeout || 5000).toString()}
-                      min={100}
-                      step={1000}
-                      onChange={handleOnQueryTimeoutSpinButtonChange}
-                      incrementButtonAriaLabel="Increase value by 1000"
-                      decrementButtonAriaLabel="Decrease value by 1000"
-                      styles={spinButtonStyles}
-                    />
                     <Toggle
-                      label="Automatically cancel query after timeout"
                       styles={toggleStyles}
-                      onChange={handleOnAutomaticallyCancelQueryToggleChange}
-                      defaultChecked={automaticallyCancelQueryAfterTimeout}
+                      label="Enable query timeout"
+                      onChange={handleOnQueryTimeoutToggleChange}
+                      defaultChecked={queryTimeoutEnabled}
                     />
                   </div>
-                )}
-              </AccordionPanel>
-            </AccordionItem>
+                  {queryTimeoutEnabled && (
+                    <div className={styles.settingsSectionPart}>
+                      <SpinButton
+                        label="Query timeout (ms)"
+                        labelPosition={Position.top}
+                        defaultValue={(queryTimeout || 5000).toString()}
+                        min={100}
+                        step={1000}
+                        onChange={handleOnQueryTimeoutSpinButtonChange}
+                        incrementButtonAriaLabel="Increase value by 1000"
+                        decrementButtonAriaLabel="Decrease value by 1000"
+                        styles={spinButtonStyles}
+                      />
+                      <Toggle
+                        label="Automatically cancel query after timeout"
+                        styles={toggleStyles}
+                        onChange={handleOnAutomaticallyCancelQueryToggleChange}
+                        defaultChecked={automaticallyCancelQueryAfterTimeout}
+                      />
+                    </div>
+                  )}
+                </AccordionPanel>
+              </AccordionItem>
 
-            <AccordionItem value="4">
-              <AccordionHeader>
-                <div className={styles.header}>RU Threshold</div>
-                <InfoTooltip className={styles.headerIcon}>If a query exceeds a configured RU threshold, the query will be aborted.</InfoTooltip>
-              </AccordionHeader>
-              <AccordionPanel>
-                <div className={styles.settingsSectionPart}>
-                  <Toggle
-                    styles={toggleStyles}
-                    label="Enable RU threshold"
-                    onChange={handleOnRUThresholdToggleChange}
-                    defaultChecked={ruThresholdEnabled}
-                  />
-                </div>
-                {ruThresholdEnabled && (
+              <AccordionItem value="4">
+                <AccordionHeader>
+                  <div className={styles.header}>RU Threshold</div>
+                  <InfoTooltip className={styles.headerIcon}>
+                    If a query exceeds a configured RU threshold, the query will be aborted.
+                  </InfoTooltip>
+                </AccordionHeader>
+                <AccordionPanel>
                   <div className={styles.settingsSectionPart}>
-                    <SpinButton
-                      label="RU Threshold (RU)"
-                      labelPosition={Position.top}
-                      defaultValue={(ruThreshold || DefaultRUThreshold).toString()}
-                      min={1}
-                      step={1000}
-                      onChange={handleOnRUThresholdSpinButtonChange}
-                      incrementButtonAriaLabel="Increase value by 1000"
-                      decrementButtonAriaLabel="Decrease value by 1000"
-                      styles={spinButtonStyles}
+                    <Toggle
+                      styles={toggleStyles}
+                      label="Enable RU threshold"
+                      onChange={handleOnRUThresholdToggleChange}
+                      defaultChecked={ruThresholdEnabled}
                     />
                   </div>
-                )}
-              </AccordionPanel>
-            </AccordionItem>
+                  {ruThresholdEnabled && (
+                    <div className={styles.settingsSectionPart}>
+                      <SpinButton
+                        label="RU Threshold (RU)"
+                        labelPosition={Position.top}
+                        defaultValue={(ruThreshold || DefaultRUThreshold).toString()}
+                        min={1}
+                        step={1000}
+                        onChange={handleOnRUThresholdSpinButtonChange}
+                        incrementButtonAriaLabel="Increase value by 1000"
+                        decrementButtonAriaLabel="Decrease value by 1000"
+                        styles={spinButtonStyles}
+                      />
+                    </div>
+                  )}
+                </AccordionPanel>
+              </AccordionItem>
 
-            <AccordionItem value="5">
-              <AccordionHeader><div className={styles.header}>Default Query Results View</div>
-                <InfoTooltip className={styles.headerIcon}>Select the default view to use when displaying query results.</InfoTooltip>
-              </AccordionHeader>
-              <AccordionPanel>
-                <div className={styles.settingsSectionPart}>
-                  <ChoiceGroup
-                    ariaLabelledBy="defaultQueryResultsView"
-                    selectedKey={defaultQueryResultsView}
-                    options={defaultQueryResultsViewOptionList}
-                    styles={choiceButtonStyles}
-                    onChange={handleOnDefaultQueryResultsViewChange}
-                  />
-                </div>
-              </AccordionPanel>
-            </AccordionItem>
-
-          </>)}
+              <AccordionItem value="5">
+                <AccordionHeader>
+                  <div className={styles.header}>Default Query Results View</div>
+                  <InfoTooltip className={styles.headerIcon}>
+                    Select the default view to use when displaying query results.
+                  </InfoTooltip>
+                </AccordionHeader>
+                <AccordionPanel>
+                  <div className={styles.settingsSectionPart}>
+                    <ChoiceGroup
+                      ariaLabelledBy="defaultQueryResultsView"
+                      selectedKey={defaultQueryResultsView}
+                      options={defaultQueryResultsViewOptionList}
+                      styles={choiceButtonStyles}
+                      onChange={handleOnDefaultQueryResultsViewChange}
+                    />
+                  </div>
+                </AccordionPanel>
+              </AccordionItem>
+            </>
+          )}
 
           <AccordionItem value="6">
-            <AccordionHeader><div className={styles.header}> Retry Settings</div>
-              <InfoTooltip className={styles.headerIcon}>Retry policy associated with throttled requests during CosmosDB queries.</InfoTooltip>
+            <AccordionHeader>
+              <div className={styles.header}> Retry Settings</div>
+              <InfoTooltip className={styles.headerIcon}>
+                Retry policy associated with throttled requests during CosmosDB queries.
+              </InfoTooltip>
             </AccordionHeader>
             <AccordionPanel>
               <div className={styles.settingsSectionPart}>
@@ -663,7 +679,9 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                   <legend id="queryRetryAttemptsLabel" className="settingsSectionLabel legendLabel">
                     Max retry attempts
                   </legend>
-                  <InfoTooltip className={styles.headerIcon}>Max number of retries to be performed for a request. Default value 9.</InfoTooltip>
+                  <InfoTooltip className={styles.headerIcon}>
+                    Max number of retries to be performed for a request. Default value 9.
+                  </InfoTooltip>
                 </div>
                 <SpinButton
                   labelPosition={Position.top}
@@ -683,8 +701,8 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                     Fixed retry interval (ms)
                   </legend>
                   <InfoTooltip className={styles.headerIcon}>
-                    Fixed retry interval in milliseconds to wait between each retry ignoring the retryAfter returned as part
-                    of the response. Default value is 0 milliseconds.
+                    Fixed retry interval in milliseconds to wait between each retry ignoring the retryAfter returned as
+                    part of the response. Default value is 0 milliseconds.
                   </InfoTooltip>
                 </div>
                 <SpinButton
@@ -727,7 +745,8 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
           </AccordionItem>
 
           <AccordionItem value="7">
-            <AccordionHeader><div className={styles.header}>Enable container pagination</div>
+            <AccordionHeader>
+              <div className={styles.header}>Enable container pagination</div>
               <InfoTooltip className={styles.headerIcon}>
                 Load 50 containers at a time. Currently, containers are not pulled in alphanumeric order.
               </InfoTooltip>
@@ -749,7 +768,8 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
 
           {shouldShowCrossPartitionOption && (
             <AccordionItem value="8">
-              <AccordionHeader><div className={styles.header}>Enable cross-partition query</div>
+              <AccordionHeader>
+                <div className={styles.header}>Enable cross-partition query</div>
                 <InfoTooltip className={styles.headerIcon}>
                   Send more than one request while executing a query. More than one request is necessary if the query is
                   not scoped to single partition key value.
@@ -773,7 +793,8 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
 
           {shouldShowParallelismOption && (
             <AccordionItem value="9">
-              <AccordionHeader><div className={styles.header}>Max degree of parallelism</div>
+              <AccordionHeader>
+                <div className={styles.header}>Max degree of parallelism</div>
                 <InfoTooltip className={styles.headerIcon}>
                   Gets or sets the number of concurrent operations run client side during parallel query execution. A
                   positive property value limits the number of concurrent operations to the set value. If it is set to
@@ -789,8 +810,12 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                     role="textbox"
                     id="max-degree"
                     value={"" + maxDegreeOfParallelism}
-                    onIncrement={(newValue) => setMaxDegreeOfParallelism(parseInt(newValue) + 1 || maxDegreeOfParallelism)}
-                    onDecrement={(newValue) => setMaxDegreeOfParallelism(parseInt(newValue) - 1 || maxDegreeOfParallelism)}
+                    onIncrement={(newValue) =>
+                      setMaxDegreeOfParallelism(parseInt(newValue) + 1 || maxDegreeOfParallelism)
+                    }
+                    onDecrement={(newValue) =>
+                      setMaxDegreeOfParallelism(parseInt(newValue) - 1 || maxDegreeOfParallelism)
+                    }
                     onValidate={(newValue) => setMaxDegreeOfParallelism(parseInt(newValue) || maxDegreeOfParallelism)}
                     ariaLabel="Max degree of parallelism"
                   />
@@ -801,7 +826,8 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
 
           {shouldShowPriorityLevelOption && (
             <AccordionItem value="10">
-              <AccordionHeader><div className={styles.header}>Priority Level</div>
+              <AccordionHeader>
+                <div className={styles.header}>Priority Level</div>
                 <InfoTooltip className={styles.headerIcon}>
                   Sets the priority level for data-plane requests from Data Explorer when using Priority-Based
                   Execution. If &quot;None&quot; is selected, Data Explorer will not specify priority level, and the
@@ -824,7 +850,8 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
 
           {shouldShowGraphAutoVizOption && (
             <AccordionItem value="11">
-              <AccordionHeader><div className={styles.header}>Display Gremlin query results as:&nbsp;</div>
+              <AccordionHeader>
+                <div className={styles.header}>Display Gremlin query results as:&nbsp;</div>
                 <InfoTooltip className={styles.headerIcon}>
                   Select Graph to automatically visualize the query results as a Graph or JSON to display the results as
                   JSON.
@@ -845,7 +872,8 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
 
           {shouldShowCopilotSampleDBOption && (
             <AccordionItem value="12">
-              <AccordionHeader><div className={styles.header}>Enable sample database</div>
+              <AccordionHeader>
+                <div className={styles.header}>Enable sample database</div>
                 <InfoTooltip className={styles.headerIcon}>
                   This is a sample database and collection with synthetic product data you can use to explore using
                   NoSQL queries and Query Advisor. This will appear as another database in the Data Explorer UI, and is
@@ -904,6 +932,6 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
           </div>
         </div>
       </div>
-    </RightPaneForm >
+    </RightPaneForm>
   );
 };

--- a/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
+++ b/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
@@ -13,7 +13,7 @@ import {
   Toggle,
   TooltipHost,
 } from "@fluentui/react";
-import { makeStyles } from "@fluentui/react-components";
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel, makeStyles } from "@fluentui/react-components";
 import { AuthType } from "AuthType";
 import * as Constants from "Common/Constants";
 import { SplitterDirection } from "Common/Splitter";
@@ -58,6 +58,23 @@ const useStyles = makeStyles({
   bulletList: {
     listStyleType: "disc",
     paddingLeft: "20px",
+  },
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    height: "100%",
+  },
+  firstItem: {
+    flex: "1",
+  },
+  header: {
+    marginRight: "5px",
+  },
+  headerIcon: {
+    paddingTop: "4px",
+  },
+  settingsSectionPart: {
+    paddingLeft: "15px",
   },
 });
 
@@ -254,8 +271,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
 
     if (shouldShowGraphAutoVizOption) {
       logConsoleInfo(
-        `Graph result will be displayed as ${
-          LocalStorageUtility.getEntryBoolean(StorageKey.IsGraphAutoVizDisabled) ? "JSON" : "Graph"
+        `Graph result will be displayed as ${LocalStorageUtility.getEntryBoolean(StorageKey.IsGraphAutoVizDisabled) ? "JSON" : "Graph"
         }`,
       );
     }
@@ -444,82 +460,82 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
 
   return (
     <RightPaneForm {...genericPaneProps}>
-      <div className="paneMainContent">
-        {shouldShowQueryPageOptions && (
-          <div className="settingsSection">
-            <div className="settingsSectionPart">
-              <fieldset>
-                <legend id="pageOptions" className="settingsSectionLabel legendLabel">
-                  Page Options
-                </legend>
-                <InfoTooltip>
+      <div className={`paneMainContent ${styles.container}`}>
+        <Accordion className={styles.firstItem}>
+          {shouldShowQueryPageOptions && (
+            <AccordionItem value="1">
+              <AccordionHeader>
+                <div className={styles.header}>Page Options</div>
+                <InfoTooltip className={styles.headerIcon}>
                   Choose Custom to specify a fixed amount of query results to show, or choose Unlimited to show as many
                   query results per page.
                 </InfoTooltip>
-                <ChoiceGroup
-                  ariaLabelledBy="pageOptions"
-                  selectedKey={pageOption}
-                  options={pageOptionList}
-                  styles={choiceButtonStyles}
-                  onChange={handleOnPageOptionChange}
-                />
-              </fieldset>
-            </div>
-            <div className="tabs settingsSectionPart">
-              {isCustomPageOptionSelected() && (
-                <div className="tabcontent">
-                  <div className="settingsSectionLabel">
-                    Query results per page
-                    <InfoTooltip>Enter the number of query results that should be shown per page.</InfoTooltip>
-                  </div>
-
-                  <SpinButton
-                    ariaLabel="Custom query items per page"
-                    value={"" + customItemPerPage}
-                    onIncrement={(newValue) => {
-                      setCustomItemPerPage(parseInt(newValue) + 1 || customItemPerPage);
-                    }}
-                    onDecrement={(newValue) => setCustomItemPerPage(parseInt(newValue) - 1 || customItemPerPage)}
-                    onValidate={(newValue) => setCustomItemPerPage(parseInt(newValue) || customItemPerPage)}
-                    min={1}
-                    step={1}
-                    className="textfontclr"
-                    incrementButtonAriaLabel="Increase value by 1"
-                    decrementButtonAriaLabel="Decrease value by 1"
+              </AccordionHeader>
+              <AccordionPanel>
+                <div className={styles.settingsSectionPart}>
+                  <ChoiceGroup
+                    ariaLabelledBy="pageOptions"
+                    selectedKey={pageOption}
+                    options={pageOptionList}
+                    styles={choiceButtonStyles}
+                    onChange={handleOnPageOptionChange}
                   />
                 </div>
-              )}
-            </div>
-          </div>
-        )}
-        {userContext.apiType === "SQL" &&
-          userContext.authType === AuthType.AAD &&
-          configContext.platform !== Platform.Fabric && (
-            <>
-              <div className="settingsSection">
-                <div className="settingsSectionPart">
-                  <fieldset>
-                    <legend id="enableDataPlaneRBACOptions" className="settingsSectionLabel legendLabel">
-                      Enable Entra ID RBAC
-                    </legend>
-                    <TooltipHost
-                      content={
-                        <>
-                          Choose Automatic to enable Entra ID RBAC automatically. True/False to force enable/disable
-                          Entra ID RBAC.
-                          <a
-                            href="https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-rbac#use-data-explorer"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            {" "}
-                            Learn more{" "}
-                          </a>
-                        </>
-                      }
-                    >
-                      <Icon iconName="Info" ariaLabel="Info tooltip" className="panelInfoIcon" tabIndex={0} />
-                    </TooltipHost>
+                <div className={`tabs ${styles.settingsSectionPart}`}>
+                  {isCustomPageOptionSelected() && (
+                    <div className="tabcontent">
+                      <div className="settingsSectionLabel">
+                        Query results per page
+                        <InfoTooltip className={styles.headerIcon}>Enter the number of query results that should be shown per page.</InfoTooltip>
+                      </div>
+
+                      <SpinButton
+                        ariaLabel="Custom query items per page"
+                        value={"" + customItemPerPage}
+                        onIncrement={(newValue) => {
+                          setCustomItemPerPage(parseInt(newValue) + 1 || customItemPerPage);
+                        }}
+                        onDecrement={(newValue) => setCustomItemPerPage(parseInt(newValue) - 1 || customItemPerPage)}
+                        onValidate={(newValue) => setCustomItemPerPage(parseInt(newValue) || customItemPerPage)}
+                        min={1}
+                        step={1}
+                        className="textfontclr"
+                        incrementButtonAriaLabel="Increase value by 1"
+                        decrementButtonAriaLabel="Decrease value by 1"
+                      />
+                    </div>
+                  )}
+                </div>
+              </AccordionPanel>
+            </AccordionItem>
+          )}
+          {userContext.apiType === "SQL" &&
+            userContext.authType === AuthType.AAD &&
+            configContext.platform !== Platform.Fabric && (
+              <AccordionItem value="2">
+                <AccordionHeader>
+                  <div className={styles.header}>Enable Entra ID RBAC</div>
+                  <TooltipHost
+                    content={
+                      <>
+                        Choose Automatic to enable Entra ID RBAC automatically. True/False to force enable/disable
+                        Entra ID RBAC.
+                        <a
+                          href="https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-rbac#use-data-explorer"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {" "}
+                          Learn more{" "}
+                        </a>
+                      </>
+                    }
+                  >
+                    <Icon iconName="Info" ariaLabel="Info tooltip" className={`panelInfoIcon ${styles.headerIcon}`} tabIndex={0} />
+                  </TooltipHost>
+                </AccordionHeader>
+                <AccordionPanel>
+                  <div className={styles.settingsSectionPart}>
                     {showDataPlaneRBACWarning && configContext.platform === Platform.Portal && (
                       <MessageBar
                         messageBarType={MessageBarType.warning}
@@ -538,58 +554,23 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                       selectedKey={enableDataPlaneRBACOption}
                       onChange={handleOnDataPlaneRBACOptionChange}
                     />
-                  </fieldset>
-                </div>
-              </div>
-            </>
-          )}
-        {userContext.apiType === "SQL" && (
-          <>
-            <div className="settingsSection">
-              <div className="settingsSectionPart">
-                <div>
-                  <legend id="ruThresholdLabel" className="settingsSectionLabel legendLabel">
-                    RU Threshold
-                  </legend>
-                  <InfoTooltip>If a query exceeds a configured RU threshold, the query will be aborted.</InfoTooltip>
-                </div>
-                <div>
-                  <Toggle
-                    styles={toggleStyles}
-                    label="Enable RU threshold"
-                    onChange={handleOnRUThresholdToggleChange}
-                    defaultChecked={ruThresholdEnabled}
-                  />
-                </div>
-                {ruThresholdEnabled && (
-                  <div>
-                    <SpinButton
-                      label="RU Threshold (RU)"
-                      labelPosition={Position.top}
-                      defaultValue={(ruThreshold || DefaultRUThreshold).toString()}
-                      min={1}
-                      step={1000}
-                      onChange={handleOnRUThresholdSpinButtonChange}
-                      incrementButtonAriaLabel="Increase value by 1000"
-                      decrementButtonAriaLabel="Decrease value by 1000"
-                      styles={spinButtonStyles}
-                    />
                   </div>
-                )}
-              </div>
-            </div>
-            <div className="settingsSection">
-              <div className="settingsSectionPart">
-                <div>
-                  <legend id="queryTimeoutLabel" className="settingsSectionLabel legendLabel">
-                    Query Timeout
-                  </legend>
-                  <InfoTooltip>
-                    When a query reaches a specified time limit, a popup with an option to cancel the query will show
-                    unless automatic cancellation has been enabled
-                  </InfoTooltip>
-                </div>
-                <div>
+                </AccordionPanel>
+              </AccordionItem>
+            )}
+
+
+          {userContext.apiType === "SQL" && (<>
+            <AccordionItem value="3">
+              <AccordionHeader>
+                <div className={styles.header}>Query Timeout</div>
+                <InfoTooltip className={styles.headerIcon}>
+                  When a query reaches a specified time limit, a popup with an option to cancel the query will show
+                  unless automatic cancellation has been enabled
+                </InfoTooltip>
+              </AccordionHeader>
+              <AccordionPanel>
+                <div className={styles.settingsSectionPart}>
                   <Toggle
                     styles={toggleStyles}
                     label="Enable query timeout"
@@ -598,7 +579,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                   />
                 </div>
                 {queryTimeoutEnabled && (
-                  <div>
+                  <div className={styles.settingsSectionPart}>
                     <SpinButton
                       label="Query timeout (ms)"
                       labelPosition={Position.top}
@@ -618,17 +599,47 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                     />
                   </div>
                 )}
-              </div>
-            </div>
-            <div className="settingsSection">
-              <div className="settingsSectionPart">
-                <div>
-                  <legend id="defaultQueryResultsView" className="settingsSectionLabel legendLabel">
-                    Default Query Results View
-                  </legend>
-                  <InfoTooltip>Select the default view to use when displaying query results.</InfoTooltip>
+              </AccordionPanel>
+            </AccordionItem>
+
+            <AccordionItem value="4">
+              <AccordionHeader>
+                <div className={styles.header}>RU Threshold</div>
+                <InfoTooltip className={styles.headerIcon}>If a query exceeds a configured RU threshold, the query will be aborted.</InfoTooltip>
+              </AccordionHeader>
+              <AccordionPanel>
+                <div className={styles.settingsSectionPart}>
+                  <Toggle
+                    styles={toggleStyles}
+                    label="Enable RU threshold"
+                    onChange={handleOnRUThresholdToggleChange}
+                    defaultChecked={ruThresholdEnabled}
+                  />
                 </div>
-                <div>
+                {ruThresholdEnabled && (
+                  <div className={styles.settingsSectionPart}>
+                    <SpinButton
+                      label="RU Threshold (RU)"
+                      labelPosition={Position.top}
+                      defaultValue={(ruThreshold || DefaultRUThreshold).toString()}
+                      min={1}
+                      step={1000}
+                      onChange={handleOnRUThresholdSpinButtonChange}
+                      incrementButtonAriaLabel="Increase value by 1000"
+                      decrementButtonAriaLabel="Decrease value by 1000"
+                      styles={spinButtonStyles}
+                    />
+                  </div>
+                )}
+              </AccordionPanel>
+            </AccordionItem>
+
+            <AccordionItem value="5">
+              <AccordionHeader><div className={styles.header}>Default Query Results View</div>
+                <InfoTooltip className={styles.headerIcon}>Select the default view to use when displaying query results.</InfoTooltip>
+              </AccordionHeader>
+              <AccordionPanel>
+                <div className={styles.settingsSectionPart}>
                   <ChoiceGroup
                     ariaLabelledBy="defaultQueryResultsView"
                     selectedKey={defaultQueryResultsView}
@@ -637,217 +648,227 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                     onChange={handleOnDefaultQueryResultsViewChange}
                   />
                 </div>
+              </AccordionPanel>
+            </AccordionItem>
+
+          </>)}
+
+          <AccordionItem value="6">
+            <AccordionHeader><div className={styles.header}> Retry Settings</div>
+              <InfoTooltip className={styles.headerIcon}>Retry policy associated with throttled requests during CosmosDB queries.</InfoTooltip>
+            </AccordionHeader>
+            <AccordionPanel>
+              <div className={styles.settingsSectionPart}>
+                <div>
+                  <legend id="queryRetryAttemptsLabel" className="settingsSectionLabel legendLabel">
+                    Max retry attempts
+                  </legend>
+                  <InfoTooltip className={styles.headerIcon}>Max number of retries to be performed for a request. Default value 9.</InfoTooltip>
+                </div>
+                <SpinButton
+                  labelPosition={Position.top}
+                  min={1}
+                  step={1}
+                  value={"" + retryAttempts}
+                  onChange={handleOnQueryRetryAttemptsSpinButtonChange}
+                  incrementButtonAriaLabel="Increase value by 1"
+                  decrementButtonAriaLabel="Decrease value by 1"
+                  onIncrement={(newValue) => setRetryAttempts(parseInt(newValue) + 1 || retryAttempts)}
+                  onDecrement={(newValue) => setRetryAttempts(parseInt(newValue) - 1 || retryAttempts)}
+                  onValidate={(newValue) => setRetryAttempts(parseInt(newValue) || retryAttempts)}
+                  styles={spinButtonStyles}
+                />
+                <div>
+                  <legend id="queryRetryAttemptsLabel" className="settingsSectionLabel legendLabel">
+                    Fixed retry interval (ms)
+                  </legend>
+                  <InfoTooltip className={styles.headerIcon}>
+                    Fixed retry interval in milliseconds to wait between each retry ignoring the retryAfter returned as part
+                    of the response. Default value is 0 milliseconds.
+                  </InfoTooltip>
+                </div>
+                <SpinButton
+                  labelPosition={Position.top}
+                  min={1000}
+                  step={1000}
+                  value={"" + retryInterval}
+                  onChange={handleOnRetryIntervalSpinButtonChange}
+                  incrementButtonAriaLabel="Increase value by 1000"
+                  decrementButtonAriaLabel="Decrease value by 1000"
+                  onIncrement={(newValue) => setRetryInterval(parseInt(newValue) + 1000 || retryInterval)}
+                  onDecrement={(newValue) => setRetryInterval(parseInt(newValue) - 1000 || retryInterval)}
+                  onValidate={(newValue) => setRetryInterval(parseInt(newValue) || retryInterval)}
+                  styles={spinButtonStyles}
+                />
+                <div>
+                  <legend id="queryRetryAttemptsLabel" className="settingsSectionLabel legendLabel">
+                    Max wait time (s)
+                  </legend>
+                  <InfoTooltip className={styles.headerIcon}>
+                    Max wait time in seconds to wait for a request while the retries are happening. Default value 30
+                    seconds.
+                  </InfoTooltip>
+                </div>
+                <SpinButton
+                  labelPosition={Position.top}
+                  min={1}
+                  step={1}
+                  value={"" + MaxWaitTimeInSeconds}
+                  onChange={handleOnMaxWaitTimeSpinButtonChange}
+                  incrementButtonAriaLabel="Increase value by 1"
+                  decrementButtonAriaLabel="Decrease value by 1"
+                  onIncrement={(newValue) => setMaxWaitTimeInSeconds(parseInt(newValue) + 1 || MaxWaitTimeInSeconds)}
+                  onDecrement={(newValue) => setMaxWaitTimeInSeconds(parseInt(newValue) - 1 || MaxWaitTimeInSeconds)}
+                  onValidate={(newValue) => setMaxWaitTimeInSeconds(parseInt(newValue) || MaxWaitTimeInSeconds)}
+                  styles={spinButtonStyles}
+                />
               </div>
-            </div>
-          </>
-        )}
-        <div className="settingsSection">
-          <div className="settingsSectionPart">
-            <div className="settingsSectionLabel">
-              Retry Settings
-              <InfoTooltip>Retry policy associated with throttled requests during CosmosDB queries.</InfoTooltip>
-            </div>
-            <div>
-              <legend id="queryRetryAttemptsLabel" className="settingsSectionLabel legendLabel">
-                Max retry attempts
-              </legend>
-              <InfoTooltip>Max number of retries to be performed for a request. Default value 9.</InfoTooltip>
-            </div>
-            <SpinButton
-              labelPosition={Position.top}
-              min={1}
-              step={1}
-              value={"" + retryAttempts}
-              onChange={handleOnQueryRetryAttemptsSpinButtonChange}
-              incrementButtonAriaLabel="Increase value by 1"
-              decrementButtonAriaLabel="Decrease value by 1"
-              onIncrement={(newValue) => setRetryAttempts(parseInt(newValue) + 1 || retryAttempts)}
-              onDecrement={(newValue) => setRetryAttempts(parseInt(newValue) - 1 || retryAttempts)}
-              onValidate={(newValue) => setRetryAttempts(parseInt(newValue) || retryAttempts)}
-              styles={spinButtonStyles}
-            />
-            <div>
-              <legend id="queryRetryAttemptsLabel" className="settingsSectionLabel legendLabel">
-                Fixed retry interval (ms)
-              </legend>
-              <InfoTooltip>
-                Fixed retry interval in milliseconds to wait between each retry ignoring the retryAfter returned as part
-                of the response. Default value is 0 milliseconds.
-              </InfoTooltip>
-            </div>
-            <SpinButton
-              labelPosition={Position.top}
-              min={1000}
-              step={1000}
-              value={"" + retryInterval}
-              onChange={handleOnRetryIntervalSpinButtonChange}
-              incrementButtonAriaLabel="Increase value by 1000"
-              decrementButtonAriaLabel="Decrease value by 1000"
-              onIncrement={(newValue) => setRetryInterval(parseInt(newValue) + 1000 || retryInterval)}
-              onDecrement={(newValue) => setRetryInterval(parseInt(newValue) - 1000 || retryInterval)}
-              onValidate={(newValue) => setRetryInterval(parseInt(newValue) || retryInterval)}
-              styles={spinButtonStyles}
-            />
-            <div>
-              <legend id="queryRetryAttemptsLabel" className="settingsSectionLabel legendLabel">
-                Max wait time (s)
-              </legend>
-              <InfoTooltip>
-                Max wait time in seconds to wait for a request while the retries are happening. Default value 30
-                seconds.
-              </InfoTooltip>
-            </div>
-            <SpinButton
-              labelPosition={Position.top}
-              min={1}
-              step={1}
-              value={"" + MaxWaitTimeInSeconds}
-              onChange={handleOnMaxWaitTimeSpinButtonChange}
-              incrementButtonAriaLabel="Increase value by 1"
-              decrementButtonAriaLabel="Decrease value by 1"
-              onIncrement={(newValue) => setMaxWaitTimeInSeconds(parseInt(newValue) + 1 || MaxWaitTimeInSeconds)}
-              onDecrement={(newValue) => setMaxWaitTimeInSeconds(parseInt(newValue) - 1 || MaxWaitTimeInSeconds)}
-              onValidate={(newValue) => setMaxWaitTimeInSeconds(parseInt(newValue) || MaxWaitTimeInSeconds)}
-              styles={spinButtonStyles}
-            />
-          </div>
-        </div>
-        <div className="settingsSection">
-          <div className="settingsSectionPart settingsSectionInlineCheckbox">
-            <div className="settingsSectionLabel">
-              Enable container pagination
-              <InfoTooltip>
+            </AccordionPanel>
+          </AccordionItem>
+
+          <AccordionItem value="7">
+            <AccordionHeader><div className={styles.header}>Enable container pagination</div>
+              <InfoTooltip className={styles.headerIcon}>
                 Load 50 containers at a time. Currently, containers are not pulled in alphanumeric order.
               </InfoTooltip>
-            </div>
-            <Checkbox
-              styles={{
-                label: { padding: 0 },
-              }}
-              className="padding"
-              ariaLabel="Enable container pagination"
-              checked={containerPaginationEnabled}
-              onChange={() => setContainerPaginationEnabled(!containerPaginationEnabled)}
-            />
-          </div>
-        </div>
-        {shouldShowCrossPartitionOption && (
-          <div className="settingsSection">
-            <div className="settingsSectionPart settingsSectionInlineCheckbox">
-              <div className="settingsSectionLabel">
-                Enable cross-partition query
-                <InfoTooltip>
+            </AccordionHeader>
+            <AccordionPanel>
+              <div className={styles.settingsSectionPart}>
+                <Checkbox
+                  styles={{
+                    label: { padding: 0 },
+                  }}
+                  className="padding"
+                  ariaLabel="Enable container pagination"
+                  checked={containerPaginationEnabled}
+                  onChange={() => setContainerPaginationEnabled(!containerPaginationEnabled)}
+                />
+              </div>
+            </AccordionPanel>
+          </AccordionItem>
+
+          {shouldShowCrossPartitionOption && (
+            <AccordionItem value="8">
+              <AccordionHeader><div className={styles.header}>Enable cross-partition query</div>
+                <InfoTooltip className={styles.headerIcon}>
                   Send more than one request while executing a query. More than one request is necessary if the query is
                   not scoped to single partition key value.
                 </InfoTooltip>
-              </div>
+              </AccordionHeader>
+              <AccordionPanel>
+                <div className={styles.settingsSectionPart}>
+                  <Checkbox
+                    styles={{
+                      label: { padding: 0 },
+                    }}
+                    className="padding"
+                    ariaLabel="Enable cross partition query"
+                    checked={crossPartitionQueryEnabled}
+                    onChange={() => setCrossPartitionQueryEnabled(!crossPartitionQueryEnabled)}
+                  />
+                </div>
+              </AccordionPanel>
+            </AccordionItem>
+          )}
 
-              <Checkbox
-                styles={{
-                  label: { padding: 0 },
-                }}
-                className="padding"
-                ariaLabel="Enable cross partition query"
-                checked={crossPartitionQueryEnabled}
-                onChange={() => setCrossPartitionQueryEnabled(!crossPartitionQueryEnabled)}
-              />
-            </div>
-          </div>
-        )}
-        {shouldShowParallelismOption && (
-          <div className="settingsSection">
-            <div className="settingsSectionPart">
-              <div className="settingsSectionLabel">
-                Max degree of parallelism
-                <InfoTooltip>
+          {shouldShowParallelismOption && (
+            <AccordionItem value="9">
+              <AccordionHeader><div className={styles.header}>Max degree of parallelism</div>
+                <InfoTooltip className={styles.headerIcon}>
                   Gets or sets the number of concurrent operations run client side during parallel query execution. A
                   positive property value limits the number of concurrent operations to the set value. If it is set to
                   less than 0, the system automatically decides the number of concurrent operations to run.
                 </InfoTooltip>
-              </div>
+              </AccordionHeader>
+              <AccordionPanel>
+                <div className={styles.settingsSectionPart}>
+                  <SpinButton
+                    min={-1}
+                    step={1}
+                    className="textfontclr"
+                    role="textbox"
+                    id="max-degree"
+                    value={"" + maxDegreeOfParallelism}
+                    onIncrement={(newValue) => setMaxDegreeOfParallelism(parseInt(newValue) + 1 || maxDegreeOfParallelism)}
+                    onDecrement={(newValue) => setMaxDegreeOfParallelism(parseInt(newValue) - 1 || maxDegreeOfParallelism)}
+                    onValidate={(newValue) => setMaxDegreeOfParallelism(parseInt(newValue) || maxDegreeOfParallelism)}
+                    ariaLabel="Max degree of parallelism"
+                  />
+                </div>
+              </AccordionPanel>
+            </AccordionItem>
+          )}
 
-              <SpinButton
-                min={-1}
-                step={1}
-                className="textfontclr"
-                role="textbox"
-                id="max-degree"
-                value={"" + maxDegreeOfParallelism}
-                onIncrement={(newValue) => setMaxDegreeOfParallelism(parseInt(newValue) + 1 || maxDegreeOfParallelism)}
-                onDecrement={(newValue) => setMaxDegreeOfParallelism(parseInt(newValue) - 1 || maxDegreeOfParallelism)}
-                onValidate={(newValue) => setMaxDegreeOfParallelism(parseInt(newValue) || maxDegreeOfParallelism)}
-                ariaLabel="Max degree of parallelism"
-              />
-            </div>
-          </div>
-        )}
-        {shouldShowPriorityLevelOption && (
-          <div className="settingsSection">
-            <div className="settingsSectionPart">
-              <fieldset>
-                <legend id="priorityLevel" className="settingsSectionLabel legendLabel">
-                  Priority Level
-                </legend>
-                <InfoTooltip>
+          {shouldShowPriorityLevelOption && (
+            <AccordionItem value="10">
+              <AccordionHeader><div className={styles.header}>Priority Level</div>
+                <InfoTooltip className={styles.headerIcon}>
                   Sets the priority level for data-plane requests from Data Explorer when using Priority-Based
                   Execution. If &quot;None&quot; is selected, Data Explorer will not specify priority level, and the
                   server-side default priority level will be used.
                 </InfoTooltip>
-                <ChoiceGroup
-                  ariaLabelledBy="priorityLevel"
-                  selectedKey={priorityLevel}
-                  options={priorityLevelOptionList}
-                  styles={choiceButtonStyles}
-                  onChange={handleOnPriorityLevelOptionChange}
-                />
-              </fieldset>
-            </div>
-          </div>
-        )}
-        {shouldShowGraphAutoVizOption && (
-          <div className="settingsSection">
-            <div className="settingsSectionPart">
-              <div className="settingsSectionLabel">
-                Display Gremlin query results as:&nbsp;
-                <InfoTooltip>
+              </AccordionHeader>
+              <AccordionPanel>
+                <div className={styles.settingsSectionPart}>
+                  <ChoiceGroup
+                    ariaLabelledBy="priorityLevel"
+                    selectedKey={priorityLevel}
+                    options={priorityLevelOptionList}
+                    styles={choiceButtonStyles}
+                    onChange={handleOnPriorityLevelOptionChange}
+                  />
+                </div>
+              </AccordionPanel>
+            </AccordionItem>
+          )}
+
+          {shouldShowGraphAutoVizOption && (
+            <AccordionItem value="11">
+              <AccordionHeader><div className={styles.header}>Display Gremlin query results as:&nbsp;</div>
+                <InfoTooltip className={styles.headerIcon}>
                   Select Graph to automatically visualize the query results as a Graph or JSON to display the results as
                   JSON.
                 </InfoTooltip>
-              </div>
+              </AccordionHeader>
+              <AccordionPanel>
+                <div className={styles.settingsSectionPart}>
+                  <ChoiceGroup
+                    selectedKey={graphAutoVizDisabled}
+                    options={graphAutoOptionList}
+                    onChange={handleOnGremlinChange}
+                    aria-label="Graph Auto-visualization"
+                  />
+                </div>
+              </AccordionPanel>
+            </AccordionItem>
+          )}
 
-              <ChoiceGroup
-                selectedKey={graphAutoVizDisabled}
-                options={graphAutoOptionList}
-                onChange={handleOnGremlinChange}
-                aria-label="Graph Auto-visualization"
-              />
-            </div>
-          </div>
-        )}
-        {shouldShowCopilotSampleDBOption && (
-          <div className="settingsSection">
-            <div className="settingsSectionPart settingsSectionInlineCheckbox">
-              <div className="settingsSectionLabel">
-                Enable sample database
-                <InfoTooltip>
+          {shouldShowCopilotSampleDBOption && (
+            <AccordionItem value="12">
+              <AccordionHeader><div className={styles.header}>Enable sample database</div>
+                <InfoTooltip className={styles.headerIcon}>
                   This is a sample database and collection with synthetic product data you can use to explore using
                   NoSQL queries and Query Advisor. This will appear as another database in the Data Explorer UI, and is
                   created by, and maintained by Microsoft at no cost to you.
                 </InfoTooltip>
-              </div>
+              </AccordionHeader>
+              <AccordionPanel>
+                <div className={styles.settingsSectionPart}>
+                  <Checkbox
+                    styles={{
+                      label: { padding: 0 },
+                    }}
+                    className="padding"
+                    ariaLabel="Enable sample db for Query Advisor"
+                    checked={copilotSampleDBEnabled}
+                    onChange={handleSampleDatabaseChange}
+                  />
+                </div>
+              </AccordionPanel>
+            </AccordionItem>
+          )}
+        </Accordion>
 
-              <Checkbox
-                styles={{
-                  label: { padding: 0 },
-                }}
-                className="padding"
-                ariaLabel="Enable sample db for Query Advisor"
-                checked={copilotSampleDBEnabled}
-                onChange={handleSampleDatabaseChange}
-              />
-            </div>
-          </div>
-        )}
         <div className="settingsSection">
           <div className="settingsSectionPart">
             <DefaultButton
@@ -883,6 +904,6 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
           </div>
         </div>
       </div>
-    </RightPaneForm>
+    </RightPaneForm >
   );
 };

--- a/src/Explorer/Panes/SettingsPane/__snapshots__/SettingsPane.test.tsx.snap
+++ b/src/Explorer/Panes/SettingsPane/__snapshots__/SettingsPane.test.tsx.snap
@@ -8,483 +8,524 @@ exports[`Settings Pane should render Default properly 1`] = `
   submitButtonText="Apply"
 >
   <div
-    className="paneMainContent"
+    className="paneMainContent ___133e6fg_0000000 f22iagw f1vx9l62 f1l02sjl"
   >
-    <div
-      className="settingsSection"
+    <Accordion
+      className="___1uf6361_0000000 fz7g6wx"
     >
-      <div
-        className="settingsSectionPart"
+      <AccordionItem
+        value="1"
       >
-        <fieldset>
-          <legend
-            className="settingsSectionLabel legendLabel"
-            id="pageOptions"
+        <AccordionHeader>
+          <div
+            className="___15c001r_0000000 fq02s40"
           >
             Page Options
-          </legend>
-          <InfoTooltip>
+          </div>
+          <InfoTooltip
+            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+          >
             Choose Custom to specify a fixed amount of query results to show, or choose Unlimited to show as many query results per page.
           </InfoTooltip>
-          <StyledChoiceGroup
-            ariaLabelledBy="pageOptions"
-            onChange={[Function]}
-            options={
-              [
-                {
-                  "key": "custom",
-                  "text": "Custom",
-                },
-                {
-                  "key": "unlimited",
-                  "text": "Unlimited",
-                },
-              ]
-            }
-            selectedKey="custom"
-            styles={
-              {
-                "flexContainer": [
+        </AccordionHeader>
+        <AccordionPanel>
+          <div
+            className="___1dfa554_0000000 fo7qwa0"
+          >
+            <StyledChoiceGroup
+              ariaLabelledBy="pageOptions"
+              onChange={[Function]}
+              options={
+                [
                   {
-                    "selectors": {
-                      ".ms-ChoiceField": {
-                        "marginTop": 0,
-                      },
-                      ".ms-ChoiceField-wrapper label": {
-                        "fontSize": 12,
-                        "paddingTop": 0,
-                      },
-                      ".ms-ChoiceFieldGroup root-133": {
-                        "clear": "both",
+                    "key": "custom",
+                    "text": "Custom",
+                  },
+                  {
+                    "key": "unlimited",
+                    "text": "Unlimited",
+                  },
+                ]
+              }
+              selectedKey="custom"
+              styles={
+                {
+                  "flexContainer": [
+                    {
+                      "selectors": {
+                        ".ms-ChoiceField": {
+                          "marginTop": 0,
+                        },
+                        ".ms-ChoiceField-wrapper label": {
+                          "fontSize": 12,
+                          "paddingTop": 0,
+                        },
+                        ".ms-ChoiceFieldGroup root-133": {
+                          "clear": "both",
+                        },
                       },
                     },
+                  ],
+                  "root": {
+                    "clear": "both",
                   },
-                ],
-                "root": {
-                  "clear": "both",
-                },
+                }
               }
-            }
-          />
-        </fieldset>
-      </div>
-      <div
-        className="tabs settingsSectionPart"
-      >
-        <div
-          className="tabcontent"
-        >
-          <div
-            className="settingsSectionLabel"
-          >
-            Query results per page
-            <InfoTooltip>
-              Enter the number of query results that should be shown per page.
-            </InfoTooltip>
+            />
           </div>
-          <StyledSpinButton
-            ariaLabel="Custom query items per page"
-            className="textfontclr"
-            decrementButtonAriaLabel="Decrease value by 1"
-            incrementButtonAriaLabel="Increase value by 1"
-            min={1}
-            onDecrement={[Function]}
-            onIncrement={[Function]}
-            onValidate={[Function]}
-            step={1}
-            value="0"
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      className="settingsSection"
-    >
-      <div
-        className="settingsSectionPart"
-      >
-        <div>
-          <legend
-            className="settingsSectionLabel legendLabel"
-            id="ruThresholdLabel"
+          <div
+            className="tabs ___1dfa554_0000000 fo7qwa0"
           >
-            RU Threshold
-          </legend>
-          <InfoTooltip>
-            If a query exceeds a configured RU threshold, the query will be aborted.
-          </InfoTooltip>
-        </div>
-        <div>
-          <StyledToggleBase
-            defaultChecked={true}
-            label="Enable RU threshold"
-            onChange={[Function]}
-            styles={
-              {
-                "container": {},
-                "label": {
-                  "display": "block",
-                  "fontSize": 12,
-                  "fontWeight": 400,
-                },
-                "pill": {},
-                "root": {},
-                "text": {},
-                "thumb": {},
-              }
-            }
-          />
-        </div>
-        <div>
-          <StyledSpinButton
-            decrementButtonAriaLabel="Decrease value by 1000"
-            defaultValue="5000"
-            incrementButtonAriaLabel="Increase value by 1000"
-            label="RU Threshold (RU)"
-            labelPosition={0}
-            min={1}
-            onChange={[Function]}
-            step={1000}
-            styles={
-              {
-                "arrowButtonsContainer": {},
-                "icon": {},
-                "input": {},
-                "label": {
-                  "fontSize": 12,
-                  "fontWeight": 400,
-                },
-                "labelWrapper": {},
-                "root": {
-                  "paddingBottom": 10,
-                },
-                "spinButtonWrapper": {},
-              }
-            }
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      className="settingsSection"
-    >
-      <div
-        className="settingsSectionPart"
+            <div
+              className="tabcontent"
+            >
+              <div
+                className="settingsSectionLabel"
+              >
+                Query results per page
+                <InfoTooltip
+                  className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+                >
+                  Enter the number of query results that should be shown per page.
+                </InfoTooltip>
+              </div>
+              <StyledSpinButton
+                ariaLabel="Custom query items per page"
+                className="textfontclr"
+                decrementButtonAriaLabel="Decrease value by 1"
+                incrementButtonAriaLabel="Increase value by 1"
+                min={1}
+                onDecrement={[Function]}
+                onIncrement={[Function]}
+                onValidate={[Function]}
+                step={1}
+                value="0"
+              />
+            </div>
+          </div>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem
+        value="3"
       >
-        <div>
-          <legend
-            className="settingsSectionLabel legendLabel"
-            id="queryTimeoutLabel"
+        <AccordionHeader>
+          <div
+            className="___15c001r_0000000 fq02s40"
           >
             Query Timeout
-          </legend>
-          <InfoTooltip>
+          </div>
+          <InfoTooltip
+            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+          >
             When a query reaches a specified time limit, a popup with an option to cancel the query will show unless automatic cancellation has been enabled
           </InfoTooltip>
-        </div>
-        <div>
-          <StyledToggleBase
-            defaultChecked={false}
-            label="Enable query timeout"
-            onChange={[Function]}
-            styles={
-              {
-                "container": {},
-                "label": {
-                  "display": "block",
-                  "fontSize": 12,
-                  "fontWeight": 400,
-                },
-                "pill": {},
-                "root": {},
-                "text": {},
-                "thumb": {},
+        </AccordionHeader>
+        <AccordionPanel>
+          <div
+            className="___1dfa554_0000000 fo7qwa0"
+          >
+            <StyledToggleBase
+              defaultChecked={false}
+              label="Enable query timeout"
+              onChange={[Function]}
+              styles={
+                {
+                  "container": {},
+                  "label": {
+                    "display": "block",
+                    "fontSize": 12,
+                    "fontWeight": 400,
+                  },
+                  "pill": {},
+                  "root": {},
+                  "text": {},
+                  "thumb": {},
+                }
               }
-            }
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      className="settingsSection"
-    >
-      <div
-        className="settingsSectionPart"
+            />
+          </div>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem
+        value="4"
       >
-        <div>
-          <legend
-            className="settingsSectionLabel legendLabel"
-            id="defaultQueryResultsView"
+        <AccordionHeader>
+          <div
+            className="___15c001r_0000000 fq02s40"
+          >
+            RU Threshold
+          </div>
+          <InfoTooltip
+            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+          >
+            If a query exceeds a configured RU threshold, the query will be aborted.
+          </InfoTooltip>
+        </AccordionHeader>
+        <AccordionPanel>
+          <div
+            className="___1dfa554_0000000 fo7qwa0"
+          >
+            <StyledToggleBase
+              defaultChecked={true}
+              label="Enable RU threshold"
+              onChange={[Function]}
+              styles={
+                {
+                  "container": {},
+                  "label": {
+                    "display": "block",
+                    "fontSize": 12,
+                    "fontWeight": 400,
+                  },
+                  "pill": {},
+                  "root": {},
+                  "text": {},
+                  "thumb": {},
+                }
+              }
+            />
+          </div>
+          <div
+            className="___1dfa554_0000000 fo7qwa0"
+          >
+            <StyledSpinButton
+              decrementButtonAriaLabel="Decrease value by 1000"
+              defaultValue="5000"
+              incrementButtonAriaLabel="Increase value by 1000"
+              label="RU Threshold (RU)"
+              labelPosition={0}
+              min={1}
+              onChange={[Function]}
+              step={1000}
+              styles={
+                {
+                  "arrowButtonsContainer": {},
+                  "icon": {},
+                  "input": {},
+                  "label": {
+                    "fontSize": 12,
+                    "fontWeight": 400,
+                  },
+                  "labelWrapper": {},
+                  "root": {
+                    "paddingBottom": 10,
+                  },
+                  "spinButtonWrapper": {},
+                }
+              }
+            />
+          </div>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem
+        value="5"
+      >
+        <AccordionHeader>
+          <div
+            className="___15c001r_0000000 fq02s40"
           >
             Default Query Results View
-          </legend>
-          <InfoTooltip>
+          </div>
+          <InfoTooltip
+            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+          >
             Select the default view to use when displaying query results.
           </InfoTooltip>
-        </div>
-        <div>
-          <StyledChoiceGroup
-            ariaLabelledBy="defaultQueryResultsView"
-            onChange={[Function]}
-            options={
-              [
-                {
-                  "key": "vertical",
-                  "text": "Vertical",
-                },
-                {
-                  "key": "horizontal",
-                  "text": "Horizontal",
-                },
-              ]
-            }
-            selectedKey="vertical"
-            styles={
-              {
-                "flexContainer": [
+        </AccordionHeader>
+        <AccordionPanel>
+          <div
+            className="___1dfa554_0000000 fo7qwa0"
+          >
+            <StyledChoiceGroup
+              ariaLabelledBy="defaultQueryResultsView"
+              onChange={[Function]}
+              options={
+                [
                   {
-                    "selectors": {
-                      ".ms-ChoiceField": {
-                        "marginTop": 0,
-                      },
-                      ".ms-ChoiceField-wrapper label": {
-                        "fontSize": 12,
-                        "paddingTop": 0,
-                      },
-                      ".ms-ChoiceFieldGroup root-133": {
-                        "clear": "both",
+                    "key": "vertical",
+                    "text": "Vertical",
+                  },
+                  {
+                    "key": "horizontal",
+                    "text": "Horizontal",
+                  },
+                ]
+              }
+              selectedKey="vertical"
+              styles={
+                {
+                  "flexContainer": [
+                    {
+                      "selectors": {
+                        ".ms-ChoiceField": {
+                          "marginTop": 0,
+                        },
+                        ".ms-ChoiceField-wrapper label": {
+                          "fontSize": 12,
+                          "paddingTop": 0,
+                        },
+                        ".ms-ChoiceFieldGroup root-133": {
+                          "clear": "both",
+                        },
                       },
                     },
+                  ],
+                  "root": {
+                    "clear": "both",
                   },
-                ],
-                "root": {
-                  "clear": "both",
-                },
+                }
               }
-            }
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      className="settingsSection"
-    >
-      <div
-        className="settingsSectionPart"
+            />
+          </div>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem
+        value="6"
       >
-        <div
-          className="settingsSectionLabel"
-        >
-          Retry Settings
-          <InfoTooltip>
+        <AccordionHeader>
+          <div
+            className="___15c001r_0000000 fq02s40"
+          >
+             Retry Settings
+          </div>
+          <InfoTooltip
+            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+          >
             Retry policy associated with throttled requests during CosmosDB queries.
           </InfoTooltip>
-        </div>
-        <div>
-          <legend
-            className="settingsSectionLabel legendLabel"
-            id="queryRetryAttemptsLabel"
+        </AccordionHeader>
+        <AccordionPanel>
+          <div
+            className="___1dfa554_0000000 fo7qwa0"
           >
-            Max retry attempts
-          </legend>
-          <InfoTooltip>
-            Max number of retries to be performed for a request. Default value 9.
-          </InfoTooltip>
-        </div>
-        <StyledSpinButton
-          decrementButtonAriaLabel="Decrease value by 1"
-          incrementButtonAriaLabel="Increase value by 1"
-          labelPosition={0}
-          min={1}
-          onChange={[Function]}
-          onDecrement={[Function]}
-          onIncrement={[Function]}
-          onValidate={[Function]}
-          step={1}
-          styles={
-            {
-              "arrowButtonsContainer": {},
-              "icon": {},
-              "input": {},
-              "label": {
-                "fontSize": 12,
-                "fontWeight": 400,
-              },
-              "labelWrapper": {},
-              "root": {
-                "paddingBottom": 10,
-              },
-              "spinButtonWrapper": {},
-            }
-          }
-          value="9"
-        />
-        <div>
-          <legend
-            className="settingsSectionLabel legendLabel"
-            id="queryRetryAttemptsLabel"
-          >
-            Fixed retry interval (ms)
-          </legend>
-          <InfoTooltip>
-            Fixed retry interval in milliseconds to wait between each retry ignoring the retryAfter returned as part of the response. Default value is 0 milliseconds.
-          </InfoTooltip>
-        </div>
-        <StyledSpinButton
-          decrementButtonAriaLabel="Decrease value by 1000"
-          incrementButtonAriaLabel="Increase value by 1000"
-          labelPosition={0}
-          min={1000}
-          onChange={[Function]}
-          onDecrement={[Function]}
-          onIncrement={[Function]}
-          onValidate={[Function]}
-          step={1000}
-          styles={
-            {
-              "arrowButtonsContainer": {},
-              "icon": {},
-              "input": {},
-              "label": {
-                "fontSize": 12,
-                "fontWeight": 400,
-              },
-              "labelWrapper": {},
-              "root": {
-                "paddingBottom": 10,
-              },
-              "spinButtonWrapper": {},
-            }
-          }
-          value="0"
-        />
-        <div>
-          <legend
-            className="settingsSectionLabel legendLabel"
-            id="queryRetryAttemptsLabel"
-          >
-            Max wait time (s)
-          </legend>
-          <InfoTooltip>
-            Max wait time in seconds to wait for a request while the retries are happening. Default value 30 seconds.
-          </InfoTooltip>
-        </div>
-        <StyledSpinButton
-          decrementButtonAriaLabel="Decrease value by 1"
-          incrementButtonAriaLabel="Increase value by 1"
-          labelPosition={0}
-          min={1}
-          onChange={[Function]}
-          onDecrement={[Function]}
-          onIncrement={[Function]}
-          onValidate={[Function]}
-          step={1}
-          styles={
-            {
-              "arrowButtonsContainer": {},
-              "icon": {},
-              "input": {},
-              "label": {
-                "fontSize": 12,
-                "fontWeight": 400,
-              },
-              "labelWrapper": {},
-              "root": {
-                "paddingBottom": 10,
-              },
-              "spinButtonWrapper": {},
-            }
-          }
-          value="30"
-        />
-      </div>
-    </div>
-    <div
-      className="settingsSection"
-    >
-      <div
-        className="settingsSectionPart settingsSectionInlineCheckbox"
+            <div>
+              <span
+                className="___15c001r_0000000 fq02s40"
+              >
+                Max retry attempts
+              </span>
+              <InfoTooltip
+                className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+              >
+                Max number of retries to be performed for a request. Default value 9.
+              </InfoTooltip>
+            </div>
+            <StyledSpinButton
+              decrementButtonAriaLabel="Decrease value by 1"
+              incrementButtonAriaLabel="Increase value by 1"
+              labelPosition={0}
+              min={1}
+              onChange={[Function]}
+              onDecrement={[Function]}
+              onIncrement={[Function]}
+              onValidate={[Function]}
+              step={1}
+              styles={
+                {
+                  "arrowButtonsContainer": {},
+                  "icon": {},
+                  "input": {},
+                  "label": {
+                    "fontSize": 12,
+                    "fontWeight": 400,
+                  },
+                  "labelWrapper": {},
+                  "root": {
+                    "paddingBottom": 10,
+                  },
+                  "spinButtonWrapper": {},
+                }
+              }
+              value="9"
+            />
+            <div>
+              <span
+                className="___15c001r_0000000 fq02s40"
+              >
+                Fixed retry interval (ms)
+              </span>
+              <InfoTooltip
+                className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+              >
+                Fixed retry interval in milliseconds to wait between each retry ignoring the retryAfter returned as part of the response. Default value is 0 milliseconds.
+              </InfoTooltip>
+            </div>
+            <StyledSpinButton
+              decrementButtonAriaLabel="Decrease value by 1000"
+              incrementButtonAriaLabel="Increase value by 1000"
+              labelPosition={0}
+              min={1000}
+              onChange={[Function]}
+              onDecrement={[Function]}
+              onIncrement={[Function]}
+              onValidate={[Function]}
+              step={1000}
+              styles={
+                {
+                  "arrowButtonsContainer": {},
+                  "icon": {},
+                  "input": {},
+                  "label": {
+                    "fontSize": 12,
+                    "fontWeight": 400,
+                  },
+                  "labelWrapper": {},
+                  "root": {
+                    "paddingBottom": 10,
+                  },
+                  "spinButtonWrapper": {},
+                }
+              }
+              value="0"
+            />
+            <div>
+              <span
+                className="___15c001r_0000000 fq02s40"
+              >
+                Max wait time (s)
+              </span>
+              <InfoTooltip
+                className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+              >
+                Max wait time in seconds to wait for a request while the retries are happening. Default value 30 seconds.
+              </InfoTooltip>
+            </div>
+            <StyledSpinButton
+              decrementButtonAriaLabel="Decrease value by 1"
+              incrementButtonAriaLabel="Increase value by 1"
+              labelPosition={0}
+              min={1}
+              onChange={[Function]}
+              onDecrement={[Function]}
+              onIncrement={[Function]}
+              onValidate={[Function]}
+              step={1}
+              styles={
+                {
+                  "arrowButtonsContainer": {},
+                  "icon": {},
+                  "input": {},
+                  "label": {
+                    "fontSize": 12,
+                    "fontWeight": 400,
+                  },
+                  "labelWrapper": {},
+                  "root": {
+                    "paddingBottom": 10,
+                  },
+                  "spinButtonWrapper": {},
+                }
+              }
+              value="30"
+            />
+          </div>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem
+        value="7"
       >
-        <div
-          className="settingsSectionLabel"
-        >
-          Enable container pagination
-          <InfoTooltip>
+        <AccordionHeader>
+          <div
+            className="___15c001r_0000000 fq02s40"
+          >
+            Enable container pagination
+          </div>
+          <InfoTooltip
+            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+          >
             Load 50 containers at a time. Currently, containers are not pulled in alphanumeric order.
           </InfoTooltip>
-        </div>
-        <StyledCheckboxBase
-          ariaLabel="Enable container pagination"
-          checked={false}
-          className="padding"
-          onChange={[Function]}
-          styles={
-            {
-              "label": {
-                "padding": 0,
-              },
-            }
-          }
-        />
-      </div>
-    </div>
-    <div
-      className="settingsSection"
-    >
-      <div
-        className="settingsSectionPart settingsSectionInlineCheckbox"
+        </AccordionHeader>
+        <AccordionPanel>
+          <div
+            className="___1dfa554_0000000 fo7qwa0"
+          >
+            <StyledCheckboxBase
+              ariaLabel="Enable container pagination"
+              checked={false}
+              className="padding"
+              onChange={[Function]}
+              styles={
+                {
+                  "label": {
+                    "padding": 0,
+                  },
+                }
+              }
+            />
+          </div>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem
+        value="8"
       >
-        <div
-          className="settingsSectionLabel"
-        >
-          Enable cross-partition query
-          <InfoTooltip>
+        <AccordionHeader>
+          <div
+            className="___15c001r_0000000 fq02s40"
+          >
+            Enable cross-partition query
+          </div>
+          <InfoTooltip
+            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+          >
             Send more than one request while executing a query. More than one request is necessary if the query is not scoped to single partition key value.
           </InfoTooltip>
-        </div>
-        <StyledCheckboxBase
-          ariaLabel="Enable cross partition query"
-          checked={false}
-          className="padding"
-          onChange={[Function]}
-          styles={
-            {
-              "label": {
-                "padding": 0,
-              },
-            }
-          }
-        />
-      </div>
-    </div>
-    <div
-      className="settingsSection"
-    >
-      <div
-        className="settingsSectionPart"
+        </AccordionHeader>
+        <AccordionPanel>
+          <div
+            className="___1dfa554_0000000 fo7qwa0"
+          >
+            <StyledCheckboxBase
+              ariaLabel="Enable cross partition query"
+              checked={false}
+              className="padding"
+              onChange={[Function]}
+              styles={
+                {
+                  "label": {
+                    "padding": 0,
+                  },
+                }
+              }
+            />
+          </div>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem
+        value="9"
       >
-        <div
-          className="settingsSectionLabel"
-        >
-          Max degree of parallelism
-          <InfoTooltip>
+        <AccordionHeader>
+          <div
+            className="___15c001r_0000000 fq02s40"
+          >
+            Max degree of parallelism
+          </div>
+          <InfoTooltip
+            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+          >
             Gets or sets the number of concurrent operations run client side during parallel query execution. A positive property value limits the number of concurrent operations to the set value. If it is set to less than 0, the system automatically decides the number of concurrent operations to run.
           </InfoTooltip>
-        </div>
-        <StyledSpinButton
-          ariaLabel="Max degree of parallelism"
-          className="textfontclr"
-          id="max-degree"
-          min={-1}
-          onDecrement={[Function]}
-          onIncrement={[Function]}
-          onValidate={[Function]}
-          role="textbox"
-          step={1}
-          value="6"
-        />
-      </div>
-    </div>
+        </AccordionHeader>
+        <AccordionPanel>
+          <div
+            className="___1dfa554_0000000 fo7qwa0"
+          >
+            <StyledSpinButton
+              ariaLabel="Max degree of parallelism"
+              className="textfontclr"
+              id="max-degree"
+              min={-1}
+              onDecrement={[Function]}
+              onIncrement={[Function]}
+              onValidate={[Function]}
+              role="textbox"
+              step={1}
+              value="6"
+            />
+          </div>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
     <div
       className="settingsSection"
     >
@@ -524,203 +565,228 @@ exports[`Settings Pane should render Gremlin properly 1`] = `
   submitButtonText="Apply"
 >
   <div
-    className="paneMainContent"
+    className="paneMainContent ___133e6fg_0000000 f22iagw f1vx9l62 f1l02sjl"
   >
-    <div
-      className="settingsSection"
+    <Accordion
+      className="___1uf6361_0000000 fz7g6wx"
     >
-      <div
-        className="settingsSectionPart"
+      <AccordionItem
+        value="6"
       >
-        <div
-          className="settingsSectionLabel"
-        >
-          Retry Settings
-          <InfoTooltip>
+        <AccordionHeader>
+          <div
+            className="___15c001r_0000000 fq02s40"
+          >
+             Retry Settings
+          </div>
+          <InfoTooltip
+            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+          >
             Retry policy associated with throttled requests during CosmosDB queries.
           </InfoTooltip>
-        </div>
-        <div>
-          <legend
-            className="settingsSectionLabel legendLabel"
-            id="queryRetryAttemptsLabel"
+        </AccordionHeader>
+        <AccordionPanel>
+          <div
+            className="___1dfa554_0000000 fo7qwa0"
           >
-            Max retry attempts
-          </legend>
-          <InfoTooltip>
-            Max number of retries to be performed for a request. Default value 9.
-          </InfoTooltip>
-        </div>
-        <StyledSpinButton
-          decrementButtonAriaLabel="Decrease value by 1"
-          incrementButtonAriaLabel="Increase value by 1"
-          labelPosition={0}
-          min={1}
-          onChange={[Function]}
-          onDecrement={[Function]}
-          onIncrement={[Function]}
-          onValidate={[Function]}
-          step={1}
-          styles={
-            {
-              "arrowButtonsContainer": {},
-              "icon": {},
-              "input": {},
-              "label": {
-                "fontSize": 12,
-                "fontWeight": 400,
-              },
-              "labelWrapper": {},
-              "root": {
-                "paddingBottom": 10,
-              },
-              "spinButtonWrapper": {},
-            }
-          }
-          value="9"
-        />
-        <div>
-          <legend
-            className="settingsSectionLabel legendLabel"
-            id="queryRetryAttemptsLabel"
-          >
-            Fixed retry interval (ms)
-          </legend>
-          <InfoTooltip>
-            Fixed retry interval in milliseconds to wait between each retry ignoring the retryAfter returned as part of the response. Default value is 0 milliseconds.
-          </InfoTooltip>
-        </div>
-        <StyledSpinButton
-          decrementButtonAriaLabel="Decrease value by 1000"
-          incrementButtonAriaLabel="Increase value by 1000"
-          labelPosition={0}
-          min={1000}
-          onChange={[Function]}
-          onDecrement={[Function]}
-          onIncrement={[Function]}
-          onValidate={[Function]}
-          step={1000}
-          styles={
-            {
-              "arrowButtonsContainer": {},
-              "icon": {},
-              "input": {},
-              "label": {
-                "fontSize": 12,
-                "fontWeight": 400,
-              },
-              "labelWrapper": {},
-              "root": {
-                "paddingBottom": 10,
-              },
-              "spinButtonWrapper": {},
-            }
-          }
-          value="0"
-        />
-        <div>
-          <legend
-            className="settingsSectionLabel legendLabel"
-            id="queryRetryAttemptsLabel"
-          >
-            Max wait time (s)
-          </legend>
-          <InfoTooltip>
-            Max wait time in seconds to wait for a request while the retries are happening. Default value 30 seconds.
-          </InfoTooltip>
-        </div>
-        <StyledSpinButton
-          decrementButtonAriaLabel="Decrease value by 1"
-          incrementButtonAriaLabel="Increase value by 1"
-          labelPosition={0}
-          min={1}
-          onChange={[Function]}
-          onDecrement={[Function]}
-          onIncrement={[Function]}
-          onValidate={[Function]}
-          step={1}
-          styles={
-            {
-              "arrowButtonsContainer": {},
-              "icon": {},
-              "input": {},
-              "label": {
-                "fontSize": 12,
-                "fontWeight": 400,
-              },
-              "labelWrapper": {},
-              "root": {
-                "paddingBottom": 10,
-              },
-              "spinButtonWrapper": {},
-            }
-          }
-          value="30"
-        />
-      </div>
-    </div>
-    <div
-      className="settingsSection"
-    >
-      <div
-        className="settingsSectionPart settingsSectionInlineCheckbox"
+            <div>
+              <span
+                className="___15c001r_0000000 fq02s40"
+              >
+                Max retry attempts
+              </span>
+              <InfoTooltip
+                className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+              >
+                Max number of retries to be performed for a request. Default value 9.
+              </InfoTooltip>
+            </div>
+            <StyledSpinButton
+              decrementButtonAriaLabel="Decrease value by 1"
+              incrementButtonAriaLabel="Increase value by 1"
+              labelPosition={0}
+              min={1}
+              onChange={[Function]}
+              onDecrement={[Function]}
+              onIncrement={[Function]}
+              onValidate={[Function]}
+              step={1}
+              styles={
+                {
+                  "arrowButtonsContainer": {},
+                  "icon": {},
+                  "input": {},
+                  "label": {
+                    "fontSize": 12,
+                    "fontWeight": 400,
+                  },
+                  "labelWrapper": {},
+                  "root": {
+                    "paddingBottom": 10,
+                  },
+                  "spinButtonWrapper": {},
+                }
+              }
+              value="9"
+            />
+            <div>
+              <span
+                className="___15c001r_0000000 fq02s40"
+              >
+                Fixed retry interval (ms)
+              </span>
+              <InfoTooltip
+                className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+              >
+                Fixed retry interval in milliseconds to wait between each retry ignoring the retryAfter returned as part of the response. Default value is 0 milliseconds.
+              </InfoTooltip>
+            </div>
+            <StyledSpinButton
+              decrementButtonAriaLabel="Decrease value by 1000"
+              incrementButtonAriaLabel="Increase value by 1000"
+              labelPosition={0}
+              min={1000}
+              onChange={[Function]}
+              onDecrement={[Function]}
+              onIncrement={[Function]}
+              onValidate={[Function]}
+              step={1000}
+              styles={
+                {
+                  "arrowButtonsContainer": {},
+                  "icon": {},
+                  "input": {},
+                  "label": {
+                    "fontSize": 12,
+                    "fontWeight": 400,
+                  },
+                  "labelWrapper": {},
+                  "root": {
+                    "paddingBottom": 10,
+                  },
+                  "spinButtonWrapper": {},
+                }
+              }
+              value="0"
+            />
+            <div>
+              <span
+                className="___15c001r_0000000 fq02s40"
+              >
+                Max wait time (s)
+              </span>
+              <InfoTooltip
+                className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+              >
+                Max wait time in seconds to wait for a request while the retries are happening. Default value 30 seconds.
+              </InfoTooltip>
+            </div>
+            <StyledSpinButton
+              decrementButtonAriaLabel="Decrease value by 1"
+              incrementButtonAriaLabel="Increase value by 1"
+              labelPosition={0}
+              min={1}
+              onChange={[Function]}
+              onDecrement={[Function]}
+              onIncrement={[Function]}
+              onValidate={[Function]}
+              step={1}
+              styles={
+                {
+                  "arrowButtonsContainer": {},
+                  "icon": {},
+                  "input": {},
+                  "label": {
+                    "fontSize": 12,
+                    "fontWeight": 400,
+                  },
+                  "labelWrapper": {},
+                  "root": {
+                    "paddingBottom": 10,
+                  },
+                  "spinButtonWrapper": {},
+                }
+              }
+              value="30"
+            />
+          </div>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem
+        value="7"
       >
-        <div
-          className="settingsSectionLabel"
-        >
-          Enable container pagination
-          <InfoTooltip>
+        <AccordionHeader>
+          <div
+            className="___15c001r_0000000 fq02s40"
+          >
+            Enable container pagination
+          </div>
+          <InfoTooltip
+            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+          >
             Load 50 containers at a time. Currently, containers are not pulled in alphanumeric order.
           </InfoTooltip>
-        </div>
-        <StyledCheckboxBase
-          ariaLabel="Enable container pagination"
-          checked={false}
-          className="padding"
-          onChange={[Function]}
-          styles={
-            {
-              "label": {
-                "padding": 0,
-              },
-            }
-          }
-        />
-      </div>
-    </div>
-    <div
-      className="settingsSection"
-    >
-      <div
-        className="settingsSectionPart"
+        </AccordionHeader>
+        <AccordionPanel>
+          <div
+            className="___1dfa554_0000000 fo7qwa0"
+          >
+            <StyledCheckboxBase
+              ariaLabel="Enable container pagination"
+              checked={false}
+              className="padding"
+              onChange={[Function]}
+              styles={
+                {
+                  "label": {
+                    "padding": 0,
+                  },
+                }
+              }
+            />
+          </div>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem
+        value="11"
       >
-        <div
-          className="settingsSectionLabel"
-        >
-          Display Gremlin query results as: 
-          <InfoTooltip>
+        <AccordionHeader>
+          <div
+            className="___15c001r_0000000 fq02s40"
+          >
+            Display Gremlin query results as: 
+          </div>
+          <InfoTooltip
+            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
+          >
             Select Graph to automatically visualize the query results as a Graph or JSON to display the results as JSON.
           </InfoTooltip>
-        </div>
-        <StyledChoiceGroup
-          aria-label="Graph Auto-visualization"
-          onChange={[Function]}
-          options={
-            [
-              {
-                "key": "false",
-                "text": "Graph",
-              },
-              {
-                "key": "true",
-                "text": "JSON",
-              },
-            ]
-          }
-          selectedKey="false"
-        />
-      </div>
-    </div>
+        </AccordionHeader>
+        <AccordionPanel>
+          <div
+            className="___1dfa554_0000000 fo7qwa0"
+          >
+            <StyledChoiceGroup
+              aria-label="Graph Auto-visualization"
+              onChange={[Function]}
+              options={
+                [
+                  {
+                    "key": "false",
+                    "text": "Graph",
+                  },
+                  {
+                    "key": "true",
+                    "text": "JSON",
+                  },
+                ]
+              }
+              selectedKey="false"
+            />
+          </div>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
     <div
       className="settingsSection"
     >

--- a/src/Explorer/Panes/SettingsPane/__snapshots__/SettingsPane.test.tsx.snap
+++ b/src/Explorer/Panes/SettingsPane/__snapshots__/SettingsPane.test.tsx.snap
@@ -300,7 +300,7 @@ exports[`Settings Pane should render Default properly 1`] = `
           >
             <div>
               <span
-                className="___15c001r_0000000 fq02s40"
+                className="___zls1px0_0000000 fq02s40 f1ugzwwg"
               >
                 Max retry attempts
               </span>
@@ -340,7 +340,7 @@ exports[`Settings Pane should render Default properly 1`] = `
             />
             <div>
               <span
-                className="___15c001r_0000000 fq02s40"
+                className="___zls1px0_0000000 fq02s40 f1ugzwwg"
               >
                 Fixed retry interval (ms)
               </span>
@@ -380,7 +380,7 @@ exports[`Settings Pane should render Default properly 1`] = `
             />
             <div>
               <span
-                className="___15c001r_0000000 fq02s40"
+                className="___zls1px0_0000000 fq02s40 f1ugzwwg"
               >
                 Max wait time (s)
               </span>
@@ -591,7 +591,7 @@ exports[`Settings Pane should render Gremlin properly 1`] = `
           >
             <div>
               <span
-                className="___15c001r_0000000 fq02s40"
+                className="___zls1px0_0000000 fq02s40 f1ugzwwg"
               >
                 Max retry attempts
               </span>
@@ -631,7 +631,7 @@ exports[`Settings Pane should render Gremlin properly 1`] = `
             />
             <div>
               <span
-                className="___15c001r_0000000 fq02s40"
+                className="___zls1px0_0000000 fq02s40 f1ugzwwg"
               >
                 Fixed retry interval (ms)
               </span>
@@ -671,7 +671,7 @@ exports[`Settings Pane should render Gremlin properly 1`] = `
             />
             <div>
               <span
-                className="___15c001r_0000000 fq02s40"
+                className="___zls1px0_0000000 fq02s40 f1ugzwwg"
               >
                 Max wait time (s)
               </span>

--- a/src/Explorer/Panes/SettingsPane/__snapshots__/SettingsPane.test.tsx.snap
+++ b/src/Explorer/Panes/SettingsPane/__snapshots__/SettingsPane.test.tsx.snap
@@ -22,16 +22,16 @@ exports[`Settings Pane should render Default properly 1`] = `
           >
             Page Options
           </div>
-          <InfoTooltip
-            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
-          >
-            Choose Custom to specify a fixed amount of query results to show, or choose Unlimited to show as many query results per page.
-          </InfoTooltip>
         </AccordionHeader>
         <AccordionPanel>
           <div
             className="___1dfa554_0000000 fo7qwa0"
           >
+            <div
+              className="___10gar1i_0000000 f1fow5ox f1ugzwwg"
+            >
+              Choose Custom to specify a fixed amount of query results to show, or choose Unlimited to show as many query results per page.
+            </div>
             <StyledChoiceGroup
               ariaLabelledBy="pageOptions"
               onChange={[Function]}
@@ -80,9 +80,10 @@ exports[`Settings Pane should render Default properly 1`] = `
               className="tabcontent"
             >
               <div
-                className="settingsSectionLabel"
+                className="___10gar1i_0000000 f1fow5ox f1ugzwwg"
               >
                 Query results per page
+                 
                 <InfoTooltip
                   className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
                 >
@@ -114,16 +115,16 @@ exports[`Settings Pane should render Default properly 1`] = `
           >
             Query Timeout
           </div>
-          <InfoTooltip
-            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
-          >
-            When a query reaches a specified time limit, a popup with an option to cancel the query will show unless automatic cancellation has been enabled
-          </InfoTooltip>
         </AccordionHeader>
         <AccordionPanel>
           <div
             className="___1dfa554_0000000 fo7qwa0"
           >
+            <div
+              className="___10gar1i_0000000 f1fow5ox f1ugzwwg"
+            >
+              When a query reaches a specified time limit, a popup with an option to cancel the query will show unless automatic cancellation has been enabled.
+            </div>
             <StyledToggleBase
               defaultChecked={false}
               label="Enable query timeout"
@@ -155,16 +156,16 @@ exports[`Settings Pane should render Default properly 1`] = `
           >
             RU Threshold
           </div>
-          <InfoTooltip
-            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
-          >
-            If a query exceeds a configured RU threshold, the query will be aborted.
-          </InfoTooltip>
         </AccordionHeader>
         <AccordionPanel>
           <div
             className="___1dfa554_0000000 fo7qwa0"
           >
+            <div
+              className="___10gar1i_0000000 f1fow5ox f1ugzwwg"
+            >
+              If a query exceeds a configured RU threshold, the query will be aborted.
+            </div>
             <StyledToggleBase
               defaultChecked={true}
               label="Enable RU threshold"
@@ -226,16 +227,16 @@ exports[`Settings Pane should render Default properly 1`] = `
           >
             Default Query Results View
           </div>
-          <InfoTooltip
-            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
-          >
-            Select the default view to use when displaying query results.
-          </InfoTooltip>
         </AccordionHeader>
         <AccordionPanel>
           <div
             className="___1dfa554_0000000 fo7qwa0"
           >
+            <div
+              className="___10gar1i_0000000 f1fow5ox f1ugzwwg"
+            >
+              Select the default view to use when displaying query results.
+            </div>
             <StyledChoiceGroup
               ariaLabelledBy="defaultQueryResultsView"
               onChange={[Function]}
@@ -286,18 +287,18 @@ exports[`Settings Pane should render Default properly 1`] = `
           <div
             className="___15c001r_0000000 fq02s40"
           >
-             Retry Settings
+            Retry Settings
           </div>
-          <InfoTooltip
-            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
-          >
-            Retry policy associated with throttled requests during CosmosDB queries.
-          </InfoTooltip>
         </AccordionHeader>
         <AccordionPanel>
           <div
             className="___1dfa554_0000000 fo7qwa0"
           >
+            <div
+              className="___10gar1i_0000000 f1fow5ox f1ugzwwg"
+            >
+              Retry policy associated with throttled requests during CosmosDB queries.
+            </div>
             <div>
               <span
                 className="___zls1px0_0000000 fq02s40 f1ugzwwg"
@@ -430,20 +431,21 @@ exports[`Settings Pane should render Default properly 1`] = `
           >
             Enable container pagination
           </div>
-          <InfoTooltip
-            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
-          >
-            Load 50 containers at a time. Currently, containers are not pulled in alphanumeric order.
-          </InfoTooltip>
         </AccordionHeader>
         <AccordionPanel>
           <div
             className="___1dfa554_0000000 fo7qwa0"
           >
+            <div
+              className="___10gar1i_0000000 f1fow5ox f1ugzwwg"
+            >
+              Load 50 containers at a time. Currently, containers are not pulled in alphanumeric order.
+            </div>
             <StyledCheckboxBase
               ariaLabel="Enable container pagination"
               checked={false}
               className="padding"
+              label="Enable container pagination"
               onChange={[Function]}
               styles={
                 {
@@ -465,20 +467,21 @@ exports[`Settings Pane should render Default properly 1`] = `
           >
             Enable cross-partition query
           </div>
-          <InfoTooltip
-            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
-          >
-            Send more than one request while executing a query. More than one request is necessary if the query is not scoped to single partition key value.
-          </InfoTooltip>
         </AccordionHeader>
         <AccordionPanel>
           <div
             className="___1dfa554_0000000 fo7qwa0"
           >
+            <div
+              className="___10gar1i_0000000 f1fow5ox f1ugzwwg"
+            >
+              Send more than one request while executing a query. More than one request is necessary if the query is not scoped to single partition key value.
+            </div>
             <StyledCheckboxBase
               ariaLabel="Enable cross partition query"
               checked={false}
               className="padding"
+              label="Enable cross-partition query"
               onChange={[Function]}
               styles={
                 {
@@ -500,20 +503,21 @@ exports[`Settings Pane should render Default properly 1`] = `
           >
             Max degree of parallelism
           </div>
-          <InfoTooltip
-            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
-          >
-            Gets or sets the number of concurrent operations run client side during parallel query execution. A positive property value limits the number of concurrent operations to the set value. If it is set to less than 0, the system automatically decides the number of concurrent operations to run.
-          </InfoTooltip>
         </AccordionHeader>
         <AccordionPanel>
           <div
             className="___1dfa554_0000000 fo7qwa0"
           >
+            <div
+              className="___10gar1i_0000000 f1fow5ox f1ugzwwg"
+            >
+              Gets or sets the number of concurrent operations run client side during parallel query execution. A positive property value limits the number of concurrent operations to the set value. If it is set to less than 0, the system automatically decides the number of concurrent operations to run.
+            </div>
             <StyledSpinButton
               ariaLabel="Max degree of parallelism"
               className="textfontclr"
               id="max-degree"
+              label="Max degree of parallelism"
               min={-1}
               onDecrement={[Function]}
               onIncrement={[Function]}
@@ -577,18 +581,18 @@ exports[`Settings Pane should render Gremlin properly 1`] = `
           <div
             className="___15c001r_0000000 fq02s40"
           >
-             Retry Settings
+            Retry Settings
           </div>
-          <InfoTooltip
-            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
-          >
-            Retry policy associated with throttled requests during CosmosDB queries.
-          </InfoTooltip>
         </AccordionHeader>
         <AccordionPanel>
           <div
             className="___1dfa554_0000000 fo7qwa0"
           >
+            <div
+              className="___10gar1i_0000000 f1fow5ox f1ugzwwg"
+            >
+              Retry policy associated with throttled requests during CosmosDB queries.
+            </div>
             <div>
               <span
                 className="___zls1px0_0000000 fq02s40 f1ugzwwg"
@@ -721,20 +725,21 @@ exports[`Settings Pane should render Gremlin properly 1`] = `
           >
             Enable container pagination
           </div>
-          <InfoTooltip
-            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
-          >
-            Load 50 containers at a time. Currently, containers are not pulled in alphanumeric order.
-          </InfoTooltip>
         </AccordionHeader>
         <AccordionPanel>
           <div
             className="___1dfa554_0000000 fo7qwa0"
           >
+            <div
+              className="___10gar1i_0000000 f1fow5ox f1ugzwwg"
+            >
+              Load 50 containers at a time. Currently, containers are not pulled in alphanumeric order.
+            </div>
             <StyledCheckboxBase
               ariaLabel="Enable container pagination"
               checked={false}
               className="padding"
+              label="Enable container pagination"
               onChange={[Function]}
               styles={
                 {
@@ -756,16 +761,16 @@ exports[`Settings Pane should render Gremlin properly 1`] = `
           >
             Display Gremlin query results as: 
           </div>
-          <InfoTooltip
-            className="___vtc5hy0_0000000 f10ra9hq f1k6fduh"
-          >
-            Select Graph to automatically visualize the query results as a Graph or JSON to display the results as JSON.
-          </InfoTooltip>
         </AccordionHeader>
         <AccordionPanel>
           <div
             className="___1dfa554_0000000 fo7qwa0"
           >
+            <div
+              className="___10gar1i_0000000 f1fow5ox f1ugzwwg"
+            >
+              Select Graph to automatically visualize the query results as a Graph or JSON to display the results as JSON.
+            </div>
             <StyledChoiceGroup
               aria-label="Graph Auto-visualization"
               onChange={[Function]}


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1945)

The current SettingsPane has too many options.
Move all items into an `<Accordion>`. Only one option can be opened at a time.
Move the Info tips (i) text into the accordion section.

![image](https://github.com/user-attachments/assets/4d5123bb-73d2-467b-bbac-c637fe6cc5e3)
