### PR TITLE
change default splitter orientation when the setting has not been set

### DIFF
--- a/src/Explorer/Panes/SettingsPane/__snapshots__/SettingsPane.test.tsx.snap
+++ b/src/Explorer/Panes/SettingsPane/__snapshots__/SettingsPane.test.tsx.snap
@@ -238,7 +238,7 @@ exports[`Settings Pane should render Default properly 1`] = `
                 },
               ]
             }
-            selectedKey="vertical"
+            selectedKey="horizontal"
             styles={
               {
                 "flexContainer": [

--- a/src/Shared/StorageUtility.ts
+++ b/src/Shared/StorageUtility.ts
@@ -57,10 +57,10 @@ export const getRUThreshold = (): number => {
 
 export const getDefaultQueryResultsView = (): SplitterDirection => {
   const defaultQueryResultsViewRaw = LocalStorageUtility.getEntryString(StorageKey.DefaultQueryResultsView);
-  if (defaultQueryResultsViewRaw === SplitterDirection.Horizontal) {
-    return SplitterDirection.Horizontal;
+  if (defaultQueryResultsViewRaw === SplitterDirection.Vertical) {
+    return SplitterDirection.Vertical;
   }
-  return SplitterDirection.Vertical;
+  return SplitterDirection.Horizontal;
 };
 
 export const DefaultRUThreshold = 5000;


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1946)

When I swapped the splitter orientation, I didn't change the default (when the default orientation hasn't been set in settings). As a result, the default is now the "Vertical" layout, which means a vertical splitter:

<img width="1127" alt="image" src="https://github.com/user-attachments/assets/e13b3cbd-32e4-44e4-ae7d-3f5c099382ee">

This is jarring for users who were used to the default (we've gotten NPS feedback about this too). This PR just flips that default. If any user has set their default in the settings, this PR won't affect them.
