### PR TITLE
[Programmatic Access - Azure Cosmos DB - Data Explorer]: Close button does not have discernible text under 'Data Explorer' pane.

### DIFF
--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -99,6 +99,7 @@ export const Tabs = ({ explorer }: TabsProps): JSX.Element => {
               fontWeight: "bold",
             },
           }}
+          dismissButtonAriaLabel="Close info"
         >
           {`To prevent queries from using excessive RUs, Data Explorer has a 5,000 RU default limit. To modify or remove
           the limit, go to the Settings cog on the right and find "RU Threshold".`}


### PR DESCRIPTION
This pull request addresses an accessibility issue within the Azure Cosmos DB Data Explorer pane. The "Close" button currently lacks discernible text, making it difficult for users relying on assistive technologies to identify its function.
![image](https://github.com/user-attachments/assets/221a134a-8a12-4348-8e8d-56cb36fab054)

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1949?feature.someFeatureFlagYouMightNeed=true)
