### PR TITLE
fix rendering of global commands menu

### DIFF
--- a/src/Explorer/Sidebar.tsx
+++ b/src/Explorer/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   SplitButton,
   makeStyles,
   mergeClasses,
-  shorthands
+  shorthands,
 } from "@fluentui/react-components";
 import { Add16Regular, ArrowSync12Regular, ChevronLeft12Regular, ChevronRight12Regular } from "@fluentui/react-icons";
 import { Platform, configContext } from "ConfigContext";

--- a/src/Explorer/Sidebar.tsx
+++ b/src/Explorer/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   SplitButton,
   makeStyles,
   mergeClasses,
-  shorthands,
+  shorthands
 } from "@fluentui/react-components";
 import { Add16Regular, ArrowSync12Regular, ChevronLeft12Regular, ChevronRight12Regular } from "@fluentui/react-icons";
 import { Platform, configContext } from "ConfigContext";
@@ -26,7 +26,7 @@ import { getCollectionName, getDatabaseName } from "Utils/APITypeUtils";
 import { Allotment, AllotmentHandle } from "allotment";
 import { useSidePanel } from "hooks/useSidePanel";
 import { debounce } from "lodash";
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const useSidebarStyles = makeStyles({
   sidebar: {
@@ -113,6 +113,12 @@ interface GlobalCommand {
 
 const GlobalCommands: React.FC<GlobalCommandsProps> = ({ explorer }) => {
   const styles = useSidebarStyles();
+
+  // Since we have two buttons in the DOM (one for small screens and one for larger screens), we wrap the entire thing in a div.
+  // However, that messes with the Menu positioning, so we need to get a reference to the 'div' to pass to the Menu.
+  // We can't use a ref though, because it would be set after the Menu is rendered, so we use a state value to force a re-render.
+  const [globalCommandButton, setGlobalCommandButton] = useState<HTMLElement | null>(null);
+
   const actions = useMemo<GlobalCommand[]>(() => {
     if (
       configContext.platform === Platform.Fabric ||
@@ -182,10 +188,10 @@ const GlobalCommands: React.FC<GlobalCommandsProps> = ({ explorer }) => {
           {primaryAction.label}
         </Button>
       ) : (
-        <Menu positioning="below-end">
+        <Menu positioning={{ target: globalCommandButton, position: "below", align: "end" }}>
           <MenuTrigger disableButtonEnhancement>
             {(triggerProps: MenuButtonProps) => (
-              <>
+              <div ref={setGlobalCommandButton}>
                 <SplitButton
                   menuButton={{ ...triggerProps, "aria-label": "More commands" }}
                   primaryActionButton={{ onClick: onPrimaryActionClick }}
@@ -197,7 +203,7 @@ const GlobalCommands: React.FC<GlobalCommandsProps> = ({ explorer }) => {
                 <MenuButton {...triggerProps} icon={primaryAction.icon} className={styles.globalCommandsMenuButton}>
                   New...
                 </MenuButton>
-              </>
+              </div>
             )}
           </MenuTrigger>
           <MenuPopover>


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1953?feature.someFeatureFlagYouMightNeed=true)

I was opening the split button "Global Commands" menu and I noticed something:

![image](https://github.com/user-attachments/assets/08b165cd-dbf3-4afe-93d3-14ca0411004f)

Hey menu, what are you doing way up there?

Well, it turns out that when you put two DOM elements under a `<MenuTrigger>`, it gets a little confused and does all the positioning based on the _last_ element. In our case, the last element is only visible on small screens (we swap between the first and last element based on container width using CSS container queries). As a result, that messes with things when the first element (the SplitButton) is the one that's visible.

This PR wraps those elements in a new `div`. Unfortunately, that's not entirely enough, we also need the Menu to know to anchor the menu off that div. We do that using a React state value.

With this change, the menu is back where it belongs:

![image](https://github.com/user-attachments/assets/59adb2f3-91fc-4124-9d95-80ddca8c63e0)

And still works fine in small screens:

![image](https://github.com/user-attachments/assets/b42c785a-2dd4-41c2-9ee6-600fd063479e)

