### PR TITLE
Add more default filters to Documents Tab

### DIFF
--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -516,7 +516,10 @@ export interface IDocumentsTabComponentProps {
 
 const getUniqueId = (collection: ViewModels.CollectionBase): string => `${collection.databaseId}-${collection.id()}`;
 
-const defaultSqlFilters = ['WHERE c.id = "foo"', "ORDER BY c._ts DESC", 'WHERE c.id = "foo" ORDER BY c._ts DESC'];
+const getDefaultSqlFilters = (partitionKeys: string[]) =>
+  ['WHERE c.id = "foo"', "ORDER BY c._ts DESC", 'WHERE c.id = "foo" ORDER BY c._ts DESC', "ORDER BY c._ts ASC"].concat(
+    partitionKeys.map((partitionKey) => `WHERE c.${partitionKey} = "foo"`),
+  );
 const defaultMongoFilters = ['{"id":"foo"}', "{ qty: { $gte: 20 } }"];
 
 // Export to expose to unit tests
@@ -1800,7 +1803,7 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
                 <datalist id={`filtersList-${getUniqueId(_collection)}`}>
                   {addStringsNoDuplicate(
                     lastFilterContents,
-                    isPreferredApiMongoDB ? defaultMongoFilters : defaultSqlFilters,
+                    isPreferredApiMongoDB ? defaultMongoFilters : getDefaultSqlFilters(partitionKeyProperties),
                   ).map((filter) => (
                     <option key={filter} value={filter} />
                   ))}


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1955)

Add `ORDER BY c._ts ASC` and dynamically generated for each partition key `WHERE c.<partition key> = "foo"` to the list of default filters.