### PR TITLE
Disable bulkdelete for users point to old mongo proxy

### DIFF
--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -942,24 +942,34 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
       const _deleteNoSqlDocuments = async (
         collection: CollectionBase,
         toDeleteDocumentIds: DocumentId[],
-      ): Promise<DocumentId[]> => {
-        return partitionKey.systemKey
+      ): Promise<DocumentId[]> =>
+        partitionKey.systemKey
           ? deleteNoSqlDocument(collection, toDeleteDocumentIds[0]).then(() => [toDeleteDocumentIds[0]])
           : deleteNoSqlDocuments(collection, toDeleteDocumentIds);
-      };
+
+      // TODO: Once new mongo proxy is available for all users, remove the call for MongoProxyClient.deleteDocument().
+      // MongoProxyClient.deleteDocuments() should be called for all users.
+      const _deleteMongoDocuments = async (
+        databaseId: string,
+        collection: ViewModels.Collection,
+        documentIds: DocumentId[],
+      ) =>
+        isMongoBulkDeleteDisabled
+          ? MongoProxyClient.deleteDocument(databaseId, collection, documentIds[0]).then(() => [toDeleteDocumentIds[0]])
+          : MongoProxyClient.deleteDocuments(databaseId, collection, documentIds).then(
+              ({ deletedCount, isAcknowledged }) => {
+                if (deletedCount === toDeleteDocumentIds.length && isAcknowledged) {
+                  return toDeleteDocumentIds;
+                }
+                throw new Error(
+                  `Delete failed with deletedCount: ${deletedCount} and isAcknowledged: ${isAcknowledged}`,
+                );
+              },
+            );
 
       const deletePromise = !isPreferredApiMongoDB
         ? _deleteNoSqlDocuments(_collection, toDeleteDocumentIds)
-        : MongoProxyClient.deleteDocuments(
-            _collection.databaseId,
-            _collection as ViewModels.Collection,
-            toDeleteDocumentIds,
-          ).then(({ deletedCount, isAcknowledged }) => {
-            if (deletedCount === toDeleteDocumentIds.length && isAcknowledged) {
-              return toDeleteDocumentIds;
-            }
-            throw new Error(`Delete failed with deletedCount: ${deletedCount} and isAcknowledged: ${isAcknowledged}`);
-          });
+        : _deleteMongoDocuments(_collection.databaseId, _collection as ViewModels.Collection, toDeleteDocumentIds);
 
       return deletePromise
         .then(
@@ -1754,6 +1764,13 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
     [createIterator, filterContent],
   );
 
+  // TODO: remove isMongoBulkDeleteDisabled when new mongo proxy is enabled for all users
+  // TODO: remove partitionKey.systemKey when JS SDK bug is fixed
+  const isMongoBulkDeleteDisabled = MongoProxyClient.useMongoProxyEndpoint("bulkdelete");
+  const isBulkDeleteDisabled =
+    (partitionKey.systemKey && !isPreferredApiMongoDB) || (isPreferredApiMongoDB && isMongoBulkDeleteDisabled);
+  //  -------------------------------------------------------
+
   return (
     <CosmosFluentProvider className={styles.container}>
       <div className="tab-pane active" role="tabpanel" style={{ display: "flex" }}>
@@ -1878,7 +1895,7 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
                     size={tableContainerSizePx}
                     columnHeaders={columnHeaders}
                     isSelectionDisabled={
-                      (partitionKey.systemKey && !isPreferredApiMongoDB) ||
+                      isBulkDeleteDisabled ||
                       (configContext.platform === Platform.Fabric && userContext.fabricContext?.isReadOnly)
                     }
                     collection={_collection}

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -1766,7 +1766,7 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
 
   // TODO: remove isMongoBulkDeleteDisabled when new mongo proxy is enabled for all users
   // TODO: remove partitionKey.systemKey when JS SDK bug is fixed
-  const isMongoBulkDeleteDisabled = MongoProxyClient.useMongoProxyEndpoint("bulkdelete");
+  const isMongoBulkDeleteDisabled = !MongoProxyClient.useMongoProxyEndpoint("bulkdelete");
   const isBulkDeleteDisabled =
     (partitionKey.systemKey && !isPreferredApiMongoDB) || (isPreferredApiMongoDB && isMongoBulkDeleteDisabled);
   //  -------------------------------------------------------

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2Mongo.test.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2Mongo.test.tsx
@@ -50,6 +50,7 @@ jest.mock("Common/MongoProxyClient", () => ({
     }),
   ),
   deleteDocuments: jest.fn(() => Promise.resolve()),
+  useMongoProxyEndpoint: jest.fn(() => true),
 }));
 
 jest.mock("Explorer/Controls/Editor/EditorReact", () => ({
@@ -60,7 +61,7 @@ jest.mock("Explorer/Controls/Dialog", () => ({
   useDialog: {
     getState: jest.fn(() => ({
       showOkCancelModalDialog: (title: string, subText: string, okLabel: string, onOk: () => void) => onOk(),
-      showOkModalDialog: () => {},
+      showOkModalDialog: () => { },
     })),
   },
 }));

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2Mongo.test.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2Mongo.test.tsx
@@ -61,7 +61,7 @@ jest.mock("Explorer/Controls/Dialog", () => ({
   useDialog: {
     getState: jest.fn(() => ({
       showOkCancelModalDialog: (title: string, subText: string, okLabel: string, onOk: () => void) => onOk(),
-      showOkModalDialog: () => { },
+      showOkModalDialog: () => {},
     })),
   },
 }));


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1964)
For all users who have IP rules but don't have the mongo proxy IP address in their IP rules we send them to the old backend.
We are updating the documentation to instruct users to add the mongo proxy, but for now, we disable bulk delete (a capability only available in the new mongo proxy) for these users.
