### PR TITLE
Replace RU limit banner by clarifying the error when RU limit is exceeded

### DIFF
--- a/src/Common/QueryError.test.ts
+++ b/src/Common/QueryError.test.ts
@@ -43,7 +43,7 @@ describe("QueryError.tryParse", () => {
     };
 
     const result = QueryError.tryParse(outerError, testErrorLocationResolver);
-    expect(result).toEqual([new QueryError("Your query is bad, and you should feel bad", QueryErrorSeverity.Error)]);
+    expect(result).toEqual([new QueryError("Your query is bad, and you should feel bad", QueryErrorSeverity.Error, "BadRequest")]);
   });
 
   // Imitate the value coming from the backend, which has the syntax errors serialized as JSON in the message.

--- a/src/Common/QueryError.test.ts
+++ b/src/Common/QueryError.test.ts
@@ -1,0 +1,88 @@
+import QueryError, { QueryErrorLocation, QueryErrorSeverity } from "Common/QueryError";
+
+describe("QueryError.tryParse", () => {
+  const testErrorLocationResolver = ({ start, end }: { start: number, end: number }) => new QueryErrorLocation(
+    { offset: start, lineNumber: start, column: start },
+    { offset: end, lineNumber: end, column: end },
+  );
+
+  it("handles a string error", () => {
+    const error = "error";
+    const result = QueryError.tryParse(error, testErrorLocationResolver);
+    expect(result).toEqual([new QueryError("error", QueryErrorSeverity.Error)]);
+  });
+
+  it("handles an error object", () => {
+    const error = {
+      message: "error",
+      severity: "Warning",
+      location: { start: 0, end: 1 },
+      code: "code",
+    };
+    const result = QueryError.tryParse(error, testErrorLocationResolver);
+    expect(result).toEqual([
+      new QueryError("error", QueryErrorSeverity.Warning, "code", new QueryErrorLocation(
+        { offset: 0, lineNumber: 0, column: 0 },
+        { offset: 1, lineNumber: 1, column: 1 },
+      )),
+    ]);
+  });
+
+  it("handles a JSON message without syntax errors", () => {
+    const innerError = {
+      code: "BadRequest",
+      message: "Your query is bad, and you should feel bad",
+    };
+    const message = JSON.stringify(innerError);
+    const outerError = {
+      code: "BadRequest",
+      message,
+    };
+
+    const result = QueryError.tryParse(outerError, testErrorLocationResolver);
+    expect(result).toEqual([
+      new QueryError("Your query is bad, and you should feel bad", QueryErrorSeverity.Error),
+    ]);
+  });
+
+
+  // Imitate the value coming from the backend, which has the syntax errors serialized as JSON in the message.
+  it("handles single-nested error", () => {
+    const errors = [
+      {
+        message: "error1",
+        severity: "Warning",
+        location: { start: 0, end: 1 },
+        code: "code1",
+      },
+      {
+        message: "error2",
+        severity: "Error",
+        location: { start: 2, end: 3 },
+        code: "code2",
+      }
+    ];
+    const innerError = {
+      code: "BadRequest",
+      message: "Your query is bad, and you should feel bad",
+      errors,
+    };
+    const message = JSON.stringify(innerError);
+    const outerError = {
+      code: "BadRequest",
+      message,
+    };
+
+    const result = QueryError.tryParse(outerError, testErrorLocationResolver);
+    expect(result).toEqual([
+      new QueryError("error1", QueryErrorSeverity.Warning, "code1", new QueryErrorLocation(
+        { offset: 0, lineNumber: 0, column: 0 },
+        { offset: 1, lineNumber: 1, column: 1 },
+      )),
+      new QueryError("error2", QueryErrorSeverity.Error, "code2", new QueryErrorLocation(
+        { offset: 2, lineNumber: 2, column: 2 },
+        { offset: 3, lineNumber: 3, column: 3 },
+      )),
+    ]);
+  });
+});

--- a/src/Common/QueryError.test.ts
+++ b/src/Common/QueryError.test.ts
@@ -1,10 +1,11 @@
 import QueryError, { QueryErrorLocation, QueryErrorSeverity } from "Common/QueryError";
 
 describe("QueryError.tryParse", () => {
-  const testErrorLocationResolver = ({ start, end }: { start: number, end: number }) => new QueryErrorLocation(
-    { offset: start, lineNumber: start, column: start },
-    { offset: end, lineNumber: end, column: end },
-  );
+  const testErrorLocationResolver = ({ start, end }: { start: number; end: number }) =>
+    new QueryErrorLocation(
+      { offset: start, lineNumber: start, column: start },
+      { offset: end, lineNumber: end, column: end },
+    );
 
   it("handles a string error", () => {
     const error = "error";
@@ -21,10 +22,12 @@ describe("QueryError.tryParse", () => {
     };
     const result = QueryError.tryParse(error, testErrorLocationResolver);
     expect(result).toEqual([
-      new QueryError("error", QueryErrorSeverity.Warning, "code", new QueryErrorLocation(
-        { offset: 0, lineNumber: 0, column: 0 },
-        { offset: 1, lineNumber: 1, column: 1 },
-      )),
+      new QueryError(
+        "error",
+        QueryErrorSeverity.Warning,
+        "code",
+        new QueryErrorLocation({ offset: 0, lineNumber: 0, column: 0 }, { offset: 1, lineNumber: 1, column: 1 }),
+      ),
     ]);
   });
 
@@ -40,11 +43,8 @@ describe("QueryError.tryParse", () => {
     };
 
     const result = QueryError.tryParse(outerError, testErrorLocationResolver);
-    expect(result).toEqual([
-      new QueryError("Your query is bad, and you should feel bad", QueryErrorSeverity.Error),
-    ]);
+    expect(result).toEqual([new QueryError("Your query is bad, and you should feel bad", QueryErrorSeverity.Error)]);
   });
-
 
   // Imitate the value coming from the backend, which has the syntax errors serialized as JSON in the message.
   it("handles single-nested error", () => {
@@ -60,7 +60,7 @@ describe("QueryError.tryParse", () => {
         severity: "Error",
         location: { start: 2, end: 3 },
         code: "code2",
-      }
+      },
     ];
     const innerError = {
       code: "BadRequest",
@@ -75,14 +75,18 @@ describe("QueryError.tryParse", () => {
 
     const result = QueryError.tryParse(outerError, testErrorLocationResolver);
     expect(result).toEqual([
-      new QueryError("error1", QueryErrorSeverity.Warning, "code1", new QueryErrorLocation(
-        { offset: 0, lineNumber: 0, column: 0 },
-        { offset: 1, lineNumber: 1, column: 1 },
-      )),
-      new QueryError("error2", QueryErrorSeverity.Error, "code2", new QueryErrorLocation(
-        { offset: 2, lineNumber: 2, column: 2 },
-        { offset: 3, lineNumber: 3, column: 3 },
-      )),
+      new QueryError(
+        "error1",
+        QueryErrorSeverity.Warning,
+        "code1",
+        new QueryErrorLocation({ offset: 0, lineNumber: 0, column: 0 }, { offset: 1, lineNumber: 1, column: 1 }),
+      ),
+      new QueryError(
+        "error2",
+        QueryErrorSeverity.Error,
+        "code2",
+        new QueryErrorLocation({ offset: 2, lineNumber: 2, column: 2 }, { offset: 3, lineNumber: 3, column: 3 }),
+      ),
     ]);
   });
 });

--- a/src/Common/QueryError.test.ts
+++ b/src/Common/QueryError.test.ts
@@ -43,7 +43,9 @@ describe("QueryError.tryParse", () => {
     };
 
     const result = QueryError.tryParse(outerError, testErrorLocationResolver);
-    expect(result).toEqual([new QueryError("Your query is bad, and you should feel bad", QueryErrorSeverity.Error, "BadRequest")]);
+    expect(result).toEqual([
+      new QueryError("Your query is bad, and you should feel bad", QueryErrorSeverity.Error, "BadRequest"),
+    ]);
   });
 
   // Imitate the value coming from the backend, which has the syntax errors serialized as JSON in the message.

--- a/src/Common/QueryError.ts
+++ b/src/Common/QueryError.ts
@@ -10,7 +10,7 @@ export class QueryErrorLocation {
   constructor(
     public start: ErrorPosition,
     public end: ErrorPosition,
-  ) { }
+  ) {}
 }
 
 export class ErrorPosition {
@@ -18,7 +18,7 @@ export class ErrorPosition {
     public offset: number,
     public lineNumber?: number,
     public column?: number,
-  ) { }
+  ) {}
 }
 
 // Maps severities to numbers for sorting.
@@ -104,18 +104,19 @@ export interface ErrorEnrichment {
 }
 
 const REPLACEMENT_MESSAGES: Record<string, (original: string) => string> = {
-  "OPERATION_RU_LIMIT_EXCEEDED": (original) => {
+  OPERATION_RU_LIMIT_EXCEEDED: (original) => {
     if (ruThresholdEnabled()) {
       const threshold = getRUThreshold();
       return `Query exceeded the Request Unit (RU) limit of ${threshold} RUs. You can change this limit in Data Explorer settings.`;
     }
     return original;
-  }
+  },
 };
 
 const HELP_LINKS: Record<string, string> = {
-  "OPERATION_RU_LIMIT_EXCEEDED": "https://learn.microsoft.com/en-us/azure/cosmos-db/data-explorer#configure-request-unit-threshold",
-}
+  OPERATION_RU_LIMIT_EXCEEDED:
+    "https://learn.microsoft.com/en-us/azure/cosmos-db/data-explorer#configure-request-unit-threshold",
+};
 
 export default class QueryError {
   message: string;
@@ -190,7 +191,9 @@ export default class QueryError {
     }
 
     const severity =
-      "severity" in error && typeof error.severity === "string" ? (error.severity as QueryErrorSeverity) : QueryErrorSeverity.Error;
+      "severity" in error && typeof error.severity === "string"
+        ? (error.severity as QueryErrorSeverity)
+        : QueryErrorSeverity.Error;
     const location =
       "location" in error && typeof error.location === "object"
         ? locationResolver(error.location as { start: number; end: number })

--- a/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
+++ b/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
@@ -608,16 +608,16 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
 
               <AccordionItem value="4">
                 <AccordionHeader>
-                  <div className={styles.header}>RU Threshold</div>
+                  <div className={styles.header}>RU Limit</div>
                 </AccordionHeader>
                 <AccordionPanel>
                   <div className={styles.settingsSectionContainer}>
                     <div className={styles.settingsSectionDescription}>
-                      If a query exceeds a configured RU threshold, the query will be aborted.
+                      If a query exceeds a configured RU limit, the query will be aborted.
                     </div>
                     <Toggle
                       styles={toggleStyles}
-                      label="Enable RU threshold"
+                      label="Enable RU limit"
                       onChange={handleOnRUThresholdToggleChange}
                       defaultChecked={ruThresholdEnabled}
                     />
@@ -625,7 +625,7 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                   {ruThresholdEnabled && (
                     <div className={styles.settingsSectionContainer}>
                       <SpinButton
-                        label="RU Threshold (RU)"
+                        label="RU Limit (RU)"
                         labelPosition={Position.top}
                         defaultValue={(ruThreshold || DefaultRUThreshold).toString()}
                         min={1}

--- a/src/Explorer/Panes/SettingsPane/__snapshots__/SettingsPane.test.tsx.snap
+++ b/src/Explorer/Panes/SettingsPane/__snapshots__/SettingsPane.test.tsx.snap
@@ -154,7 +154,7 @@ exports[`Settings Pane should render Default properly 1`] = `
           <div
             className="___15c001r_0000000 fq02s40"
           >
-            RU Threshold
+            RU Limit
           </div>
         </AccordionHeader>
         <AccordionPanel>
@@ -164,11 +164,11 @@ exports[`Settings Pane should render Default properly 1`] = `
             <div
               className="___10gar1i_0000000 f1fow5ox f1ugzwwg"
             >
-              If a query exceeds a configured RU threshold, the query will be aborted.
+              If a query exceeds a configured RU limit, the query will be aborted.
             </div>
             <StyledToggleBase
               defaultChecked={true}
-              label="Enable RU threshold"
+              label="Enable RU limit"
               onChange={[Function]}
               styles={
                 {
@@ -193,7 +193,7 @@ exports[`Settings Pane should render Default properly 1`] = `
               decrementButtonAriaLabel="Decrease value by 1000"
               defaultValue="5000"
               incrementButtonAriaLabel="Increase value by 1000"
-              label="RU Threshold (RU)"
+              label="RU Limit (RU)"
               labelPosition={0}
               min={1}
               onChange={[Function]}

--- a/src/Explorer/Tabs/QueryTab/ErrorList.tsx
+++ b/src/Explorer/Tabs/QueryTab/ErrorList.tsx
@@ -10,7 +10,6 @@ import {
   TableColumnDefinition,
   TableColumnSizingOptions,
   createTableColumn,
-  mergeClasses,
   tokens
 } from "@fluentui/react-components";
 import { ErrorCircleFilled, MoreHorizontalRegular, QuestionRegular, WarningFilled } from "@fluentui/react-icons";
@@ -36,37 +35,37 @@ export const ErrorList: React.FC<{ errors: QueryError[] }> = ({ errors }) => {
       columnId: "code",
       compare: (item1, item2) => item1.code.localeCompare(item2.code),
       renderHeaderCell: () => "Code",
-      renderCell: (item) => <div className={styles.errorListTableCell}>{item.code}</div>, //<div className={styles.errorListTableCell}>{item.code}</div>
+      renderCell: (item) => <TableCellLayout truncate>{item.code}</TableCellLayout>,
     }),
     createTableColumn<QueryError>({
       columnId: "severity",
       compare: (item1, item2) => compareSeverity(item1.severity, item2.severity),
       renderHeaderCell: () => "Severity",
-      renderCell: (item) => <TableCellLayout className={styles.errorListTableCell} media={severityIcons[item.severity]}>{item.severity}</TableCellLayout>,
+      renderCell: (item) => <TableCellLayout truncate media={severityIcons[item.severity]}>{item.severity}</TableCellLayout>,
     }),
     createTableColumn<QueryError>({
       columnId: "location",
       compare: (item1, item2) => item1.location?.start?.offset - item2.location?.start?.offset,
       renderHeaderCell: () => "Location",
       renderCell: (item) =>
-        <div className={styles.errorListTableCell}>
+        <TableCellLayout truncate>
           {item.location
             ? item.location.start.lineNumber
               ? `Line ${item.location.start.lineNumber}`
               : "<unknown>"
             : "<no location>"}
-        </div>,
+        </TableCellLayout>,
     }),
     createTableColumn<QueryError>({
       columnId: "message",
       compare: (item1, item2) => item1.message.localeCompare(item2.message),
       renderHeaderCell: () => "Message",
       renderCell: (item) => (
-        <div className={mergeClasses(styles.errorListTableCell, styles.errorListMessageCell)}>
+        <div className={styles.errorListMessageCell}>
           <div className={styles.errorListMessage} title={item.message}>
             {item.message}
           </div>
-          <div>
+          <div className={styles.errorListMessageActions}>
             {item.helpLink &&
               <Button
                 as="a"

--- a/src/Explorer/Tabs/QueryTab/ErrorList.tsx
+++ b/src/Explorer/Tabs/QueryTab/ErrorList.tsx
@@ -10,9 +10,10 @@ import {
   TableColumnDefinition,
   TableColumnSizingOptions,
   createTableColumn,
-  tokens,
+  mergeClasses,
+  tokens
 } from "@fluentui/react-components";
-import { ErrorCircleFilled, MoreHorizontalRegular, WarningFilled } from "@fluentui/react-icons";
+import { ErrorCircleFilled, MoreHorizontalRegular, QuestionRegular, WarningFilled } from "@fluentui/react-icons";
 import QueryError, { QueryErrorSeverity, compareSeverity } from "Common/QueryError";
 import { useQueryTabStyles } from "Explorer/Tabs/QueryTab/Styles";
 import { useNotificationConsole } from "hooks/useNotificationConsole";
@@ -34,34 +35,48 @@ export const ErrorList: React.FC<{ errors: QueryError[] }> = ({ errors }) => {
     createTableColumn<QueryError>({
       columnId: "code",
       compare: (item1, item2) => item1.code.localeCompare(item2.code),
-      renderHeaderCell: () => null,
-      renderCell: (item) => item.code,
+      renderHeaderCell: () => "Code",
+      renderCell: (item) => <div className={styles.errorListTableCell}>{item.code}</div>, //<div className={styles.errorListTableCell}>{item.code}</div>
     }),
     createTableColumn<QueryError>({
       columnId: "severity",
       compare: (item1, item2) => compareSeverity(item1.severity, item2.severity),
-      renderHeaderCell: () => null,
-      renderCell: (item) => <TableCellLayout media={severityIcons[item.severity]}>{item.severity}</TableCellLayout>,
+      renderHeaderCell: () => "Severity",
+      renderCell: (item) => <TableCellLayout className={styles.errorListTableCell} media={severityIcons[item.severity]}>{item.severity}</TableCellLayout>,
     }),
     createTableColumn<QueryError>({
       columnId: "location",
       compare: (item1, item2) => item1.location?.start?.offset - item2.location?.start?.offset,
       renderHeaderCell: () => "Location",
       renderCell: (item) =>
-        item.location
-          ? item.location.start.lineNumber
-            ? `Line ${item.location.start.lineNumber}`
-            : "<unknown>"
-          : "<no location>",
+        <div className={styles.errorListTableCell}>
+          {item.location
+            ? item.location.start.lineNumber
+              ? `Line ${item.location.start.lineNumber}`
+              : "<unknown>"
+            : "<no location>"}
+        </div>,
     }),
     createTableColumn<QueryError>({
       columnId: "message",
       compare: (item1, item2) => item1.message.localeCompare(item2.message),
       renderHeaderCell: () => "Message",
       renderCell: (item) => (
-        <div className={styles.errorListMessageCell}>
-          <div className={styles.errorListMessage}>{item.message}</div>
+        <div className={mergeClasses(styles.errorListTableCell, styles.errorListMessageCell)}>
+          <div className={styles.errorListMessage} title={item.message}>
+            {item.message}
+          </div>
           <div>
+            {item.helpLink &&
+              <Button
+                as="a"
+                aria-label="Help"
+                appearance="subtle"
+                icon={<QuestionRegular />}
+                href={item.helpLink}
+                target="_blank"
+              />
+            }
             <Button
               aria-label="Details"
               appearance="subtle"
@@ -76,9 +91,9 @@ export const ErrorList: React.FC<{ errors: QueryError[] }> = ({ errors }) => {
 
   const columnSizingOptions: TableColumnSizingOptions = {
     code: {
-      minWidth: 75,
-      idealWidth: 75,
-      defaultWidth: 75,
+      minWidth: 90,
+      idealWidth: 90,
+      defaultWidth: 90,
     },
     severity: {
       minWidth: 100,

--- a/src/Explorer/Tabs/QueryTab/ErrorList.tsx
+++ b/src/Explorer/Tabs/QueryTab/ErrorList.tsx
@@ -10,7 +10,7 @@ import {
   TableColumnDefinition,
   TableColumnSizingOptions,
   createTableColumn,
-  tokens
+  tokens,
 } from "@fluentui/react-components";
 import { ErrorCircleFilled, MoreHorizontalRegular, QuestionRegular, WarningFilled } from "@fluentui/react-icons";
 import QueryError, { QueryErrorSeverity, compareSeverity } from "Common/QueryError";
@@ -41,20 +41,25 @@ export const ErrorList: React.FC<{ errors: QueryError[] }> = ({ errors }) => {
       columnId: "severity",
       compare: (item1, item2) => compareSeverity(item1.severity, item2.severity),
       renderHeaderCell: () => "Severity",
-      renderCell: (item) => <TableCellLayout truncate media={severityIcons[item.severity]}>{item.severity}</TableCellLayout>,
+      renderCell: (item) => (
+        <TableCellLayout truncate media={severityIcons[item.severity]}>
+          {item.severity}
+        </TableCellLayout>
+      ),
     }),
     createTableColumn<QueryError>({
       columnId: "location",
       compare: (item1, item2) => item1.location?.start?.offset - item2.location?.start?.offset,
       renderHeaderCell: () => "Location",
-      renderCell: (item) =>
+      renderCell: (item) => (
         <TableCellLayout truncate>
           {item.location
             ? item.location.start.lineNumber
               ? `Line ${item.location.start.lineNumber}`
               : "<unknown>"
             : "<no location>"}
-        </TableCellLayout>,
+        </TableCellLayout>
+      ),
     }),
     createTableColumn<QueryError>({
       columnId: "message",
@@ -66,7 +71,7 @@ export const ErrorList: React.FC<{ errors: QueryError[] }> = ({ errors }) => {
             {item.message}
           </div>
           <div className={styles.errorListMessageActions}>
-            {item.helpLink &&
+            {item.helpLink && (
               <Button
                 as="a"
                 aria-label="Help"
@@ -75,7 +80,7 @@ export const ErrorList: React.FC<{ errors: QueryError[] }> = ({ errors }) => {
                 href={item.helpLink}
                 target="_blank"
               />
-            }
+            )}
             <Button
               aria-label="Details"
               appearance="subtle"

--- a/src/Explorer/Tabs/QueryTab/Styles.ts
+++ b/src/Explorer/Tabs/QueryTab/Styles.ts
@@ -86,6 +86,11 @@ export const useQueryTabStyles = makeStyles({
   errorListMessage: {
     flexGrow: 1,
     textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
     overflow: "hidden",
+  },
+  errorListMessageActions: {
+    display: "flex",
+    flexDirection: "row",
   },
 });

--- a/src/Explorer/Tabs/QueryTab/Styles.ts
+++ b/src/Explorer/Tabs/QueryTab/Styles.ts
@@ -72,6 +72,11 @@ export const useQueryTabStyles = makeStyles({
   metricsGridButtons: {
     ...cosmosShorthands.borderTop(),
   },
+  errorListTableCell: {
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+  },
   errorListMessageCell: {
     display: "flex",
     flexDirection: "row",
@@ -80,5 +85,7 @@ export const useQueryTabStyles = makeStyles({
   },
   errorListMessage: {
     flexGrow: 1,
+    textOverflow: "ellipsis",
+    overflow: "hidden",
   },
 });

--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -1,7 +1,7 @@
-import { IMessageBarStyles, Link, MessageBar, MessageBarButton, MessageBarType } from "@fluentui/react";
+import { IMessageBarStyles, MessageBar, MessageBarButton, MessageBarType } from "@fluentui/react";
 import { CassandraProxyEndpoints, MongoProxyEndpoints } from "Common/Constants";
 import { sendMessage } from "Common/MessageHandler";
-import { Platform, configContext, updateConfigContext } from "ConfigContext";
+import { configContext, updateConfigContext } from "ConfigContext";
 import { IpRule } from "Contracts/DataModels";
 import { MessageTypes } from "Contracts/ExplorerContracts";
 import { CollectionTabKind } from "Contracts/ViewModels";
@@ -16,7 +16,6 @@ import { VcoreMongoConnectTab } from "Explorer/Tabs/VCoreMongoConnectTab";
 import { VcoreMongoQuickstartTab } from "Explorer/Tabs/VCoreMongoQuickstartTab";
 import { LayoutConstants } from "Explorer/Theme/ThemeUtil";
 import { KeyboardAction, KeyboardActionGroup, useKeyboardActionGroup } from "KeyboardShortcuts";
-import { hasRUThresholdBeenConfigured } from "Shared/StorageUtility";
 import { userContext } from "UserContext";
 import { CassandraProxyOutboundIPs, MongoProxyOutboundIPs, PortalBackendIPs } from "Utils/EndpointUtils";
 import { useTeachingBubble } from "hooks/useTeachingBubble";
@@ -37,9 +36,6 @@ interface TabsProps {
 
 export const Tabs = ({ explorer }: TabsProps): JSX.Element => {
   const { openedTabs, openedReactTabs, activeTab, activeReactTab, networkSettingsWarning } = useTabs();
-  const [showRUThresholdMessageBar, setShowRUThresholdMessageBar] = useState<boolean>(
-    userContext.apiType === "SQL" && configContext.platform !== Platform.Fabric && !hasRUThresholdBeenConfigured(),
-  );
   const [
     showMongoAndCassandraProxiesNetworkSettingsWarningState,
     setShowMongoAndCassandraProxiesNetworkSettingsWarningState,
@@ -85,30 +81,6 @@ export const Tabs = ({ explorer }: TabsProps): JSX.Element => {
           messageBarIconProps={{ iconName: "WarningSolid", className: "messageBarWarningIcon" }}
         >
           {networkSettingsWarning}
-        </MessageBar>
-      )}
-      {showRUThresholdMessageBar && (
-        <MessageBar
-          messageBarType={MessageBarType.info}
-          onDismiss={() => {
-            setShowRUThresholdMessageBar(false);
-          }}
-          styles={{
-            ...defaultMessageBarStyles,
-            innerText: {
-              fontWeight: "bold",
-            },
-          }}
-          dismissButtonAriaLabel="Close info"
-        >
-          {`Data Explorer has a 5,000 RU default limit. To adjust the limit, go to the Settings page and find "RU Threshold".`}
-          <Link
-            className="underlinedLink"
-            href="https://review.learn.microsoft.com/en-us/azure/cosmos-db/data-explorer?branch=main#configure-request-unit-threshold"
-            target="_blank"
-          >
-            Learn More
-          </Link>
         </MessageBar>
       )}
       {showMongoAndCassandraProxiesNetworkSettingsWarningState && (


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1966)

Currently, if you open DE and don't have any "RU Threshold" value set in settings, you get this banner:

![image](https://github.com/user-attachments/assets/2a167f7a-de72-4f55-80a3-2fc92765b4a6)

This takes up a fair amount of vertical space, especially in the portal, and is telling you something that you may not be interested in, and it may never be relevant for a user depending on the kinds of queries they run and the data they're querying. Plus, the only way to permanently dismiss it is to go to the settings and set an RU Threshold explicitly, which isn't easy.

So, this PR removes that banner. Instead of the banner, I've added logic to refine the error message when the RU limit is violated for a given query. Prior to this PR, that error looked like this:

![image](https://github.com/user-attachments/assets/50a0234e-6e09-4336-a616-c564438f843c)

The error message is coming from the JS SDK, and is accurate but not particularly helpful to a Data Explorer user. They don't know how that RU limit was set, nor how to change it. So, we detect this case by looking at the `code` field of the error (which is `OPERATION_RU_LIMIT_EXCEEDED`) and provide a new message of our own that includes context useful to a DE user:

![image](https://github.com/user-attachments/assets/d14d0303-6fe9-406e-9d91-80f38a21ae01)

In addition, the user can click the "?" icon to the right of the message to open [the documentation page describing the RU threshold feature](https://learn.microsoft.com/en-us/azure/cosmos-db/data-explorer#configure-request-unit-threshold), which was previously available through the "Learn More" link in the banner.

Given these updates, I felt OK removing the banner altogether and regaining that space.

**In addition** I noticed that a lot of the messaging around this feature refers to it as a "limit", including the error message coming from the SDK. Given that, I felt it would be clearer to rename the settings field from "RU Threshold" to "RU Limit". I did this as the last commit on the branch though, so that I could easily remove it if we didn't want to do that rename. If we are OK with that rename, I can also go ahead and make a PR to the docs to update the documentation page I referenced above (which shows it as RU Threshold)

