### PR TITLE
Descriptive Label is not provided for 'Value' edit fields under 'Add Table Row' pane.

### DIFF
--- a/src/Common/EntityValue.tsx
+++ b/src/Common/EntityValue.tsx
@@ -10,6 +10,7 @@ export interface TableEntityProps {
   isEntityValueDisable?: boolean;
   entityTimeValue: string;
   entityValueType: string;
+  entityProperty: string;
   onEntityValueChange: (event: React.FormEvent<HTMLElement>, newInput?: string) => void;
   onSelectDate: (date: Date | null | undefined) => void;
   onEntityTimeValueChange: (event: React.FormEvent<HTMLElement>, newInput?: string) => void;
@@ -26,6 +27,7 @@ export const EntityValue: FunctionComponent<TableEntityProps> = ({
   onSelectDate,
   isEntityValueDisable,
   onEntityTimeValueChange,
+  entityProperty,
 }: TableEntityProps): JSX.Element => {
   if (isEntityTypeDate) {
     return (
@@ -51,15 +53,20 @@ export const EntityValue: FunctionComponent<TableEntityProps> = ({
   }
 
   return (
-    <TextField
-      label={entityValueLabel && entityValueLabel}
-      className="addEntityTextField"
-      disabled={isEntityValueDisable}
-      type={entityValueType}
-      placeholder={entityValuePlaceholder}
-      value={typeof entityValue === "string" ? entityValue : ""}
-      onChange={onEntityValueChange}
-      ariaLabel={attributeValueLabel}
-    />
+    <>
+      <span id={entityProperty} className="screenReaderOnly">
+        Edit Property {entityProperty} {attributeValueLabel}
+      </span>
+      <TextField
+        label={entityValueLabel && entityValueLabel}
+        className="addEntityTextField"
+        disabled={isEntityValueDisable}
+        type={entityValueType}
+        placeholder={entityValuePlaceholder}
+        value={typeof entityValue === "string" ? entityValue : ""}
+        onChange={onEntityValueChange}
+        aria-labelledby={entityProperty}
+      />
+    </>
   );
 };

--- a/src/Common/TableEntity.tsx
+++ b/src/Common/TableEntity.tsx
@@ -135,6 +135,7 @@ export const TableEntity: FunctionComponent<TableEntityProps> = ({
           onEntityValueChange={onEntityValueChange}
           onSelectDate={onSelectDate}
           onEntityTimeValueChange={onEntityTimeValueChange}
+          entityProperty={entityProperty}
         />
         {!isEntityValueDisable && (
           <TooltipHost content="Edit property" id="editTooltip">


### PR DESCRIPTION
This pull request addresses an accessibility issue in the 'Add Table Row' pane within Azure Cosmos DB. Specifically, it corrects a missing descriptive label for the 'Value' edit fields, which was impacting screen reader users.

![image](https://github.com/user-attachments/assets/1c6a8fbd-f66d-499a-b07a-48214e0d1fc0)

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1970?feature.someFeatureFlagYouMightNeed=true)
