### PR TITLE
Add config files for Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm
+
+# Install pre-reqs for gyp, and 'canvas' npm module
+RUN apt-get update && \
+    apt-get install -y \
+        make \
+        gcc \
+        g++ \
+        python3-minimal \
+        libcairo2-dev \
+        libpango1.0-dev \
+        && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install node-gyp to build native modules
+RUN npm install -g node-gyp

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Azure Cosmos DB Explorer",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"onCreateCommand": ".devcontainer/oncreate",
+	"features": {
+		"ghcr.io/devcontainers/features/azure-cli:1": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/github-cli:1": {
+			"installDirectlyFromGitHubRelease": true,
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/sshd:1": {
+			"version": "latest"
+		}
+	}
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/oncreate
+++ b/.devcontainer/oncreate
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Install packages once, to prime the node_modules directory.
+npm ci


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

*This change doesn't affect the app functionality at all*

This PR adds a few config files to provide a standardized configuration for launching a GitHub Codespace or VS Code Dev Container (locally) for this repo. It doesn't require the use of codespaces at all, but makes it possible for a user to quickly open the repo up in a Codespace that is preconfigured to immediately run the app.

I've been using Codespaces more for development and trying it out on this repo (among others I'm working with, in particular the Azure SDKs) and it provides a useful alternative to having to install all the prereqs on my local box.
