### PR TITLE
Set shared throughput default to false for New Databases

### DIFF
--- a/src/Common/DatabaseUtility.ts
+++ b/src/Common/DatabaseUtility.ts
@@ -1,0 +1,3 @@
+export function getNewDatabaseSharedThroughputDefault(): boolean {
+  return false;
+}

--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -17,10 +17,10 @@ import {
 } from "@fluentui/react";
 import * as Constants from "Common/Constants";
 import { createCollection } from "Common/dataAccess/createCollection";
+import { getNewDatabaseSharedThroughputDefault } from "Common/DatabaseUtility";
 import { getErrorMessage, getErrorStack } from "Common/ErrorHandlingUtils";
 import { configContext, Platform } from "ConfigContext";
 import * as DataModels from "Contracts/DataModels";
-import { SubscriptionType } from "Contracts/SubscriptionType";
 import { AddVectorEmbeddingPolicyForm } from "Explorer/Panes/VectorSearchPanel/AddVectorEmbeddingPolicyForm";
 import { useSidePanel } from "hooks/useSidePanel";
 import { useTeachingBubble } from "hooks/useTeachingBubble";
@@ -125,7 +125,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
       createNewDatabase:
         userContext.apiType !== "Tables" && configContext.platform !== Platform.Fabric && !this.props.databaseId,
       newDatabaseId: props.isQuickstart ? this.getSampleDBName() : "",
-      isSharedThroughputChecked: this.getSharedThroughputDefault(),
+      isSharedThroughputChecked: getNewDatabaseSharedThroughputDefault(),
       selectedDatabaseId:
         userContext.apiType === "Tables" ? CollectionCreation.TablesAPIDefaultDatabase : this.props.databaseId,
       collectionId: props.isQuickstart ? `Sample${getCollectionName()}` : "",
@@ -1136,10 +1136,6 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
 
   private isFreeTierAccount(): boolean {
     return userContext.databaseAccount?.properties?.enableFreeTier;
-  }
-
-  private getSharedThroughputDefault(): boolean {
-    return userContext.subscriptionType !== SubscriptionType.EA && !isServerlessAccount();
   }
 
   private getFreeTierIndexingText(): string {

--- a/src/Explorer/Panes/AddDatabasePanel/AddDatabasePanel.tsx
+++ b/src/Explorer/Panes/AddDatabasePanel/AddDatabasePanel.tsx
@@ -1,4 +1,5 @@
 import { Checkbox, Stack, Text, TextField } from "@fluentui/react";
+import { getNewDatabaseSharedThroughputDefault } from "Common/DatabaseUtility";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import * as Constants from "../../../Common/Constants";
 import { getErrorMessage, getErrorStack } from "../../../Common/ErrorHandlingUtils";
@@ -48,7 +49,7 @@ export const AddDatabasePanel: FunctionComponent<AddDatabasePaneProps> = ({
 
   const databaseLevelThroughputTooltipText = `Provisioned throughput at the ${databaseLabel} level will be shared across all ${collectionsLabel} within the ${databaseLabel}.`;
   const [databaseCreateNewShared, setDatabaseCreateNewShared] = useState<boolean>(
-    subscriptionType !== SubscriptionType.EA && !isServerlessAccount(),
+    getNewDatabaseSharedThroughputDefault(),
   );
   const [formErrors, setFormErrors] = useState<string>("");
   const [isExecuting, setIsExecuting] = useState<boolean>(false);

--- a/src/Explorer/Panes/AddDatabasePanel/__snapshots__/AddDatabasePanel.test.tsx.snap
+++ b/src/Explorer/Panes/AddDatabasePanel/__snapshots__/AddDatabasePanel.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`AddDatabasePane Pane should render Default properly 1`] = `
         horizontal={true}
       >
         <StyledCheckboxBase
-          checked={true}
+          checked={false}
           label="Provision throughput"
           onChange={[Function]}
           styles={
@@ -90,14 +90,6 @@ exports[`AddDatabasePane Pane should render Default properly 1`] = `
         </InfoTooltip>
       </Stack>
     </Stack>
-    <ThroughputInput
-      isDatabase={true}
-      isSharded={true}
-      onCostAcknowledgeChange={[Function]}
-      setIsAutoscale={[Function]}
-      setIsThroughputCapExceeded={[Function]}
-      setThroughputValue={[Function]}
-    />
   </div>
 </RightPaneForm>
 `;

--- a/src/Explorer/Panes/__snapshots__/AddCollectionPanel.test.tsx.snap
+++ b/src/Explorer/Panes/__snapshots__/AddCollectionPanel.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`AddCollectionPanel should render Default properly 1`] = `
           horizontal={true}
         >
           <StyledCheckboxBase
-            checked={true}
+            checked={false}
             label="Share throughput across containers"
             onChange={[Function]}
             styles={
@@ -137,14 +137,6 @@ exports[`AddCollectionPanel should render Default properly 1`] = `
             />
           </StyledTooltipHostBase>
         </Stack>
-        <ThroughputInput
-          isDatabase={true}
-          isSharded={true}
-          onCostAcknowledgeChange={[Function]}
-          setIsAutoscale={[Function]}
-          setIsThroughputCapExceeded={[Function]}
-          setThroughputValue={[Function]}
-        />
       </Stack>
       <Separator
         className="panelSeparator"
@@ -263,6 +255,14 @@ exports[`AddCollectionPanel should render Default properly 1`] = `
         </CustomizedDefaultButton>
       </Stack>
     </Stack>
+    <ThroughputInput
+      isDatabase={false}
+      isSharded={true}
+      onCostAcknowledgeChange={[Function]}
+      setIsAutoscale={[Function]}
+      setIsThroughputCapExceeded={[Function]}
+      setThroughputValue={[Function]}
+    />
     <Stack>
       <Stack
         horizontal={true}

--- a/test/cassandra/container.spec.ts
+++ b/test/cassandra/container.spec.ts
@@ -14,7 +14,6 @@ test("Cassandra keyspace and table CRUD", async ({ page }) => {
     async (panel, okButton) => {
       await panel.getByPlaceholder("Type a new keyspace id").fill(keyspaceId);
       await panel.getByPlaceholder("Enter table Id").fill(tableId);
-      await panel.getByLabel("Table max RU/s").fill("1000");
       await okButton.click();
     },
     { closeTimeout: 5 * 60 * 1000 },

--- a/test/gremlin/container.spec.ts
+++ b/test/gremlin/container.spec.ts
@@ -16,7 +16,6 @@ test("Gremlin graph CRUD", async ({ page }) => {
       await panel.getByPlaceholder("Type a new database id").fill(databaseId);
       await panel.getByRole("textbox", { name: "Graph id, Example Graph1" }).fill(graphId);
       await panel.getByRole("textbox", { name: "Partition key" }).fill("/pk");
-      await panel.getByLabel("Database max RU/s").fill("1000");
       await okButton.click();
     },
     { closeTimeout: 5 * 60 * 1000 },

--- a/test/mongo/container.spec.ts
+++ b/test/mongo/container.spec.ts
@@ -21,7 +21,6 @@ import { DataExplorer, TestAccount, generateUniqueName } from "../fx";
         await panel.getByPlaceholder("Type a new database id").fill(databaseId);
         await panel.getByRole("textbox", { name: "Collection id, Example Collection1" }).fill(collectionId);
         await panel.getByRole("textbox", { name: "Shard key" }).fill("pk");
-        await panel.getByLabel("Database max RU/s").fill("1000");
         await okButton.click();
       },
       { closeTimeout: 5 * 60 * 1000 },

--- a/test/sql/container.spec.ts
+++ b/test/sql/container.spec.ts
@@ -15,7 +15,6 @@ test("SQL database and container CRUD", async ({ page }) => {
       await panel.getByPlaceholder("Type a new database id").fill(databaseId);
       await panel.getByRole("textbox", { name: "Container id, Example Container1" }).fill(containerId);
       await panel.getByRole("textbox", { name: "Partition key" }).fill("/pk");
-      await panel.getByLabel("Database max RU/s").fill("1000");
       await okButton.click();
     },
     { closeTimeout: 5 * 60 * 1000 },


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1981?feature.someFeatureFlagYouMightNeed=true)

Pulls the logic for determining the default value of enabling shared throughput when creating a new database into a common function and then changes that to false. 