### PR TITLE
Switch E2E tests to use new accounts.

### DIFF
--- a/test/fx.ts
+++ b/test/fx.ts
@@ -40,15 +40,15 @@ export enum TestAccount {
 }
 
 export const defaultAccounts: Record<TestAccount, string> = {
-  [TestAccount.Tables]: "portal-tables-runner",
-  [TestAccount.Cassandra]: "portal-cassandra-runner",
-  [TestAccount.Gremlin]: "portal-gremlin-runner",
-  [TestAccount.Mongo]: "portal-mongo-runner",
-  [TestAccount.Mongo32]: "portal-mongo32-runner",
-  [TestAccount.SQL]: "portal-sql-runner-west-us",
+  [TestAccount.Tables]: "github-e2etests-tables",
+  [TestAccount.Cassandra]: "github-e2etests-cassandra",
+  [TestAccount.Gremlin]: "github-e2etests-gremlin",
+  [TestAccount.Mongo]: "github-e2etests-mongo",
+  [TestAccount.Mongo32]: "github-e2etests-mongo32",
+  [TestAccount.SQL]: "github-e2etests-sql",
 };
 
-export const resourceGroupName = process.env.DE_TEST_RESOURCE_GROUP ?? "runners";
+export const resourceGroupName = process.env.DE_TEST_RESOURCE_GROUP ?? "de-e2e-tests";
 export const subscriptionId = process.env.DE_TEST_SUBSCRIPTION_ID ?? "69e02f2d-f059-4409-9eac-97e8a276ae2c";
 
 function tryGetStandardName(accountType: TestAccount) {

--- a/utils/cleanupDBs.js
+++ b/utils/cleanupDBs.js
@@ -3,7 +3,7 @@ const { CosmosDBManagementClient } = require("@azure/arm-cosmosdb");
 const ms = require("ms");
 
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
-const resourceGroupName = "runners";
+const resourceGroupName = "de-e2e-tests";
 
 const thirtyMinutesAgo = new Date(Date.now() - 1000 * 60 * 30).getTime();
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,7 @@ const gitSha = childProcess.execSync("git rev-parse HEAD").toString("utf8");
 const AZURE_CLIENT_ID = "fd8753b0-0707-4e32-84e9-2532af865fb4";
 const AZURE_TENANT_ID = "72f988bf-86f1-41af-91ab-2d7cd011db47";
 const SUBSCRIPTION_ID = "69e02f2d-f059-4409-9eac-97e8a276ae2c";
-const RESOURCE_GROUP = "runners";
+const RESOURCE_GROUP = "de-e2e-tests";
 const AZURE_CLIENT_SECRET = process.env.AZURE_CLIENT_SECRET || process.env.NOTEBOOKS_TEST_RUNNER_CLIENT_SECRET; // TODO Remove. Exists for backwards compat with old .env files. Prefer AZURE_CLIENT_SECRET
 
 if (!AZURE_CLIENT_SECRET) {


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1982?feature.someFeatureFlagYouMightNeed=true)

This change modifies the E2E test configuration to use a new set of database accounts.
