### PR TITLE
Pull Additional Allowed Cassandra and Mongo Proxy Endpoints from Deployed Config

### DIFF
--- a/src/Common/MongoProxyClient.ts
+++ b/src/Common/MongoProxyClient.ts
@@ -1,7 +1,7 @@
 import { Constants as CosmosSDKConstants } from "@azure/cosmos";
 import {
-  allowedMongoProxyEndpoints,
   allowedMongoProxyEndpoints_ToBeDeprecated,
+  defaultAllowedMongoProxyEndpoints,
   validateEndpoint,
 } from "Utils/EndpointUtils";
 import queryString from "querystring";
@@ -689,15 +689,16 @@ export function createMongoCollectionWithProxy_ToBeDeprecated(
 }
 export function getFeatureEndpointOrDefault(feature: string): string {
   let endpoint;
+  const allowedMongoProxyEndpoints = configContext.allowedMongoProxyEndpoints || [
+    ...defaultAllowedMongoProxyEndpoints,
+    ...allowedMongoProxyEndpoints_ToBeDeprecated,
+  ];
   if (useMongoProxyEndpoint(feature)) {
     endpoint = configContext.MONGO_PROXY_ENDPOINT;
   } else {
     endpoint =
       hasFlag(userContext.features.mongoProxyAPIs, feature) &&
-      validateEndpoint(userContext.features.mongoProxyEndpoint, [
-        ...allowedMongoProxyEndpoints,
-        ...allowedMongoProxyEndpoints_ToBeDeprecated,
-      ])
+      validateEndpoint(userContext.features.mongoProxyEndpoint, allowedMongoProxyEndpoints)
         ? userContext.features.mongoProxyEndpoint
         : configContext.MONGO_BACKEND_ENDPOINT || configContext.BACKEND_ENDPOINT;
   }

--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -8,7 +8,6 @@ import {
 import {
   allowedAadEndpoints,
   allowedArcadiaEndpoints,
-  allowedCassandraProxyEndpoints,
   allowedEmulatorEndpoints,
   allowedGraphEndpoints,
   allowedHostedExplorerEndpoints,
@@ -18,6 +17,7 @@ import {
   allowedMsalRedirectEndpoints,
   defaultAllowedArmEndpoints,
   defaultAllowedBackendEndpoints,
+  defaultAllowedCassandraProxyEndpoints,
   validateEndpoint,
 } from "Utils/EndpointUtils";
 
@@ -32,6 +32,7 @@ export interface ConfigContext {
   platform: Platform;
   allowedArmEndpoints: ReadonlyArray<string>;
   allowedBackendEndpoints: ReadonlyArray<string>;
+  allowedCassandraProxyEndpoints: ReadonlyArray<string>;
   allowedParentFrameOrigins: ReadonlyArray<string>;
   gitSha?: string;
   proxyPath?: string;
@@ -72,6 +73,7 @@ let configContext: Readonly<ConfigContext> = {
   platform: Platform.Portal,
   allowedArmEndpoints: defaultAllowedArmEndpoints,
   allowedBackendEndpoints: defaultAllowedBackendEndpoints,
+  allowedCassandraProxyEndpoints: defaultAllowedCassandraProxyEndpoints,
   allowedParentFrameOrigins: [
     `^https:\\/\\/cosmos\\.azure\\.(com|cn|us)$`,
     `^https:\\/\\/[\\.\\w]*portal\\.azure\\.(com|cn|us)$`,
@@ -161,7 +163,12 @@ export function updateConfigContext(newContext: Partial<ConfigContext>): void {
     delete newContext.MONGO_BACKEND_ENDPOINT;
   }
 
-  if (!validateEndpoint(newContext.CASSANDRA_PROXY_ENDPOINT, allowedCassandraProxyEndpoints)) {
+  if (
+    !validateEndpoint(
+      newContext.CASSANDRA_PROXY_ENDPOINT,
+      configContext.allowedCassandraProxyEndpoints || defaultAllowedCassandraProxyEndpoints,
+    )
+  ) {
     delete newContext.CASSANDRA_PROXY_ENDPOINT;
   }
 

--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -13,11 +13,11 @@ import {
   allowedHostedExplorerEndpoints,
   allowedJunoOrigins,
   allowedMongoBackendEndpoints,
-  allowedMongoProxyEndpoints,
   allowedMsalRedirectEndpoints,
   defaultAllowedArmEndpoints,
   defaultAllowedBackendEndpoints,
   defaultAllowedCassandraProxyEndpoints,
+  defaultAllowedMongoProxyEndpoints,
   validateEndpoint,
 } from "Utils/EndpointUtils";
 
@@ -33,6 +33,7 @@ export interface ConfigContext {
   allowedArmEndpoints: ReadonlyArray<string>;
   allowedBackendEndpoints: ReadonlyArray<string>;
   allowedCassandraProxyEndpoints: ReadonlyArray<string>;
+  allowedMongoProxyEndpoints: ReadonlyArray<string>;
   allowedParentFrameOrigins: ReadonlyArray<string>;
   gitSha?: string;
   proxyPath?: string;
@@ -74,6 +75,7 @@ let configContext: Readonly<ConfigContext> = {
   allowedArmEndpoints: defaultAllowedArmEndpoints,
   allowedBackendEndpoints: defaultAllowedBackendEndpoints,
   allowedCassandraProxyEndpoints: defaultAllowedCassandraProxyEndpoints,
+  allowedMongoProxyEndpoints: defaultAllowedMongoProxyEndpoints,
   allowedParentFrameOrigins: [
     `^https:\\/\\/cosmos\\.azure\\.(com|cn|us)$`,
     `^https:\\/\\/[\\.\\w]*portal\\.azure\\.(com|cn|us)$`,
@@ -155,7 +157,12 @@ export function updateConfigContext(newContext: Partial<ConfigContext>): void {
     delete newContext.BACKEND_ENDPOINT;
   }
 
-  if (!validateEndpoint(newContext.MONGO_PROXY_ENDPOINT, allowedMongoProxyEndpoints)) {
+  if (
+    !validateEndpoint(
+      newContext.MONGO_PROXY_ENDPOINT,
+      configContext.allowedMongoProxyEndpoints || defaultAllowedMongoProxyEndpoints,
+    )
+  ) {
     delete newContext.MONGO_PROXY_ENDPOINT;
   }
 

--- a/src/Utils/EndpointUtils.ts
+++ b/src/Utils/EndpointUtils.ts
@@ -108,7 +108,7 @@ export const allowedMongoProxyEndpoints_ToBeDeprecated: ReadonlyArray<string> = 
   "https://localhost:12901",
 ];
 
-export const allowedCassandraProxyEndpoints: ReadonlyArray<string> = [
+export const defaultAllowedCassandraProxyEndpoints: ReadonlyArray<string> = [
   CassandraProxyEndpoints.Development,
   CassandraProxyEndpoints.Mpac,
   CassandraProxyEndpoints.Prod,

--- a/src/Utils/EndpointUtils.ts
+++ b/src/Utils/EndpointUtils.ts
@@ -92,7 +92,7 @@ export const MongoProxyOutboundIPs: { [key: string]: string[] } = {
   [MongoProxyEndpoints.Mooncake]: ["52.131.240.99", "143.64.61.130"],
 };
 
-export const allowedMongoProxyEndpoints: ReadonlyArray<string> = [
+export const defaultAllowedMongoProxyEndpoints: ReadonlyArray<string> = [
   MongoProxyEndpoints.Local,
   MongoProxyEndpoints.Mpac,
   MongoProxyEndpoints.Prod,


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1984?feature.someFeatureFlagYouMightNeed=true)

When DE is deployed, config is added.  Allow pulling additional allowedCassandraProxyEndpoints and allowedMongoProxyEndpoints from that deployment config.