### PR TITLE
[Keyboard Navigation - Azure CosmosDB - Data Explorer]: "Learn more" link is not accessible using keyboard present inside the tooltip of "Analytical store’.

### DIFF
--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -804,22 +804,9 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
 
           {this.shouldShowAnalyticalStoreOptions() && (
             <Stack className="panelGroupSpacing">
-              <Stack horizontal>
-                <Text className="panelTextBold" variant="small">
-                  Analytical store
-                </Text>
-                <TooltipHost
-                  directionalHint={DirectionalHint.bottomLeftEdge}
-                  content={this.getAnalyticalStorageTooltipContent()}
-                >
-                  <Icon
-                    iconName="Info"
-                    className="panelInfoIcon"
-                    tabIndex={0}
-                    ariaLabel="Enable analytical store capability to perform near real-time analytics on your operational data, without impacting the performance of transactional workloads."
-                  />
-                </TooltipHost>
-              </Stack>
+              <Text className="panelTextBold" variant="small">
+                {this.getAnalyticalStorageContent()}
+              </Text>
 
               <Stack horizontal verticalAlign="center">
                 <div role="radiogroup">
@@ -1187,7 +1174,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
     return "";
   }
 
-  private getAnalyticalStorageTooltipContent(): JSX.Element {
+  private getAnalyticalStorageContent(): JSX.Element {
     return (
       <Text variant="small">
         Enable analytical store capability to perform near real-time analytics on your operational data, without

--- a/src/Explorer/Panes/__snapshots__/AddCollectionPanel.test.tsx.snap
+++ b/src/Explorer/Panes/__snapshots__/AddCollectionPanel.test.tsx.snap
@@ -309,40 +309,23 @@ exports[`AddCollectionPanel should render Default properly 1`] = `
     <Stack
       className="panelGroupSpacing"
     >
-      <Stack
-        horizontal={true}
+      <Text
+        className="panelTextBold"
+        variant="small"
       >
         <Text
-          className="panelTextBold"
           variant="small"
         >
-          Analytical store
+          Enable analytical store capability to perform near real-time analytics on your operational data, without impacting the performance of transactional workloads.
+           
+          <StyledLinkBase
+            href="https://aka.ms/analytical-store-overview"
+            target="_blank"
+          >
+            Learn more
+          </StyledLinkBase>
         </Text>
-        <StyledTooltipHostBase
-          content={
-            <Text
-              variant="small"
-            >
-              Enable analytical store capability to perform near real-time analytics on your operational data, without impacting the performance of transactional workloads.
-               
-              <StyledLinkBase
-                href="https://aka.ms/analytical-store-overview"
-                target="_blank"
-              >
-                Learn more
-              </StyledLinkBase>
-            </Text>
-          }
-          directionalHint={4}
-        >
-          <Icon
-            ariaLabel="Enable analytical store capability to perform near real-time analytics on your operational data, without impacting the performance of transactional workloads."
-            className="panelInfoIcon"
-            iconName="Info"
-            tabIndex={0}
-          />
-        </StyledTooltipHostBase>
-      </Stack>
+      </Text>
       <Stack
         horizontal={true}
         verticalAlign="center"


### PR DESCRIPTION
The "Learn more" link within the tooltip of the "Analytical store" was initially inaccessible via keyboard navigation, which posed an accessibility concern. To address this issue, we removed the tooltip and restructured the user interface. This improvement not only aligns with our accessibility standards but also enhances overall usability. Users can now easily access the "Learn more" link directly, ensuring a seamless experience without the need for a tooltip.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1989?feature.someFeatureFlagYouMightNeed=true)


![image](https://github.com/user-attachments/assets/967121bd-9b93-4f03-a97e-2481c26ee2c8)

