### PR TITLE
CP and MP API Overrides from Config.json

### DIFF
--- a/src/Common/MongoProxyClient.test.ts
+++ b/src/Common/MongoProxyClient.test.ts
@@ -73,6 +73,7 @@ describe("MongoProxyClient", () => {
       });
       updateConfigContext({
         MONGO_PROXY_ENDPOINT: MongoProxyEndpoints.Prod,
+        globallyEnabledMongoAPIs: [],
       });
       window.fetch = jest.fn().mockImplementation(fetchMock);
     });
@@ -89,7 +90,10 @@ describe("MongoProxyClient", () => {
     });
 
     it("builds the correct proxy URL in development", () => {
-      updateConfigContext({ MONGO_PROXY_ENDPOINT: "https://localhost:1234" });
+      updateConfigContext({
+        MONGO_PROXY_ENDPOINT: "https://localhost:1234",
+        globallyEnabledMongoAPIs: [],
+      });
       queryDocuments(databaseId, collection, true, "{}");
       expect(window.fetch).toHaveBeenCalledWith(
         `${configContext.MONGO_PROXY_ENDPOINT}/api/mongo/explorer/resourcelist`,
@@ -105,6 +109,7 @@ describe("MongoProxyClient", () => {
       });
       updateConfigContext({
         MONGO_PROXY_ENDPOINT: MongoProxyEndpoints.Prod,
+        globallyEnabledMongoAPIs: [],
       });
       window.fetch = jest.fn().mockImplementation(fetchMock);
     });
@@ -121,7 +126,10 @@ describe("MongoProxyClient", () => {
     });
 
     it("builds the correct proxy URL in development", () => {
-      updateConfigContext({ MONGO_PROXY_ENDPOINT: "https://localhost:1234" });
+      updateConfigContext({
+        MONGO_PROXY_ENDPOINT: "https://localhost:1234",
+        globallyEnabledMongoAPIs: [],
+      });
       readDocument(databaseId, collection, documentId);
       expect(window.fetch).toHaveBeenCalledWith(
         `${configContext.MONGO_PROXY_ENDPOINT}/api/mongo/explorer`,
@@ -137,6 +145,7 @@ describe("MongoProxyClient", () => {
       });
       updateConfigContext({
         MONGO_PROXY_ENDPOINT: MongoProxyEndpoints.Prod,
+        globallyEnabledMongoAPIs: [],
       });
       window.fetch = jest.fn().mockImplementation(fetchMock);
     });
@@ -153,7 +162,10 @@ describe("MongoProxyClient", () => {
     });
 
     it("builds the correct proxy URL in development", () => {
-      updateConfigContext({ MONGO_PROXY_ENDPOINT: "https://localhost:1234" });
+      updateConfigContext({
+        MONGO_PROXY_ENDPOINT: "https://localhost:1234",
+        globallyEnabledMongoAPIs: [],
+      });
       readDocument(databaseId, collection, documentId);
       expect(window.fetch).toHaveBeenCalledWith(
         `${configContext.MONGO_PROXY_ENDPOINT}/api/mongo/explorer`,
@@ -169,6 +181,7 @@ describe("MongoProxyClient", () => {
       });
       updateConfigContext({
         MONGO_PROXY_ENDPOINT: MongoProxyEndpoints.Prod,
+        globallyEnabledMongoAPIs: [],
       });
       window.fetch = jest.fn().mockImplementation(fetchMock);
     });
@@ -185,7 +198,10 @@ describe("MongoProxyClient", () => {
     });
 
     it("builds the correct proxy URL in development", () => {
-      updateConfigContext({ MONGO_BACKEND_ENDPOINT: "https://localhost:1234" });
+      updateConfigContext({
+        MONGO_BACKEND_ENDPOINT: "https://localhost:1234",
+        globallyEnabledMongoAPIs: [],
+      });
       updateDocument(databaseId, collection, documentId, "{}");
       expect(window.fetch).toHaveBeenCalledWith(
         `${configContext.MONGO_PROXY_ENDPOINT}/api/mongo/explorer`,
@@ -201,6 +217,7 @@ describe("MongoProxyClient", () => {
       });
       updateConfigContext({
         MONGO_PROXY_ENDPOINT: MongoProxyEndpoints.Prod,
+        globallyEnabledMongoAPIs: [],
       });
       window.fetch = jest.fn().mockImplementation(fetchMock);
     });
@@ -217,7 +234,10 @@ describe("MongoProxyClient", () => {
     });
 
     it("builds the correct proxy URL in development", () => {
-      updateConfigContext({ MONGO_PROXY_ENDPOINT: "https://localhost:1234" });
+      updateConfigContext({
+        MONGO_PROXY_ENDPOINT: "https://localhost:1234",
+        globallyEnabledMongoAPIs: [],
+      });
       deleteDocument(databaseId, collection, documentId);
       expect(window.fetch).toHaveBeenCalledWith(
         `${configContext.MONGO_PROXY_ENDPOINT}/api/mongo/explorer`,
@@ -233,6 +253,7 @@ describe("MongoProxyClient", () => {
       });
       updateConfigContext({
         MONGO_PROXY_ENDPOINT: MongoProxyEndpoints.Prod,
+        globallyEnabledMongoAPIs: [],
       });
     });
 
@@ -260,6 +281,7 @@ describe("MongoProxyClient", () => {
       resetConfigContext();
       updateConfigContext({
         MONGO_PROXY_ENDPOINT: MongoProxyEndpoints.Prod,
+        globallyEnabledMongoAPIs: [],
       });
       const params = new URLSearchParams({
         "feature.mongoProxyEndpoint": MongoProxyEndpoints.Prod,

--- a/src/Common/MongoProxyClient.ts
+++ b/src/Common/MongoProxyClient.ts
@@ -1,11 +1,10 @@
 import { Constants as CosmosSDKConstants } from "@azure/cosmos";
-import { getEnvironment } from "Common/EnvironmentUtility";
-import queryString from "querystring";
 import {
   allowedMongoProxyEndpoints_ToBeDeprecated,
   defaultAllowedMongoProxyEndpoints,
   validateEndpoint,
 } from "Utils/EndpointUtils";
+import queryString from "querystring";
 import { AuthType } from "../AuthType";
 import { configContext } from "../ConfigContext";
 import * as DataModels from "../Contracts/DataModels";
@@ -791,7 +790,7 @@ export function useMongoProxyEndpoint(mongoProxyApi: string): boolean {
     return false;
   }
 
-  if (getEnvironment() === undefined && configContext.globallyEnabledMongoAPIs.includes(mongoProxyApi)) {
+  if (configContext.globallyEnabledMongoAPIs.includes(mongoProxyApi)) {
     return true;
   }
 

--- a/src/Common/MongoProxyClient.ts
+++ b/src/Common/MongoProxyClient.ts
@@ -1,10 +1,11 @@
 import { Constants as CosmosSDKConstants } from "@azure/cosmos";
+import { getEnvironment } from "Common/EnvironmentUtility";
+import queryString from "querystring";
 import {
   allowedMongoProxyEndpoints_ToBeDeprecated,
   defaultAllowedMongoProxyEndpoints,
   validateEndpoint,
 } from "Utils/EndpointUtils";
-import queryString from "querystring";
 import { AuthType } from "../AuthType";
 import { configContext } from "../ConfigContext";
 import * as DataModels from "../Contracts/DataModels";
@@ -790,8 +791,7 @@ export function useMongoProxyEndpoint(mongoProxyApi: string): boolean {
     return false;
   }
 
-  const globallyEnabledMongoProxyApis = [MongoProxyApi.ResourceList];
-  if (globallyEnabledMongoProxyApis.includes(mongoProxyApi)) {
+  if (getEnvironment() === undefined && configContext.globallyEnabledMongoAPIs.includes(mongoProxyApi)) {
     return true;
   }
 

--- a/src/Common/MongoProxyClient.ts
+++ b/src/Common/MongoProxyClient.ts
@@ -790,7 +790,12 @@ export function useMongoProxyEndpoint(mongoProxyApi: string): boolean {
     return false;
   }
 
-  return true;
+  const globallyEnabledMongoProxyApis = [MongoProxyApi.ResourceList];
+  if (globallyEnabledMongoProxyApis.includes(mongoProxyApi)) {
+    return true;
+  }
+
+  return mongoProxyEnvironmentMap[mongoProxyApi].includes(configContext.MONGO_PROXY_ENDPOINT);
 }
 
 export class ThrottlingError extends Error {

--- a/src/Common/MongoProxyClient.ts
+++ b/src/Common/MongoProxyClient.ts
@@ -790,12 +790,11 @@ export function useMongoProxyEndpoint(mongoProxyApi: string): boolean {
     return false;
   }
 
-  //return mongoProxyEnvironmentMap[mongoProxyApi].includes(configContext.MONGO_PROXY_ENDPOINT);
   const allowedMongoProxyEndpoints = configContext.allowedMongoProxyEndpoints || [
     ...defaultAllowedMongoProxyEndpoints,
     ...allowedMongoProxyEndpoints_ToBeDeprecated,
   ];
-  return validateEndpoint(userContext.features.mongoProxyEndpoint, allowedMongoProxyEndpoints);
+  return validateEndpoint(configContext.MONGO_PROXY_ENDPOINT, allowedMongoProxyEndpoints);
 }
 
 export class ThrottlingError extends Error {

--- a/src/Common/MongoProxyClient.ts
+++ b/src/Common/MongoProxyClient.ts
@@ -689,13 +689,13 @@ export function createMongoCollectionWithProxy_ToBeDeprecated(
 }
 export function getFeatureEndpointOrDefault(feature: string): string {
   let endpoint;
-  const allowedMongoProxyEndpoints = configContext.allowedMongoProxyEndpoints || [
-    ...defaultAllowedMongoProxyEndpoints,
-    ...allowedMongoProxyEndpoints_ToBeDeprecated,
-  ];
   if (useMongoProxyEndpoint(feature)) {
     endpoint = configContext.MONGO_PROXY_ENDPOINT;
   } else {
+    const allowedMongoProxyEndpoints = configContext.allowedMongoProxyEndpoints || [
+      ...defaultAllowedMongoProxyEndpoints,
+      ...allowedMongoProxyEndpoints_ToBeDeprecated,
+    ];
     endpoint =
       hasFlag(userContext.features.mongoProxyAPIs, feature) &&
       validateEndpoint(userContext.features.mongoProxyEndpoint, allowedMongoProxyEndpoints)
@@ -790,7 +790,12 @@ export function useMongoProxyEndpoint(mongoProxyApi: string): boolean {
     return false;
   }
 
-  return mongoProxyEnvironmentMap[mongoProxyApi].includes(configContext.MONGO_PROXY_ENDPOINT);
+  //return mongoProxyEnvironmentMap[mongoProxyApi].includes(configContext.MONGO_PROXY_ENDPOINT);
+  const allowedMongoProxyEndpoints = configContext.allowedMongoProxyEndpoints || [
+    ...defaultAllowedMongoProxyEndpoints,
+    ...allowedMongoProxyEndpoints_ToBeDeprecated,
+  ];
+  return validateEndpoint(userContext.features.mongoProxyEndpoint, allowedMongoProxyEndpoints);
 }
 
 export class ThrottlingError extends Error {

--- a/src/Common/MongoProxyClient.ts
+++ b/src/Common/MongoProxyClient.ts
@@ -790,11 +790,7 @@ export function useMongoProxyEndpoint(mongoProxyApi: string): boolean {
     return false;
   }
 
-  const allowedMongoProxyEndpoints = configContext.allowedMongoProxyEndpoints || [
-    ...defaultAllowedMongoProxyEndpoints,
-    ...allowedMongoProxyEndpoints_ToBeDeprecated,
-  ];
-  return validateEndpoint(configContext.MONGO_PROXY_ENDPOINT, allowedMongoProxyEndpoints);
+  return true;
 }
 
 export class ThrottlingError extends Error {

--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -2,6 +2,7 @@ import {
   BackendApi,
   CassandraProxyEndpoints,
   JunoEndpoints,
+  MongoProxyApi,
   MongoProxyEndpoints,
   PortalBackendEndpoints,
 } from "Common/Constants";
@@ -67,6 +68,8 @@ export interface ConfigContext {
   hostedExplorerURL: string;
   armAPIVersion?: string;
   msalRedirectURI?: string;
+  globallyEnabledCassandraAPIs?: string[];
+  globallyEnabledMongoAPIs?: string[];
 }
 
 // Default configuration
@@ -114,6 +117,8 @@ let configContext: Readonly<ConfigContext> = {
   NEW_CASSANDRA_APIS: ["postQuery", "createOrDelete", "getKeys", "getSchema"],
   isTerminalEnabled: false,
   isPhoenixEnabled: false,
+  globallyEnabledCassandraAPIs: ["postQuery"],
+  globallyEnabledMongoAPIs: [MongoProxyApi.ResourceList],
 };
 
 export function resetConfigContext(): void {

--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -2,7 +2,6 @@ import {
   BackendApi,
   CassandraProxyEndpoints,
   JunoEndpoints,
-  MongoProxyApi,
   MongoProxyEndpoints,
   PortalBackendEndpoints,
 } from "Common/Constants";
@@ -117,8 +116,8 @@ let configContext: Readonly<ConfigContext> = {
   NEW_CASSANDRA_APIS: ["postQuery", "createOrDelete", "getKeys", "getSchema"],
   isTerminalEnabled: false,
   isPhoenixEnabled: false,
-  globallyEnabledCassandraAPIs: ["postQuery"],
-  globallyEnabledMongoAPIs: [MongoProxyApi.ResourceList],
+  globallyEnabledCassandraAPIs: [],
+  globallyEnabledMongoAPIs: [],
 };
 
 export function resetConfigContext(): void {

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -757,6 +757,11 @@ export class CassandraAPIDataClient extends TableDataClient {
       CassandraProxyEndpoints.Mooncake,
     ];
 
+    const globallyEnabledCassandraProxyApis = ["postQuery"];
+    if (globallyEnabledCassandraProxyApis.includes(api)) {
+      return true;
+    }
+
     return (
       configContext.NEW_CASSANDRA_APIS?.includes(api) &&
       activeCassandraProxyEndpoints.includes(configContext.CASSANDRA_PROXY_ENDPOINT)

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -757,6 +757,9 @@ export class CassandraAPIDataClient extends TableDataClient {
       CassandraProxyEndpoints.Mooncake,
     ];
 
-    return configContext.NEW_CASSANDRA_APIS?.includes(api);
+    return (
+      configContext.NEW_CASSANDRA_APIS?.includes(api) &&
+      activeCassandraProxyEndpoints.includes(configContext.CASSANDRA_PROXY_ENDPOINT)
+    );
   }
 }

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -1,5 +1,4 @@
 import { FeedOptions } from "@azure/cosmos";
-import { getEnvironment } from "Common/EnvironmentUtility";
 import * as ko from "knockout";
 import Q from "q";
 import { AuthType } from "../../AuthType";
@@ -758,7 +757,7 @@ export class CassandraAPIDataClient extends TableDataClient {
       CassandraProxyEndpoints.Mooncake,
     ];
 
-    if (getEnvironment() === undefined && configContext.globallyEnabledCassandraAPIs.includes(api)) {
+    if (configContext.globallyEnabledCassandraAPIs.includes(api)) {
       return true;
     }
 

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -1,9 +1,4 @@
 import { FeedOptions } from "@azure/cosmos";
-import {
-  allowedCassandraProxyEndpoints_ToBeDeprecated,
-  defaultAllowedCassandraProxyEndpoints,
-  validateEndpoint,
-} from "Utils/EndpointUtils";
 import * as ko from "knockout";
 import Q from "q";
 import { AuthType } from "../../AuthType";
@@ -762,14 +757,6 @@ export class CassandraAPIDataClient extends TableDataClient {
       CassandraProxyEndpoints.Mooncake,
     ];
 
-    const allowedCassandraProxyEndpoints = configContext.allowedCassandraProxyEndpoints || [
-      ...defaultAllowedCassandraProxyEndpoints,
-      ...allowedCassandraProxyEndpoints_ToBeDeprecated,
-    ];
-
-    return (
-      configContext.NEW_CASSANDRA_APIS?.includes(api) &&
-      validateEndpoint(configContext.MONGO_PROXY_ENDPOINT, allowedCassandraProxyEndpoints)
-    );
+    return configContext.NEW_CASSANDRA_APIS?.includes(api);
   }
 }

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -1,4 +1,5 @@
 import { FeedOptions } from "@azure/cosmos";
+import { getEnvironment } from "Common/EnvironmentUtility";
 import * as ko from "knockout";
 import Q from "q";
 import { AuthType } from "../../AuthType";
@@ -757,8 +758,7 @@ export class CassandraAPIDataClient extends TableDataClient {
       CassandraProxyEndpoints.Mooncake,
     ];
 
-    const globallyEnabledCassandraProxyApis = ["postQuery"];
-    if (globallyEnabledCassandraProxyApis.includes(api)) {
+    if (getEnvironment() === undefined && configContext.globallyEnabledCassandraAPIs.includes(api)) {
       return true;
     }
 

--- a/src/Explorer/Tables/TableDataClient.ts
+++ b/src/Explorer/Tables/TableDataClient.ts
@@ -1,4 +1,9 @@
 import { FeedOptions } from "@azure/cosmos";
+import {
+  allowedCassandraProxyEndpoints_ToBeDeprecated,
+  defaultAllowedCassandraProxyEndpoints,
+  validateEndpoint,
+} from "Utils/EndpointUtils";
 import * as ko from "knockout";
 import Q from "q";
 import { AuthType } from "../../AuthType";
@@ -757,9 +762,14 @@ export class CassandraAPIDataClient extends TableDataClient {
       CassandraProxyEndpoints.Mooncake,
     ];
 
+    const allowedCassandraProxyEndpoints = configContext.allowedCassandraProxyEndpoints || [
+      ...defaultAllowedCassandraProxyEndpoints,
+      ...allowedCassandraProxyEndpoints_ToBeDeprecated,
+    ];
+
     return (
       configContext.NEW_CASSANDRA_APIS?.includes(api) &&
-      activeCassandraProxyEndpoints.includes(configContext.CASSANDRA_PROXY_ENDPOINT)
+      validateEndpoint(configContext.MONGO_PROXY_ENDPOINT, allowedCassandraProxyEndpoints)
     );
   }
 }


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1992?feature.someFeatureFlagYouMightNeed=true)

Adds ability to globally enable cassandra or mongo proxy APIs in all environments through config.json.