### PR TITLE
Correct spelling of CreateDocumen to CreateDocuments

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -158,7 +158,7 @@ export class MongoProxyEndpoints {
 export class MongoProxyApi {
   public static readonly ResourceList: string = "ResourceList";
   public static readonly QueryDocuments: string = "QueryDocuments";
-  public static readonly CreateDocument: string = "CreateDocumen";
+  public static readonly CreateDocument: string = "CreateDocument";
   public static readonly ReadDocument: string = "ReadDocument";
   public static readonly UpdateDocument: string = "UpdateDocument";
   public static readonly DeleteDocument: string = "DeleteDocument";


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1995?feature.someFeatureFlagYouMightNeed=true)

Correcting spelling of CreateDocumen to CreateDocument for the Mongo API list.  CreateDocumen does not exist anywhere else in backend or frontend.