### PR TITLE
fix layout issues in fabric

### DIFF
--- a/less/documentDB.less
+++ b/less/documentDB.less
@@ -3117,3 +3117,7 @@ a:link {
   background: white;
   height: 100%;
 }
+
+.sidebarContainer {
+  height: 100%;
+}

--- a/less/documentDBFabric.less
+++ b/less/documentDBFabric.less
@@ -20,14 +20,18 @@ a:focus {
   text-decoration: underline;
 }
 
+.splashLoaderContainer {
+  background-color: #f5f5f5;
+}
+
 #divExplorer {
   background-color: #f5f5f5;
+  padding: @FabricBoxMargin;
 }
 
 .resourceTreeAndTabs {
   border-radius: 0px;
   box-shadow: @FabricBoxBorderShadow;
-  margin: @FabricBoxMargin;
   margin-top: 0px;
   margin-bottom: 0px;
   background-color: #ffffff;
@@ -46,7 +50,6 @@ a:focus {
   background-color: #ffffff;
   border-radius: @FabricBoxBorderRadius @FabricBoxBorderRadius 0px 0px;
   box-shadow: @FabricBoxBorderShadow;
-  margin: @FabricBoxMargin;
   margin-top: 0px;
   margin-bottom: 0px;
   padding-top: 2px;
@@ -167,7 +170,6 @@ a:focus {
 .dataExplorerErrorConsoleContainer {
   border-radius:  0px 0px @FabricBoxBorderRadius @FabricBoxBorderRadius;
   box-shadow: @FabricBoxBorderShadow;
-  margin: @FabricBoxMargin;
   margin-top: 0px;
   width: auto;
   align-self: auto;

--- a/src/Explorer/Sidebar.tsx
+++ b/src/Explorer/Sidebar.tsx
@@ -282,67 +282,69 @@ export const SidebarContainer: React.FC<SidebarProps> = ({ explorer }) => {
   );
 
   return (
-    <Allotment ref={allotment} onChange={onChange} onDragEnd={onDragEnd} className="resourceTreeAndTabs">
-      {/* Collections Tree - Start */}
-      {hasSidebar && (
-        // When collapsed, we force the pane to 24 pixels wide and make it non-resizable.
-        <Allotment.Pane minSize={24} preferredSize={250}>
-          <CosmosFluentProvider className={mergeClasses(styles.sidebar)}>
-            <div className={styles.sidebarContainer}>
-              {loading && (
-                // The Fluent UI progress bar has some issues in reduced-motion environments so we use a simple CSS animation here.
-                // https://github.com/microsoft/fluentui/issues/29076
-                <div className={styles.loadingProgressBar} title="Refreshing tree..." />
-              )}
-              {expanded ? (
-                <>
-                  <div className={styles.floatingControlsContainer}>
-                    <div className={styles.floatingControls}>
-                      <button
-                        type="button"
-                        data-test="Sidebar/RefreshButton"
-                        className={styles.floatingControlButton}
-                        disabled={loading}
-                        title="Refresh"
-                        onClick={onRefreshClick}
-                      >
-                        <ArrowSync12Regular />
-                      </button>
-                      <button
-                        type="button"
-                        className={styles.floatingControlButton}
-                        title="Collapse sidebar"
-                        onClick={() => collapse()}
-                      >
-                        <ChevronLeft12Regular />
-                      </button>
+    <div className="sidebarContainer">
+      <Allotment ref={allotment} onChange={onChange} onDragEnd={onDragEnd} className="resourceTreeAndTabs">
+        {/* Collections Tree - Start */}
+        {hasSidebar && (
+          // When collapsed, we force the pane to 24 pixels wide and make it non-resizable.
+          <Allotment.Pane minSize={24} preferredSize={250}>
+            <CosmosFluentProvider className={mergeClasses(styles.sidebar)}>
+              <div className={styles.sidebarContainer}>
+                {loading && (
+                  // The Fluent UI progress bar has some issues in reduced-motion environments so we use a simple CSS animation here.
+                  // https://github.com/microsoft/fluentui/issues/29076
+                  <div className={styles.loadingProgressBar} title="Refreshing tree..." />
+                )}
+                {expanded ? (
+                  <>
+                    <div className={styles.floatingControlsContainer}>
+                      <div className={styles.floatingControls}>
+                        <button
+                          type="button"
+                          data-test="Sidebar/RefreshButton"
+                          className={styles.floatingControlButton}
+                          disabled={loading}
+                          title="Refresh"
+                          onClick={onRefreshClick}
+                        >
+                          <ArrowSync12Regular />
+                        </button>
+                        <button
+                          type="button"
+                          className={styles.floatingControlButton}
+                          title="Collapse sidebar"
+                          onClick={() => collapse()}
+                        >
+                          <ChevronLeft12Regular />
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className={styles.expandedContent}
-                    style={!hasGlobalCommands ? { gridTemplateRows: "1fr" } : undefined}
+                    <div
+                      className={styles.expandedContent}
+                      style={!hasGlobalCommands ? { gridTemplateRows: "1fr" } : undefined}
+                    >
+                      {hasGlobalCommands && <GlobalCommands explorer={explorer} />}
+                      <ResourceTree explorer={explorer} />
+                    </div>
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    className={styles.floatingControlButton}
+                    title="Expand sidebar"
+                    onClick={() => expand()}
                   >
-                    {hasGlobalCommands && <GlobalCommands explorer={explorer} />}
-                    <ResourceTree explorer={explorer} />
-                  </div>
-                </>
-              ) : (
-                <button
-                  type="button"
-                  className={styles.floatingControlButton}
-                  title="Expand sidebar"
-                  onClick={() => expand()}
-                >
-                  <ChevronRight12Regular />
-                </button>
-              )}
-            </div>
-          </CosmosFluentProvider>
+                    <ChevronRight12Regular />
+                  </button>
+                )}
+              </div>
+            </CosmosFluentProvider>
+          </Allotment.Pane>
+        )}
+        <Allotment.Pane minSize={200}>
+          <Tabs explorer={explorer} />
         </Allotment.Pane>
-      )}
-      <Allotment.Pane minSize={200}>
-        <Tabs explorer={explorer} />
-      </Allotment.Pane>
-    </Allotment>
+      </Allotment>
+    </div>
   );
 };


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1996?feature.someFeatureFlagYouMightNeed=true)

This PR changes the layout slightly so that the right side of the command bar doesn't push out past the containing element when rendered in Fabric.

Here's an example screenshot:

![image](https://github.com/user-attachments/assets/84c20d12-2c7c-47db-845c-9760d6eb3843)

To fix this, I changed from having individual elements of DE include special margins for fabric to having the top-level _container_ apply a padding. I also had to wrap the split pane we use to hold the sidebar and center pane in a container, to prevent it trying to push past the padding on the right.

In addition, I made a little change to put the fabric background colors in the loading splash screen, which avoids a somewhat-jarring white background when DE is loading. Instead, the splash screen just blends in with the rest of the fabric UI.


