### PR TITLE
Fix row selection issue in DocumentsTab when sorting rows

### DIFF
--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -663,23 +663,6 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
     }
   }, [isFilterFocused]);
 
-  // Clicked row must be defined
-  useEffect(() => {
-    if (documentIds.length > 0) {
-      let currentClickedRowIndex = clickedRowIndex;
-      if (
-        (currentClickedRowIndex === RESET_INDEX &&
-          editorState === ViewModels.DocumentExplorerState.noDocumentSelected) ||
-        currentClickedRowIndex > documentIds.length - 1
-      ) {
-        // reset clicked row or the current clicked row is out of bounds
-        currentClickedRowIndex = INITIAL_SELECTED_ROW_INDEX;
-        setSelectedRows(new Set([INITIAL_SELECTED_ROW_INDEX]));
-        onDocumentClicked(currentClickedRowIndex, documentIds);
-      }
-    }
-  }, [documentIds, clickedRowIndex, editorState]);
-
   /**
    * Recursively delete all documents by retrying throttled requests (429).
    * This only works for NoSQL, because the bulk response includes status for each delete document request.

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -610,7 +610,7 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
   // Table user clicked on this row
   const [clickedRowIndex, setClickedRowIndex] = useState<number>(RESET_INDEX);
   // Table multiple selection
-  const [selectedRows, setSelectedRows] = React.useState<Set<TableRowId>>(() => new Set<TableRowId>([0]));
+  const [selectedRows, setSelectedRows] = React.useState<Set<TableRowId>>(() => new Set<TableRowId>());
 
   // Command buttons
   const [editorState, setEditorState] = useState<ViewModels.DocumentExplorerState>(
@@ -2232,7 +2232,6 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
                     <DocumentsTableComponent
                       onRefreshTable={() => refreshDocumentsGrid(false)}
                       items={tableItems}
-                      onItemClicked={(index) => onDocumentClicked(index, documentIds)}
                       onSelectedRowsChange={onSelectedRowsChange}
                       selectedRows={selectedRows}
                       size={tableContainerSizePx}

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTableComponent.test.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTableComponent.test.tsx
@@ -14,7 +14,6 @@ describe("DocumentsTableComponent", () => {
       { [ID_HEADER]: "2", [PARTITION_KEY_HEADER]: "pk2" },
       { [ID_HEADER]: "3", [PARTITION_KEY_HEADER]: "pk3" },
     ],
-    onItemClicked: (): void => {},
     onSelectedRowsChange: (): void => {},
     selectedRows: new Set<TableRowId>(),
     size: {

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTableComponent.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTableComponent.tsx
@@ -454,15 +454,8 @@ export const DocumentsTableComponent: React.FC<IDocumentsTableComponentProps> = 
   React.useEffect(() => {
     if (autoSelectFirstDoc && sortedRowsRef.current?.length > 0 && selectedRows.size === 0) {
       setAutoSelectFirstDoc(false);
-
-      setTimeout(() => {
-        if (!autoSelectFirstDoc) {
-          return;
-        }
-
-        const DOC_INDEX_TO_SELECT = 0;
-        onTableCellClicked(undefined, DOC_INDEX_TO_SELECT, sortedRowsRef.current[DOC_INDEX_TO_SELECT].rowId);
-      });
+      const DOC_INDEX_TO_SELECT = 0;
+      onTableCellClicked(undefined, DOC_INDEX_TO_SELECT, sortedRowsRef.current[DOC_INDEX_TO_SELECT].rowId);
     }
   }, [selectedRows, onTableCellClicked, autoSelectFirstDoc]);
 

--- a/src/Explorer/Tabs/DocumentsTabV2/__snapshots__/DocumentsTabV2.test.tsx.snap
+++ b/src/Explorer/Tabs/DocumentsTabV2/__snapshots__/DocumentsTabV2.test.tsx.snap
@@ -90,7 +90,6 @@ exports[`Documents tab (noSql API) when rendered should render the page 1`] = `
                   isRowSelectionDisabled={true}
                   items={[]}
                   onColumnSelectionChange={[Function]}
-                  onItemClicked={[Function]}
                   onRefreshTable={[Function]}
                   onSelectedRowsChange={[Function]}
                   selectedColumnIds={
@@ -98,11 +97,7 @@ exports[`Documents tab (noSql API) when rendered should render the page 1`] = `
                       "id",
                     ]
                   }
-                  selectedRows={
-                    Set {
-                      0,
-                    }
-                  }
+                  selectedRows={Set {}}
                 />
               </div>
             </div>

--- a/src/Explorer/Tabs/DocumentsTabV2/__snapshots__/DocumentsTableComponent.test.tsx.snap
+++ b/src/Explorer/Tabs/DocumentsTabV2/__snapshots__/DocumentsTableComponent.test.tsx.snap
@@ -39,7 +39,6 @@ exports[`DocumentsTableComponent should not render selection column when isSelec
       },
     ]
   }
-  onItemClicked={[Function]}
   onRefreshTable={[Function]}
   onSelectedRowsChange={[Function]}
   selectedColumnIds={[]}
@@ -504,7 +503,6 @@ exports[`DocumentsTableComponent should render documents and partition keys in h
       },
     ]
   }
-  onItemClicked={[Function]}
   onRefreshTable={[Function]}
   onSelectedRowsChange={[Function]}
   selectedColumnIds={[]}


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1997)

When the table is sorted, the order of the original items array changes, so clicking on a row index highlighted the wrong document. The distinction is now made between `rowId` (the index of the original array passed to `DocumentsTableComponent`) and `index` (the index of the row in the table visible by the user, ie the index of the sorted array).

The initial first row selection is now done by `DocumentsTableComponent` as it is the only one that knows which index is the top row in the sorted array, because it is the component that sorts the array.

We use a `React.ref` to store the sorted array for later access instead of a state which triggers a render.