### PR TITLE
Improve DocumentsTab filter input

### DIFF
--- a/src/Explorer/Controls/InputDataList/InputDataList.tsx
+++ b/src/Explorer/Controls/InputDataList/InputDataList.tsx
@@ -19,8 +19,6 @@ import { NormalizedEventKey } from "Common/Constants";
 import { tokens } from "Explorer/Theme/ThemeUtil";
 import React, { FC, useEffect, useRef } from "react";
 
-const theme = getTheme();
-
 const useStyles = makeStyles({
   container: {
     padding: 0,
@@ -40,7 +38,6 @@ const useStyles = makeStyles({
     width: "100%",
     fontSize: tokens.fontSizeBase300,
     fontWeight: 600,
-    color: theme.palette.themePrimary,
     padding: `${tokens.spacingVerticalM} 0 0 ${tokens.spacingVerticalM}`,
   },
   dropdownStack: {
@@ -109,6 +106,7 @@ export const InputDataList: FC<InputDataListProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const positioningRef = React.useRef<PositioningImperativeRef>(null);
   const [isInputFocused, setIsInputFocused] = React.useState(autofocus);
+  const theme = getTheme();
 
   useEffect(() => {
     if (inputRef.current) {
@@ -197,7 +195,7 @@ export const InputDataList: FC<InputDataListProps> = ({
         <PopoverSurface className={styles.container}>
           {dropdownOptions.map((section, sectionIndex) => (
             <div key={section.label}>
-              <div className={styles.dropdownHeader}>{section.label}</div>
+              <div className={styles.dropdownHeader} style={{ color: theme.palette.themePrimary }}>{section.label}</div>
               <div className={styles.dropdownStack}>
                 {section.options.map((option, index) => (
                   <Button

--- a/src/Explorer/Controls/InputDataList/InputDataList.tsx
+++ b/src/Explorer/Controls/InputDataList/InputDataList.tsx
@@ -25,6 +25,10 @@ const useStyles = makeStyles({
   input: {
     flexGrow: 1,
     paddingRight: 0,
+    outline: "none",
+    "& input:focus": {
+      outline: "none" // Undo body :focus dashed outline
+    }
   },
   inputButton: {
     border: 0,

--- a/src/Explorer/Controls/InputDataList/InputDataList.tsx
+++ b/src/Explorer/Controls/InputDataList/InputDataList.tsx
@@ -174,6 +174,7 @@ export const InputDataList: FC<InputDataListProps> = ({
         }}
         contentAfter={
           <Button
+            aria-label="Clear filter"
             className={styles.inputButton}
             size="small"
             icon={<DismissRegular />}

--- a/src/Explorer/Controls/InputDataList/InputDataList.tsx
+++ b/src/Explorer/Controls/InputDataList/InputDataList.tsx
@@ -1,0 +1,189 @@
+// This component is used to create a dropdown list of options for the user to select from.
+// The options are displayed in a dropdown list when the user clicks on the input field.
+// The user can then select an option from the list. The selected option is then displayed in the input field.
+
+import {
+  Button,
+  Divider,
+  Input,
+  Link,
+  makeStyles,
+  Popover,
+  PopoverProps,
+  PopoverSurface,
+  PositioningImperativeRef,
+} from "@fluentui/react-components";
+import { tokens } from "Explorer/Theme/ThemeUtil";
+import React, { FC, useEffect, useRef } from "react";
+
+const useStyles = makeStyles({
+  container: {
+    padding: 0,
+  },
+  input: {
+    flexGrow: 1,
+  },
+  dropdownHeader: {
+    width: "100%",
+    fontSize: tokens.fontSizeBase300,
+    fontWeight: 600,
+    color: "#0078D4",
+    padding: `${tokens.spacingVerticalM} 0 0 ${tokens.spacingVerticalM}`,
+  },
+  dropdownStack: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalS,
+    marginTop: tokens.spacingVerticalS,
+    marginBottom: "1px",
+  },
+  dropdownOption: {
+    fontSize: tokens.fontSizeBase300,
+    fontWeight: 400,
+    justifyContent: "left",
+    padding: `${tokens.spacingHorizontalXS} ${tokens.spacingHorizontalS} ${tokens.spacingHorizontalXS} ${tokens.spacingHorizontalL}`,
+    overflow: "hidden",
+    whiteSpace: "nowrap",
+    textOverflow: "ellipsis",
+    border: 0,
+    ":hover": {
+      outline: `1px dashed ${tokens.colorNeutralForeground1Hover}`,
+      backgroundColor: tokens.colorNeutralBackground2Hover,
+      color: tokens.colorNeutralForeground1,
+    },
+  },
+  bottomSection: {
+    fontSize: tokens.fontSizeBase300,
+    fontWeight: 400,
+    padding: `${tokens.spacingHorizontalXS} ${tokens.spacingHorizontalS} ${tokens.spacingHorizontalXS} ${tokens.spacingHorizontalL}`,
+    overflow: "hidden",
+    whiteSpace: "nowrap",
+    textOverflow: "ellipsis",
+  },
+});
+
+export interface InputDatalistDropdownOptionSection {
+  label: string;
+  options: string[];
+}
+
+export interface InputDataListProps {
+  dropdownOptions: InputDatalistDropdownOptionSection[];
+  placeholder?: string;
+  title?: string;
+  value: string;
+  onChange: (value: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  autofocus?: boolean; // true: acquire focus on first render
+  bottomLink?: {
+    text: string;
+    url: string;
+  };
+}
+
+export const InputDataList: FC<InputDataListProps> = ({
+  dropdownOptions,
+  placeholder,
+  title,
+  value,
+  onChange,
+  onKeyDown,
+  autofocus,
+  bottomLink,
+}) => {
+  const styles = useStyles();
+  const [showDropdown, setShowDropdown] = React.useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const positioningRef = React.useRef<PositioningImperativeRef>(null);
+  const [isInputFocused, setIsInputFocused] = React.useState(autofocus);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      positioningRef.current?.setTarget(inputRef.current);
+    }
+  }, [inputRef, positioningRef]);
+
+  useEffect(() => {
+    if (isInputFocused) {
+      inputRef.current?.focus();
+    }
+  }, [isInputFocused]);
+
+  const handleOpenChange: PopoverProps["onOpenChange"] = (e, data) => {
+    console.log("handleOpenChange", showDropdown, isInputFocused, data.open);
+    setShowDropdown(data.open || false);
+    if (data.open) {
+      setIsInputFocused(true);
+    }
+  };
+
+  return (
+    <>
+      <Input
+        id="filterInput"
+        ref={inputRef}
+        type="text"
+        size="small"
+        className={`filterInput ${styles.input}`}
+        title={title}
+        placeholder={placeholder}
+        value={value}
+        autoFocus={true}
+        onKeyDown={onKeyDown}
+        onChange={(e) => onChange(e.target.value)}
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+        onFocus={() => {
+          console.log("onFocus", showDropdown, isInputFocused);
+          // setIsInputFocused(true);
+          setShowDropdown(true);
+        }}
+      />
+
+      <Popover
+        inline
+        unstable_disableAutoFocus
+        // trapFocus
+
+        open={showDropdown}
+        onOpenChange={handleOpenChange}
+        positioning={{ positioningRef, position: "below", align: "start", offset: 4 }}
+      >
+        <PopoverSurface className={styles.container}>
+          {dropdownOptions.map((section) => (
+            <div key={section.label}>
+              <div className={styles.dropdownHeader}>{section.label}</div>
+              <div className={styles.dropdownStack}>
+                {section.options.map((option) => (
+                  <Button
+                    key={option}
+                    appearance="transparent"
+                    shape="square"
+                    className={styles.dropdownOption}
+                    onClick={() => {
+                      onChange(option);
+                      setShowDropdown(false);
+                    }}
+                  >
+                    {option}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          ))}
+          {bottomLink && (
+            <>
+              <Divider />
+              <div className={styles.bottomSection}>
+                <Link href={bottomLink.url} target="_blank">
+                  {bottomLink.text}
+                </Link>
+              </div>
+            </>
+          )}
+        </PopoverSurface>
+      </Popover>
+    </>
+  );
+};

--- a/src/Explorer/Controls/InputDataList/InputDataList.tsx
+++ b/src/Explorer/Controls/InputDataList/InputDataList.tsx
@@ -27,8 +27,8 @@ const useStyles = makeStyles({
     paddingRight: 0,
     outline: "none",
     "& input:focus": {
-      outline: "none" // Undo body :focus dashed outline
-    }
+      outline: "none", // Undo body :focus dashed outline
+    },
   },
   inputButton: {
     border: 0,
@@ -191,11 +191,11 @@ export const InputDataList: FC<InputDataListProps> = ({
         positioning={{ positioningRef, position: "below", align: "start", offset: 4 }}
       >
         <PopoverSurface className={styles.container}>
-          {dropdownOptions.map((section) => (
+          {dropdownOptions.map((section, sectionIndex) => (
             <div key={section.label}>
               <div className={styles.dropdownHeader}>{section.label}</div>
               <div className={styles.dropdownStack}>
-                {section.options.map((option) => (
+                {section.options.map((option, index) => (
                   <Button
                     key={option}
                     appearance="transparent"
@@ -206,6 +206,12 @@ export const InputDataList: FC<InputDataListProps> = ({
                       setShowDropdown(false);
                       setIsInputFocused(true);
                     }}
+                    onBlur={() =>
+                      !bottomLink &&
+                      sectionIndex === dropdownOptions.length - 1 &&
+                      index === section.options.length - 1 &&
+                      setShowDropdown(false)
+                    }
                   >
                     {option}
                   </Button>
@@ -217,7 +223,7 @@ export const InputDataList: FC<InputDataListProps> = ({
             <>
               <Divider />
               <div className={styles.bottomSection}>
-                <Link href={bottomLink.url} target="_blank">
+                <Link href={bottomLink.url} target="_blank" onBlur={() => setShowDropdown(false)}>
                   {bottomLink.text}
                 </Link>
               </div>

--- a/src/Explorer/Controls/InputDataList/InputDataList.tsx
+++ b/src/Explorer/Controls/InputDataList/InputDataList.tsx
@@ -196,7 +196,9 @@ export const InputDataList: FC<InputDataListProps> = ({
         <PopoverSurface className={styles.container}>
           {dropdownOptions.map((section, sectionIndex) => (
             <div key={section.label}>
-              <div className={styles.dropdownHeader} style={{ color: theme.palette.themePrimary }}>{section.label}</div>
+              <div className={styles.dropdownHeader} style={{ color: theme.palette.themePrimary }}>
+                {section.label}
+              </div>
               <div className={styles.dropdownStack}>
                 {section.options.map((option, index) => (
                   <Button

--- a/src/Explorer/Controls/InputDataList/InputDataList.tsx
+++ b/src/Explorer/Controls/InputDataList/InputDataList.tsx
@@ -2,6 +2,7 @@
 // The options are displayed in a dropdown list when the user clicks on the input field.
 // The user can then select an option from the list. The selected option is then displayed in the input field.
 
+import { getTheme } from "@fluentui/react";
 import {
   Button,
   Divider,
@@ -17,6 +18,8 @@ import { DismissRegular } from "@fluentui/react-icons";
 import { NormalizedEventKey } from "Common/Constants";
 import { tokens } from "Explorer/Theme/ThemeUtil";
 import React, { FC, useEffect, useRef } from "react";
+
+const theme = getTheme();
 
 const useStyles = makeStyles({
   container: {
@@ -37,7 +40,7 @@ const useStyles = makeStyles({
     width: "100%",
     fontSize: tokens.fontSizeBase300,
     fontWeight: 600,
-    color: "#0078D4",
+    color: theme.palette.themePrimary,
     padding: `${tokens.spacingVerticalM} 0 0 ${tokens.spacingVerticalM}`,
   },
   dropdownStack: {
@@ -138,6 +141,7 @@ export const InputDataList: FC<InputDataListProps> = ({
         ref={inputRef}
         type="text"
         size="small"
+        autoComplete="off"
         className={`filterInput ${styles.input}`}
         title={title}
         placeholder={placeholder}

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.test.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.test.tsx
@@ -385,22 +385,6 @@ describe("Documents tab (noSql API)", () => {
     it("should render the page", () => {
       expect(wrapper).toMatchSnapshot();
     });
-
-    it("clicking on Edit filter should render the Apply Filter button", () => {
-      wrapper
-        .findWhere((node) => node.text() === "Edit Filter")
-        .at(0)
-        .simulate("click");
-      expect(wrapper.findWhere((node) => node.text() === "Apply Filter").exists()).toBeTruthy();
-    });
-
-    it("clicking on Edit filter should render input for filter", () => {
-      wrapper
-        .findWhere((node) => node.text() === "Edit Filter")
-        .at(0)
-        .simulate("click");
-      expect(wrapper.find("Input.filterInput").exists()).toBeTruthy();
-    });
   });
 
   describe("Command bar buttons", () => {

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -2069,10 +2069,6 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
         <div className={styles.filterRow}>
           {!isPreferredApiMongoDB && <span> SELECT * FROM c </span>}
           <InputDataList
-            // dropdownOptions={addStringsNoDuplicate(
-            //   lastFilterContents,
-            //   isPreferredApiMongoDB ? defaultMongoFilters : getDefaultSqlFilters(partitionKeyProperties),
-            // ).map((option) => ({ label: option, value: option }))}
             dropdownOptions={getFilterChoices()}
             placeholder={
               isPreferredApiMongoDB
@@ -2083,7 +2079,6 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
             value={filterContent}
             onChange={(value) => setFilterContent(value)}
             onKeyDown={onFilterKeyDown}
-            // onApplyFilterClick={onApplyFilterClick}
             bottomLink={{ text: "Learn more", url: DATA_EXPLORER_DOC_URL }}
           />
           <Button

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -1471,7 +1471,7 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
   };
 
   const onFilterKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
-    if (e.key === "Enter") {
+    if (e.key === Constants.NormalizedEventKey.Enter) {
       onApplyFilterClick();
 
       // Suppress the default behavior of the key

--- a/src/Explorer/Tabs/DocumentsTabV2/__snapshots__/DocumentsTabV2.test.tsx.snap
+++ b/src/Explorer/Tabs/DocumentsTabV2/__snapshots__/DocumentsTabV2.test.tsx.snap
@@ -17,106 +17,124 @@ exports[`Documents tab (noSql API) when rendered should render the page 1`] = `
       className="___11ktxfv_0000000 f1o614cb fy9rknc f22iagw fsnqrgy f1f5gg8d fjodcmx f122n59 f1f09k3d fg706s2 frpde29"
     >
       <span>
-        SELECT * FROM c
+         SELECT * FROM c 
       </span>
-      <span
-        className="___r7kt3y0_0000000 fqerorx"
+      <InputDataList
+        bottomLink={
+          {
+            "text": "Learn more",
+            "url": "https://learn.microsoft.com/en-us/azure/cosmos-db/data-explorer",
+          }
+        }
+        dropdownOptions={
+          [
+            {
+              "label": "Default filters",
+              "options": [
+                "WHERE c.id = "foo"",
+                "ORDER BY c._ts DESC",
+                "WHERE c.id = "foo" ORDER BY c._ts DESC",
+                "ORDER BY c._ts ASC",
+                "WHERE c.foo = "foo"",
+              ],
+            },
+          ]
+        }
+        onChange={[Function]}
+        onKeyDown={[Function]}
+        placeholder="Type a query predicate (e.g., WHERE c.id=´1´), or choose one from the drop down list, or leave empty to query all documents."
+        title="Type a query predicate or choose one from the list."
+        value=""
       />
       <Button
         appearance="primary"
+        aria-label="Apply filter"
+        disabled={false}
         onClick={[Function]}
         size="small"
+        tabIndex={0}
       >
-        Edit Filter
+        Apply Filter
       </Button>
     </div>
-    <div
-      style={
-        {
-          "height": "100%",
-          "overflow": "hidden",
-        }
-      }
+    <Allotment
+      onDragEnd={[Function]}
     >
-      <Allotment
-        onDragEnd={[Function]}
+      <Allotment.Pane
+        minSize={55}
+        preferredSize="35%"
       >
-        <Allotment.Pane
-          minSize={55}
-          preferredSize="35%"
+        <div
+          style={
+            {
+              "height": "100%",
+              "overflow": "hidden",
+              "width": "100%",
+            }
+          }
         >
           <div
-            style={
-              {
-                "height": "100%",
-                "overflow": "hidden",
-                "width": "100%",
-              }
-            }
+            className="___9o87uj0_0000000 ffefeo0"
           >
             <div
-              className="___9o87uj0_0000000 ffefeo0"
+              style={
+                {
+                  "height": "100%",
+                  "width": "calc(100% + -11px)",
+                }
+              }
             >
-              <div
-                style={
+              <DocumentsTableComponent
+                collection={
                   {
-                    "height": "100%",
-                    "width": "calc(100% + -11px)",
+                    "databaseId": "databaseId",
+                    "id": [Function],
                   }
                 }
-              >
-                <DocumentsTableComponent
-                  collection={
+                columnDefinitions={
+                  [
                     {
-                      "databaseId": "databaseId",
-                      "id": [Function],
-                    }
-                  }
-                  columnDefinitions={
-                    [
-                      {
-                        "id": "id",
-                        "isPartitionKey": false,
-                        "label": "id",
-                      },
-                    ]
-                  }
-                  defaultColumnSelection={
-                    [
-                      "id",
-                    ]
-                  }
-                  isColumnSelectionDisabled={false}
-                  isRowSelectionDisabled={true}
-                  items={[]}
-                  onColumnSelectionChange={[Function]}
-                  onRefreshTable={[Function]}
-                  onSelectedRowsChange={[Function]}
-                  selectedColumnIds={
-                    [
-                      "id",
-                    ]
-                  }
-                  selectedRows={Set {}}
-                />
-              </div>
+                      "id": "id",
+                      "isPartitionKey": false,
+                      "label": "id",
+                    },
+                  ]
+                }
+                defaultColumnSelection={
+                  [
+                    "id",
+                  ]
+                }
+                isColumnSelectionDisabled={false}
+                isRowSelectionDisabled={true}
+                items={[]}
+                onColumnSelectionChange={[Function]}
+                onRefreshTable={[Function]}
+                onSelectedRowsChange={[Function]}
+                selectedColumnIds={
+                  [
+                    "id",
+                  ]
+                }
+                selectedRows={Set {}}
+              />
             </div>
           </div>
-        </Allotment.Pane>
-        <Allotment.Pane
-          minSize={30}
-        >
-          <div
-            style={
-              {
-                "height": "100%",
-                "width": "100%",
-              }
+        </div>
+      </Allotment.Pane>
+      <Allotment.Pane
+        minSize={30}
+      >
+        <div
+          style={
+            {
+              "height": "100%",
+              "width": "100%",
             }
-          />
-        </Allotment.Pane>
-      </Allotment>
-    </div>
+          }
+        />
+      </Allotment.Pane>
+    </Allotment>
   </div>
 </CosmosFluentProvider>
 `;


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/1998)
 * Always keep filter editable
 * Single "Apply filter"/"Cancel"
 * Fluent UI-based dropdown for saved and default filters with link to learn more. 
 * Clear button on the right clear filter
 * Cleaned up old style and code (for example don't focus with outline)
 * Input and dropdown navigation with tab for a11y compliance
 * The input and dropdown menu is a React component.

<img width="1052" alt="image" src="https://github.com/user-attachments/assets/a2977d32-4493-433e-86af-dcfba8831b73">

#### Behavior of the dropdown and keyboard navigation
* Dropdown will show when input gets focus
* Dropdown shows only when input has no text
* Clear button at the end of the input box becomes down button to reveal dropdown if input has no text. 
* Generally first dropdown item gets autofocus when dropdown opens (when input doesn't have focus)
* Arrow up/down move focus in the dropdown item. If last item, we focus back to the input.
* Tab or shift tab also work. If last item, tab goes to the Apply button.