### PR TITLE
Update query advisor privacy statement and link

### DIFF
--- a/src/Explorer/QueryCopilot/Modal/QueryCopilotFeedbackModal.tsx
+++ b/src/Explorer/QueryCopilot/Modal/QueryCopilotFeedbackModal.tsx
@@ -79,9 +79,13 @@ export const QueryCopilotFeedbackModal = ({
             readOnly
           />
           <Text style={{ fontSize: 12, marginBottom: 14 }}>
-            By pressing submit, your feedback will be used to improve Microsoft products and services. Please see the{" "}
+            Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to
+            improve your and your organization’s experience with this product. If you have any questions about the use
+            of feedback data, please contact your tenant administrator. Processing of feedback data is governed by the
+            Microsoft Products and Services Data Protection Addendum between your organization and Microsoft, and the
+            feedback you submit is considered Personal Data under that addendum. Please see the{" "}
             {
-              <Link href="https://privacy.microsoft.com/privacystatement" target="_blank">
+              <Link href="https://go.microsoft.com/fwlink/?LinkId=521839" target="_blank">
                 Privacy statement
               </Link>
             }{" "}

--- a/src/Explorer/QueryCopilot/Modal/__snapshots__/QueryCopilotFeedbackModal.test.tsx.snap
+++ b/src/Explorer/QueryCopilot/Modal/__snapshots__/QueryCopilotFeedbackModal.test.tsx.snap
@@ -99,10 +99,10 @@ exports[`Query Copilot Feedback Modal snapshot test shoud render and match snaps
           }
         }
       >
-        By pressing submit, your feedback will be used to improve Microsoft products and services. Please see the
+        Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions about the use of feedback data, please contact your tenant administrator. Processing of feedback data is governed by the Microsoft Products and Services Data Protection Addendum between your organization and Microsoft, and the feedback you submit is considered Personal Data under that addendum. Please see the
          
         <StyledLinkBase
-          href="https://privacy.microsoft.com/privacystatement"
+          href="https://go.microsoft.com/fwlink/?LinkId=521839"
           target="_blank"
         >
           Privacy statement
@@ -236,10 +236,10 @@ exports[`Query Copilot Feedback Modal snapshot test should cancel submission 1`]
           }
         }
       >
-        By pressing submit, your feedback will be used to improve Microsoft products and services. Please see the
+        Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions about the use of feedback data, please contact your tenant administrator. Processing of feedback data is governed by the Microsoft Products and Services Data Protection Addendum between your organization and Microsoft, and the feedback you submit is considered Personal Data under that addendum. Please see the
          
         <StyledLinkBase
-          href="https://privacy.microsoft.com/privacystatement"
+          href="https://go.microsoft.com/fwlink/?LinkId=521839"
           target="_blank"
         >
           Privacy statement
@@ -373,10 +373,10 @@ exports[`Query Copilot Feedback Modal snapshot test should close on cancel click
           }
         }
       >
-        By pressing submit, your feedback will be used to improve Microsoft products and services. Please see the
+        Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions about the use of feedback data, please contact your tenant administrator. Processing of feedback data is governed by the Microsoft Products and Services Data Protection Addendum between your organization and Microsoft, and the feedback you submit is considered Personal Data under that addendum. Please see the
          
         <StyledLinkBase
-          href="https://privacy.microsoft.com/privacystatement"
+          href="https://go.microsoft.com/fwlink/?LinkId=521839"
           target="_blank"
         >
           Privacy statement
@@ -510,10 +510,10 @@ exports[`Query Copilot Feedback Modal snapshot test should get user unput 1`] = 
           }
         }
       >
-        By pressing submit, your feedback will be used to improve Microsoft products and services. Please see the
+        Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions about the use of feedback data, please contact your tenant administrator. Processing of feedback data is governed by the Microsoft Products and Services Data Protection Addendum between your organization and Microsoft, and the feedback you submit is considered Personal Data under that addendum. Please see the
          
         <StyledLinkBase
-          href="https://privacy.microsoft.com/privacystatement"
+          href="https://go.microsoft.com/fwlink/?LinkId=521839"
           target="_blank"
         >
           Privacy statement
@@ -647,10 +647,10 @@ exports[`Query Copilot Feedback Modal snapshot test should not render dont show 
           }
         }
       >
-        By pressing submit, your feedback will be used to improve Microsoft products and services. Please see the
+        Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions about the use of feedback data, please contact your tenant administrator. Processing of feedback data is governed by the Microsoft Products and Services Data Protection Addendum between your organization and Microsoft, and the feedback you submit is considered Personal Data under that addendum. Please see the
          
         <StyledLinkBase
-          href="https://privacy.microsoft.com/privacystatement"
+          href="https://go.microsoft.com/fwlink/?LinkId=521839"
           target="_blank"
         >
           Privacy statement
@@ -784,10 +784,10 @@ exports[`Query Copilot Feedback Modal snapshot test should render dont show agai
           }
         }
       >
-        By pressing submit, your feedback will be used to improve Microsoft products and services. Please see the
+        Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions about the use of feedback data, please contact your tenant administrator. Processing of feedback data is governed by the Microsoft Products and Services Data Protection Addendum between your organization and Microsoft, and the feedback you submit is considered Personal Data under that addendum. Please see the
          
         <StyledLinkBase
-          href="https://privacy.microsoft.com/privacystatement"
+          href="https://go.microsoft.com/fwlink/?LinkId=521839"
           target="_blank"
         >
           Privacy statement
@@ -936,10 +936,10 @@ exports[`Query Copilot Feedback Modal snapshot test should submit submission 1`]
           }
         }
       >
-        By pressing submit, your feedback will be used to improve Microsoft products and services. Please see the
+        Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions about the use of feedback data, please contact your tenant administrator. Processing of feedback data is governed by the Microsoft Products and Services Data Protection Addendum between your organization and Microsoft, and the feedback you submit is considered Personal Data under that addendum. Please see the
          
         <StyledLinkBase
-          href="https://privacy.microsoft.com/privacystatement"
+          href="https://go.microsoft.com/fwlink/?LinkId=521839"
           target="_blank"
         >
           Privacy statement


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/2000?feature.someFeatureFlagYouMightNeed=true)

This change updates the privacy text when users submit feedback from the Query Advisor. It also updates the link 
to the privacy statement.

![image](https://github.com/user-attachments/assets/dfd3b576-63fd-4b08-a3bb-25fed68845ac)
