### PR TITLE
[Screen reader - Cosmos DB Query Copilot - Query Faster with Copilot>Enable Query Advisor]: Screen reader does not announce status information which appears on invoking the 'Send' button.

### DIFF
--- a/src/Explorer/QueryCopilot/QueryCopilotPromptbar.tsx
+++ b/src/Explorer/QueryCopilot/QueryCopilotPromptbar.tsx
@@ -711,31 +711,31 @@ export const QueryCopilotPromptbar: React.FC<QueryCopilotPromptProps> = ({
             <span role="alert" className="screenReaderOnly" aria-label={getAriaLabel()} />
           )}
           {isGeneratingQuery && (
-              <ProgressIndicator
-                label="Thinking..."
-                ariaLabel={getAriaLabel()}
-                barHeight={4}
-                styles={{
-                  root: {
-                    fontSize: 12,
-                    width: "100%",
-                    bottom: 0,
-                  },
-                  itemName: {
-                    padding: "0px 8px",
-                  },
-                  itemProgress: {
-                    borderBottomLeftRadius: 8,
-                    borderBottomRightRadius: 8,
-                    padding: 0,
-                  },
-                  progressBar: {
-                    backgroundImage:
-                      "linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgb(24, 90, 189) 35%, rgb(71, 207, 250) 70%, rgb(180, 124, 248) 92%, rgba(0, 0, 0, 0))",
-                    animationDuration: "5s",
-                  },
-                }}
-              />
+            <ProgressIndicator
+              label="Thinking..."
+              ariaLabel={getAriaLabel()}
+              barHeight={4}
+              styles={{
+                root: {
+                  fontSize: 12,
+                  width: "100%",
+                  bottom: 0,
+                },
+                itemName: {
+                  padding: "0px 8px",
+                },
+                itemProgress: {
+                  borderBottomLeftRadius: 8,
+                  borderBottomRightRadius: 8,
+                  padding: 0,
+                },
+                progressBar: {
+                  backgroundImage:
+                    "linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgb(24, 90, 189) 35%, rgb(71, 207, 250) 70%, rgb(180, 124, 248) 92%, rgba(0, 0, 0, 0))",
+                  animationDuration: "5s",
+                },
+              }}
+            />
           )}
         </Stack>
         <IconButton

--- a/src/Explorer/QueryCopilot/QueryCopilotPromptbar.tsx
+++ b/src/Explorer/QueryCopilot/QueryCopilotPromptbar.tsx
@@ -305,7 +305,7 @@ export const QueryCopilotPromptbar: React.FC<QueryCopilotPromptProps> = ({
     if (isGeneratingQuery === null) {
       return " ";
     } else if (isGeneratingQuery) {
-      return "Content is loading";
+      return "Thinking";
     } else {
       return "Content is updated";
     }
@@ -400,6 +400,7 @@ export const QueryCopilotPromptbar: React.FC<QueryCopilotPromptProps> = ({
                   <IconButton
                     iconProps={{ iconName: "Send" }}
                     disabled={isGeneratingQuery || !userPrompt.trim()}
+                    allowDisabledFocus={true}
                     style={{ background: "none" }}
                     onClick={() => startGenerateQueryProcess()}
                     aria-label="Send"
@@ -706,32 +707,35 @@ export const QueryCopilotPromptbar: React.FC<QueryCopilotPromptProps> = ({
               )}
             </Stack>
           )}
+          {(showFeedbackBar || isGeneratingQuery) && (
+            <span role="alert" className="screenReaderOnly" aria-label={getAriaLabel()} />
+          )}
           {isGeneratingQuery && (
-            <ProgressIndicator
-              label="Thinking..."
-              ariaLabel={getAriaLabel()}
-              barHeight={4}
-              styles={{
-                root: {
-                  fontSize: 12,
-                  width: "100%",
-                  bottom: 0,
-                },
-                itemName: {
-                  padding: "0px 8px",
-                },
-                itemProgress: {
-                  borderBottomLeftRadius: 8,
-                  borderBottomRightRadius: 8,
-                  padding: 0,
-                },
-                progressBar: {
-                  backgroundImage:
-                    "linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgb(24, 90, 189) 35%, rgb(71, 207, 250) 70%, rgb(180, 124, 248) 92%, rgba(0, 0, 0, 0))",
-                  animationDuration: "5s",
-                },
-              }}
-            />
+              <ProgressIndicator
+                label="Thinking..."
+                ariaLabel={getAriaLabel()}
+                barHeight={4}
+                styles={{
+                  root: {
+                    fontSize: 12,
+                    width: "100%",
+                    bottom: 0,
+                  },
+                  itemName: {
+                    padding: "0px 8px",
+                  },
+                  itemProgress: {
+                    borderBottomLeftRadius: 8,
+                    borderBottomRightRadius: 8,
+                    padding: 0,
+                  },
+                  progressBar: {
+                    backgroundImage:
+                      "linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgb(24, 90, 189) 35%, rgb(71, 207, 250) 70%, rgb(180, 124, 248) 92%, rgba(0, 0, 0, 0))",
+                    animationDuration: "5s",
+                  },
+                }}
+              />
           )}
         </Stack>
         <IconButton


### PR DESCRIPTION
Description: This PR addresses an accessibility issue in the Cosmos DB Query Copilot feature. Previously, the screen reader did not announce the status information when the 'Send' button was invoked. We have resolved this by ensuring that the screen reader now reads out the status, including "thinking" while the query is processing, and announces "content updated" once the status has loaded. These enhancements improve the overall user experience for individuals using assistive technologies.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/2002?feature.someFeatureFlagYouMightNeed=true)


https://github.com/user-attachments/assets/8020dca4-4fd3-4b91-9db2-e1f06c41fb7c


