### PR TITLE
[Programmatic Access- Azure Cosmos DB- Data explorer]: Ensures <img> elements have alternate text or a role of none or presentation.

### DIFF
--- a/src/Explorer/SplashScreen/SplashScreenButton.tsx
+++ b/src/Explorer/SplashScreen/SplashScreenButton.tsx
@@ -39,7 +39,7 @@ export const SplashScreenButton: React.FC<SplashScreenButtonProps> = ({
       role="button"
     >
       <div>
-        <img src={imgSrc} />
+        <img src={imgSrc} alt={title} aria-hidden="true" />
       </div>
       <Stack style={{ marginLeft: 16 }}>
         <Text style={{ fontSize: 18, fontWeight: 600 }}>{title}</Text>


### PR DESCRIPTION
This PR improves accessibility in the Azure Cosmos DB Data Explorer by adding alt text to <img> elements and setting aria-hidden="true" for decorative images. These changes ensure that images are either properly described for screen readers or ignored, enhancing the experience for users with visual impairments.

[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/2007?feature.someFeatureFlagYouMightNeed=true)
Before:
![image](https://github.com/user-attachments/assets/88d8c82c-d2ba-41a1-8f45-85e29425ff4b)
After:
![image](https://github.com/user-attachments/assets/d5b775fb-192a-41d7-8656-abb2e0197773)

