### PR TITLE
fix tab wrapping with a lil' css tweak

### DIFF
--- a/less/documentDB.less
+++ b/less/documentDB.less
@@ -1906,13 +1906,20 @@ input::-webkit-calendar-picker-indicator::after {
 }
 
 .nav-tabs-margin {
-  height: 32px;
   background-color: #f2f2f2;
 
   .nav-tabs {
     display: flex;
+    flex-wrap: wrap;
     align-items: flex-end;
     height: 100%;
+    margin-bottom: -0.5px;
+
+    li {
+      // Override the bootstrap defaults here to align with our layout constants.
+      margin-bottom: 0px;
+      height: 32px;
+    }
   }
 }
 


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/2013)

When you open more tabs than can fit in the bar, the tabs don't wrap anymore and you simply can't access the extra tabs. This PR fixes the wrapping by enabling `flex-wrap` on the container and disabling the hard `32px` height cap on the tab bar. Once I did that though, the bottom border of the tab bar stopped lining up with the lines on the tree view, so I adjusted the individual tabs so they had a height of `32px` (to match our "layout row height"). And then, because CSS problems always tend to *casdade* ;), I had to adjut the border and margins a little bit to nudge everything in to place. Now we have wrapping and alignment!

https://github.com/user-attachments/assets/e8fb9bcc-f129-4bc5-8254-6c4873c6bb8d
