### PR TITLE
Close all tabs and always load first container when initializing Fabric

### DIFF
--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -142,7 +142,7 @@ async function configureFabric(): Promise<Explorer> {
             await scheduleRefreshDatabaseResourceToken(true);
             resolve(explorer);
             await explorer.refreshAllDatabases();
-            if (userContext.fabricContext.isVisible && !firstContainerOpened) {
+            if (userContext.fabricContext.isVisible) {
               firstContainerOpened = true;
               openFirstContainer(explorer, userContext.fabricContext.databaseConnectionInfo.databaseId);
             }
@@ -439,6 +439,7 @@ function createExplorerFabric(params: { connectionId: string; isVisible: boolean
       },
     },
   });
+  useTabs.getState().closeAllTabs();
   const explorer = new Explorer();
   return explorer;
 }

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -42,6 +42,7 @@ export interface TabsState {
   selectLeftTab: () => void;
   selectRightTab: () => void;
   closeActiveTab: () => void;
+  closeAllTabs: () => void;
   persistTabsState: () => void;
 }
 
@@ -236,6 +237,9 @@ export const useTabs: UseStore<TabsState> = create((set, get) => ({
     } else if (state.activeTab !== undefined) {
       state.closeTab(state.activeTab);
     }
+  },
+  closeAllTabs: () => {
+    set({ openedTabs: [], openedReactTabs: [], activeTab: undefined, activeReactTab: undefined });
   },
   persistTabsState: () => {
     const state = get();


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/2014)

In Fabric, the user can switch between artifacts resulting Data Explorer to call the "initialize" handler in `useKnockoutExplorer` multiple times. The handler re-instantiates Data Explorer by instantiating `Explorer`, but there is some leftover state like open tabs.
This closes the tabs, so the user will not see tabs from the old artifact when switching artifacts.

There should be a more comprehensive version that cleans up everything, but for now, this fix is the least risky change with minimal impact on the other use cases.

No more check for `firstContainerOpened`: in the new Trident-DI-extension, the "initialize" handler is always called first, so no need to check for this flag and always load container.

- [x] test if this change can be deployed while old extension is still in prod