### PR TITLE
Use dotnet CLI for nuget operations in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,6 @@ jobs:
     env:
       NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
       AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
-      #NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_PAT }}
       DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
     steps:
       - name: Download Dist Folder
@@ -120,45 +119,40 @@ jobs:
         with:
           name: dist
       - run: cp ./configs/prod.json config.json
-      #- run: nuget sources add -Name "ADO" -Source "$NUGET_SOURCE" -UserName "jawelton@microsoft.com" -Password "$AZURE_DEVOPS_PAT"
-      #- run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}"
-      #- run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.2.0.0-github-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget add source "$NUGET_SOURCE" --name "ADO" --username "jawelton@microsoft.com" --password "$AZURE_DEVOPS_PAT" --store-password-in-clear-text
-      - run: dotnet pack DataExplorer.proj /p:PackageVersion="0.0.9-TEST-${GITHUB_SHA}"
+      #- run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}"
+      - run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-test-${GITHUB_SHA}"
       - run: dotnet nuget push "bin/Release/*.nupkg" --skip-duplicate --api-key Az --source="$NUGET_SOURCE"
-      - run: dotnet nuget remove source --name "ADO"
-      #- run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"
-      #- run: nuget push -SkipDuplicate -Source "$NUGET_SOURCE" -ApiKey Az *.nupkg
-
-      #- uses: actions/upload-artifact@v4
-      #  name: packages
-      #  with:
-      #    path: "*.nupkg"
-  #nugetmpac:
-  #  name: Publish Nuget MPAC
-  #  if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
-  #  needs: [build]
-  #  runs-on: ubuntu-latest
-  #  env:
-  #    NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
-  #    AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
-  #  steps:
-  #    - uses: nuget/setup-nuget@v2
-  #      with:
-  #        nuget-api-key: ${{ secrets.NUGET_API_KEY }}
-  #    - name: Download Dist Folder
-  #      uses: actions/download-artifact@v4
-  #      with:
-  #        name: dist
-  #    - run: cp ./configs/mpac.json config.json
-  #    - run: sed -i 's/Azure.Cosmos.DB.Data.Explorer/Azure.Cosmos.DB.Data.Explorer.MPAC/g' DataExplorer.nuspec
-  #    - run: nuget sources add -Name "ADO" -Source "$NUGET_SOURCE" -UserName "jawelton@microsoft.com" -Password "$AZURE_DEVOPS_PAT"
-  #    - run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"
-  #    - run: nuget push -SkipDuplicate -Source "$NUGET_SOURCE" -ApiKey Az *.nupkg
-  #    - uses: actions/upload-artifact@v4
-  #      name: packages
-  #      with:
-  #        path: "*.nupkg"
+      - run: dotnet nuget remove source "ADO"
+      - uses: actions/upload-artifact@v4
+        name: packages
+        with:
+          path: "bin/Release/*.nupkg"
+  nugetmpac:
+    name: Publish Nuget MPAC
+    #if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
+    needs: [build]
+    runs-on: ubuntu-latest
+    env:
+      NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
+      AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
+      DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
+    steps:
+      - name: Download Dist Folder
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+      - run: cp ./configs/mpac.json config.json
+      - run: sed -i 's/Azure.Cosmos.DB.Data.Explorer/Azure.Cosmos.DB.Data.Explorer.MPAC/g' DataExplorer.nuspec
+      - run: dotnet nuget add source "$NUGET_SOURCE" --name "ADO" --username "jawelton@microsoft.com" --password "$AZURE_DEVOPS_PAT" --store-password-in-clear-text
+      #- run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}"
+      - run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-test-${GITHUB_SHA}"
+      - run: dotnet nuget push "bin/Release/*.nupkg" --skip-duplicate --api-key Az --source="$NUGET_SOURCE"
+      - run: dotnet nuget remove source "ADO"
+      - uses: actions/upload-artifact@v4
+        name: packages
+        with:
+          path: "bin/Release/*.nupkg"
 
   playwright-tests:
     name: "Run Playwright Tests (Shard ${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,13 +106,12 @@ jobs:
           PREVIEW_STORAGE_KEY: ${{ secrets.PREVIEW_STORAGE_KEY }}
   nuget:
     name: Publish Nuget
-    #if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
+    if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
     needs: [build]
     runs-on: ubuntu-latest
     env:
       NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
       AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
-      #DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
     steps:
       - name: Download Dist Folder
         uses: actions/download-artifact@v4
@@ -120,23 +119,22 @@ jobs:
           name: dist
       - run: cp ./configs/prod.json config.json
       - run: dotnet nuget add source "$NUGET_SOURCE" --name "ADO" --username "jawelton@microsoft.com" --password "$AZURE_DEVOPS_PAT" --store-password-in-clear-text
-      #- run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}"
-      - run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-test-${GITHUB_SHA}"
+      - run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}"
       - run: dotnet nuget push "bin/Release/*.nupkg" --skip-duplicate --api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget remove source "ADO"
       - uses: actions/upload-artifact@v4
         name: packages
         with:
           path: "bin/Release/*.nupkg"
+
   nugetmpac:
     name: Publish Nuget MPAC
-    #if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
+    if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
     needs: [build]
     runs-on: ubuntu-latest
     env:
       NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
       AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
-      DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
     steps:
       - name: Download Dist Folder
         uses: actions/download-artifact@v4
@@ -145,8 +143,7 @@ jobs:
       - run: cp ./configs/mpac.json config.json
       - run: sed -i 's/Azure.Cosmos.DB.Data.Explorer/Azure.Cosmos.DB.Data.Explorer.MPAC/g' DataExplorer.nuspec
       - run: dotnet nuget add source "$NUGET_SOURCE" --name "ADO" --username "jawelton@microsoft.com" --password "$AZURE_DEVOPS_PAT" --store-password-in-clear-text
-      #- run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}"
-      - run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-test-${GITHUB_SHA}"
+      - run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}"
       - run: dotnet nuget push "bin/Release/*.nupkg" --skip-duplicate --api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget remove source "ADO"
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
       #NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
       #AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
       NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_PAT }}
+      DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
     steps:
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,11 +115,11 @@ jobs:
       NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_PAT }}
       DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
     steps:
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '3.1.x'
-          source-url: ${{ secrets.NUGET_SOURCE }}
-          #nuget-api-key: ${{ secrets.NUGET_API_KEY }}
+      #- uses: actions/setup-dotnet@v4
+      #  with:
+      #    dotnet-version: '3.1.x'
+      #    source-url: ${{ secrets.NUGET_SOURCE }}
+      #    #nuget-api-key: ${{ secrets.NUGET_API_KEY }}
       - name: Download Dist Folder
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,9 @@ jobs:
       #- run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.2.0.0-github-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget add source "$NUGET_SOURCE" --name "ADO" --username "jawelton@microsoft.com" --password "$AZURE_DEVOPS_PAT" --store-password-in-clear-text
       - run: dotnet pack DataExplorer.proj /p:PackageVersion="0.0.9-TEST-${GITHUB_SHA}"
-      - run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.0.0.9-TEST-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
+      - run: ls -la .
+      - run: ls -la ./bin/release
+      - run: dotnet nuget push *.nupkg --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget remove source --name "ADO"
       #- run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"
       #- run: nuget push -SkipDuplicate -Source "$NUGET_SOURCE" -ApiKey Az *.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,15 +111,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
-      #AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
-      NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_PAT }}
+      AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
+      #NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_PAT }}
       DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
     steps:
-      #- uses: actions/setup-dotnet@v4
-      #  with:
-      #    dotnet-version: '3.1.x'
-      #    source-url: ${{ secrets.NUGET_SOURCE }}
-      #    #nuget-api-key: ${{ secrets.NUGET_API_KEY }}
       - name: Download Dist Folder
         uses: actions/download-artifact@v4
         with:
@@ -128,6 +123,7 @@ jobs:
       #- run: nuget sources add -Name "ADO" -Source "$NUGET_SOURCE" -UserName "jawelton@microsoft.com" -Password "$AZURE_DEVOPS_PAT"
       #- run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}"
       #- run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.2.0.0-github-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
+      - run: dotnet nuget add source "$NUGET_SOURCE" --name "ADO" --name "jawelton@microsoft.com" -Password "$AZURE_DEVOPS_PAT"
       - run: dotnet pack DataExplorer.proj /p:PackageVersion="0.0.9-TEST-${GITHUB_SHA}"
       - run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.0.0.9-TEST-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
       #- run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     env:
-      #NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
+      NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
       #AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
       NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_PAT }}
       DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
@@ -126,7 +126,9 @@ jobs:
           name: dist
       - run: cp ./configs/prod.json config.json
       #- run: nuget sources add -Name "ADO" -Source "$NUGET_SOURCE" -UserName "jawelton@microsoft.com" -Password "$AZURE_DEVOPS_PAT"
-      - run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}"
+      #- run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}"
+      - run: dotnet pack DataExplorer.proj /p:PackageVersion="TEST-${GITHUB_SHA}"
+      - run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.2.0.0-github-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
       #- run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"
       #- run: nuget push -SkipDuplicate -Source "$NUGET_SOURCE" -ApiKey Az *.nupkg
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
       #- run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.2.0.0-github-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget add source "$NUGET_SOURCE" --name "ADO" --username "jawelton@microsoft.com" --password "$AZURE_DEVOPS_PAT" --store-password-in-clear-text
       - run: dotnet pack DataExplorer.proj /p:PackageVersion="0.0.9-TEST-${GITHUB_SHA}"
-      - run: dotnet nuget push "bin/Release/*.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
+      - run: dotnet nuget push "bin/Release/*.nupkg" --skip-duplicate --api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget remove source --name "ADO"
       #- run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"
       #- run: nuget push -SkipDuplicate -Source "$NUGET_SOURCE" -ApiKey Az *.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       #- run: nuget sources add -Name "ADO" -Source "$NUGET_SOURCE" -UserName "jawelton@microsoft.com" -Password "$AZURE_DEVOPS_PAT"
       #- run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}"
       #- run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.2.0.0-github-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
-      - run: dotnet nuget add source "$NUGET_SOURCE" --name "ADO" --name "jawelton@microsoft.com" -Password "$AZURE_DEVOPS_PAT"
+      - run: dotnet nuget add source "$NUGET_SOURCE" --name "ADO" --username "jawelton@microsoft.com" --password "$AZURE_DEVOPS_PAT"
       - run: dotnet pack DataExplorer.proj /p:PackageVersion="0.0.9-TEST-${GITHUB_SHA}"
       - run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.0.0.9-TEST-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
       #- run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,53 +106,57 @@ jobs:
           PREVIEW_STORAGE_KEY: ${{ secrets.PREVIEW_STORAGE_KEY }}
   nuget:
     name: Publish Nuget
-    if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
+    #if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
     needs: [build]
     runs-on: ubuntu-latest
     env:
-      NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
-      AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
+      #NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
+      #AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
     steps:
-      - uses: nuget/setup-nuget@v2
+      - uses: actions/setup-dotnet@v4
         with:
-          nuget-api-key: ${{ secrets.NUGET_API_KEY }}
+          dotnet-version: '3.1.x'
+          source-url: ${{ secrets.NUGET_SOURCE }}
+          #nuget-api-key: ${{ secrets.NUGET_API_KEY }}
       - name: Download Dist Folder
         uses: actions/download-artifact@v4
         with:
           name: dist
       - run: cp ./configs/prod.json config.json
-      - run: nuget sources add -Name "ADO" -Source "$NUGET_SOURCE" -UserName "jawelton@microsoft.com" -Password "$AZURE_DEVOPS_PAT"
-      - run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"
-      - run: nuget push -SkipDuplicate -Source "$NUGET_SOURCE" -ApiKey Az *.nupkg
-      - uses: actions/upload-artifact@v4
-        name: packages
-        with:
-          path: "*.nupkg"
-  nugetmpac:
-    name: Publish Nuget MPAC
-    if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
-    needs: [build]
-    runs-on: ubuntu-latest
-    env:
-      NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
-      AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
-    steps:
-      - uses: nuget/setup-nuget@v2
-        with:
-          nuget-api-key: ${{ secrets.NUGET_API_KEY }}
-      - name: Download Dist Folder
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-      - run: cp ./configs/mpac.json config.json
-      - run: sed -i 's/Azure.Cosmos.DB.Data.Explorer/Azure.Cosmos.DB.Data.Explorer.MPAC/g' DataExplorer.nuspec
-      - run: nuget sources add -Name "ADO" -Source "$NUGET_SOURCE" -UserName "jawelton@microsoft.com" -Password "$AZURE_DEVOPS_PAT"
-      - run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"
-      - run: nuget push -SkipDuplicate -Source "$NUGET_SOURCE" -ApiKey Az *.nupkg
-      - uses: actions/upload-artifact@v4
-        name: packages
-        with:
-          path: "*.nupkg"
+      #- run: nuget sources add -Name "ADO" -Source "$NUGET_SOURCE" -UserName "jawelton@microsoft.com" -Password "$AZURE_DEVOPS_PAT"
+      - run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}" --no-build
+      #- run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"
+      #- run: nuget push -SkipDuplicate -Source "$NUGET_SOURCE" -ApiKey Az *.nupkg
+
+      #- uses: actions/upload-artifact@v4
+      #  name: packages
+      #  with:
+      #    path: "*.nupkg"
+  #nugetmpac:
+  #  name: Publish Nuget MPAC
+  #  if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
+  #  needs: [build]
+  #  runs-on: ubuntu-latest
+  #  env:
+  #    NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
+  #    AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
+  #  steps:
+  #    - uses: nuget/setup-nuget@v2
+  #      with:
+  #        nuget-api-key: ${{ secrets.NUGET_API_KEY }}
+  #    - name: Download Dist Folder
+  #      uses: actions/download-artifact@v4
+  #      with:
+  #        name: dist
+  #    - run: cp ./configs/mpac.json config.json
+  #    - run: sed -i 's/Azure.Cosmos.DB.Data.Explorer/Azure.Cosmos.DB.Data.Explorer.MPAC/g' DataExplorer.nuspec
+  #    - run: nuget sources add -Name "ADO" -Source "$NUGET_SOURCE" -UserName "jawelton@microsoft.com" -Password "$AZURE_DEVOPS_PAT"
+  #    - run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"
+  #    - run: nuget push -SkipDuplicate -Source "$NUGET_SOURCE" -ApiKey Az *.nupkg
+  #    - uses: actions/upload-artifact@v4
+  #      name: packages
+  #      with:
+  #        path: "*.nupkg"
 
   playwright-tests:
     name: "Run Playwright Tests (Shard ${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,10 @@ jobs:
     #if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
     needs: [build]
     runs-on: ubuntu-latest
-    #env:
+    env:
       #NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
       #AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
+      NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_PAT }}
     steps:
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           name: dist
       - run: cp ./configs/prod.json config.json
       #- run: nuget sources add -Name "ADO" -Source "$NUGET_SOURCE" -UserName "jawelton@microsoft.com" -Password "$AZURE_DEVOPS_PAT"
-      - run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}" --no-build
+      - run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}"
       #- run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"
       #- run: nuget push -SkipDuplicate -Source "$NUGET_SOURCE" -ApiKey Az *.nupkg
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,9 @@ jobs:
       - run: cp ./configs/prod.json config.json
       #- run: nuget sources add -Name "ADO" -Source "$NUGET_SOURCE" -UserName "jawelton@microsoft.com" -Password "$AZURE_DEVOPS_PAT"
       #- run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}"
-      - run: dotnet pack DataExplorer.proj /p:PackageVersion="TEST-${GITHUB_SHA}"
-      - run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.2.0.0-github-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
+      #- run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.2.0.0-github-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
+      - run: dotnet pack DataExplorer.proj /p:PackageVersion="0.0.9-TEST-${GITHUB_SHA}"
+      - run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.0.0.9-TEST-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
       #- run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"
       #- run: nuget push -SkipDuplicate -Source "$NUGET_SOURCE" -ApiKey Az *.nupkg
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
     env:
       NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
       AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
-      DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
+      #DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
     steps:
       - name: Download Dist Folder
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
     #if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
     needs: [build]
     runs-on: ubuntu-latest
-    env:
+    #env:
       #NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
       #AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,9 +123,10 @@ jobs:
       #- run: nuget sources add -Name "ADO" -Source "$NUGET_SOURCE" -UserName "jawelton@microsoft.com" -Password "$AZURE_DEVOPS_PAT"
       #- run: dotnet pack DataExplorer.proj /p:PackageVersion="2.0.0-github-${GITHUB_SHA}"
       #- run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.2.0.0-github-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
-      - run: dotnet nuget add source "$NUGET_SOURCE" --name "ADO" --username "jawelton@microsoft.com" --password "$AZURE_DEVOPS_PAT"
+      - run: dotnet nuget add source "$NUGET_SOURCE" --name "ADO" --username "jawelton@microsoft.com" --password "$AZURE_DEVOPS_PAT" --store-password-in-clear-text
       - run: dotnet pack DataExplorer.proj /p:PackageVersion="0.0.9-TEST-${GITHUB_SHA}"
       - run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.0.0.9-TEST-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
+      - run: dotnet nuget remove source --name "ADO"
       #- run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"
       #- run: nuget push -SkipDuplicate -Source "$NUGET_SOURCE" -ApiKey Az *.nupkg
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,6 @@ jobs:
       #- run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.2.0.0-github-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget add source "$NUGET_SOURCE" --name "ADO" --username "jawelton@microsoft.com" --password "$AZURE_DEVOPS_PAT" --store-password-in-clear-text
       - run: dotnet pack DataExplorer.proj /p:PackageVersion="0.0.9-TEST-${GITHUB_SHA}"
-      - run: ls -la .
-      - run: ls -la ./bin/release
       - run: dotnet nuget push *.nupkg --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget remove source --name "ADO"
       #- run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
       #- run: dotnet nuget push "Azure.Cosmos.DB.Data.Explorer.2.0.0-github-${GITHUB_SHA}.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget add source "$NUGET_SOURCE" --name "ADO" --username "jawelton@microsoft.com" --password "$AZURE_DEVOPS_PAT" --store-password-in-clear-text
       - run: dotnet pack DataExplorer.proj /p:PackageVersion="0.0.9-TEST-${GITHUB_SHA}"
-      - run: dotnet nuget push *.nupkg --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
+      - run: dotnet nuget push "bin/Release/*.nupkg" --skip-duplicate --symbol-api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget remove source --name "ADO"
       #- run: nuget pack -Version "2.0.0-github-${GITHUB_SHA}"
       #- run: nuget push -SkipDuplicate -Source "$NUGET_SOURCE" -ApiKey Az *.nupkg

--- a/DataExplorer.proj
+++ b/DataExplorer.proj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>v4.8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoBuild>true</NoBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NuspecFile>DataExplorer.nuspec</NuspecFile>

--- a/DataExplorer.proj
+++ b/DataExplorer.proj
@@ -1,9 +1,8 @@
-<Project>
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <NoBuild>true</NoBuild>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
     <NuspecFile>DataExplorer.nuspec</NuspecFile>
     <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
   </PropertyGroup>
-  <ItemGroup>
-    <Content Include=".\**\*.*" />
-  </ItemGroup>
 </Project>

--- a/DataExplorer.proj
+++ b/DataExplorer.proj
@@ -3,5 +3,7 @@
     <NuspecFile>DataExplorer.nuspec</NuspecFile>
     <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
   </PropertyGroup>
-  <Content Include=".\**\*.*" />
+  <ItemGroup>
+    <Content Include=".\**\*.*" />
+  </ItemGroup>
 </Project>

--- a/DataExplorer.proj
+++ b/DataExplorer.proj
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <NuspecFile>DataExplorer.nuspec</NuspecFile>
+    <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
+  </PropertyGroup>
+  <Content Include=".\**\*.*" />
+</Project>

--- a/DataExplorer.proj
+++ b/DataExplorer.proj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>v4.8</TargetFramework>
     <NoBuild>true</NoBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NuspecFile>DataExplorer.nuspec</NuspecFile>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -187,7 +187,12 @@ module.exports = function (_env = {}, argv = {}) {
     }),
     new MonacoWebpackPlugin(),
     new CopyWebpackPlugin({
-      patterns: [{ from: "DataExplorer.nuspec" }, { from: "DataExplorer.proj" }, { from: "web.config" }, { from: "quickstart/*.zip" }],
+      patterns: [
+        { from: "DataExplorer.nuspec" },
+        { from: "DataExplorer.proj" },
+        { from: "web.config" },
+        { from: "quickstart/*.zip" },
+      ],
     }),
     new EnvironmentPlugin(envVars),
   ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -187,7 +187,7 @@ module.exports = function (_env = {}, argv = {}) {
     }),
     new MonacoWebpackPlugin(),
     new CopyWebpackPlugin({
-      patterns: [{ from: "DataExplorer.nuspec" }, { from: "DataExplorer.proj" } ,{ from: "web.config" }, { from: "quickstart/*.zip" }],
+      patterns: [{ from: "DataExplorer.nuspec" }, { from: "DataExplorer.proj" }, { from: "web.config" }, { from: "quickstart/*.zip" }],
     }),
     new EnvironmentPlugin(envVars),
   ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -187,7 +187,7 @@ module.exports = function (_env = {}, argv = {}) {
     }),
     new MonacoWebpackPlugin(),
     new CopyWebpackPlugin({
-      patterns: [{ from: "DataExplorer.nuspec" }, { from: "web.config" }, { from: "quickstart/*.zip" }],
+      patterns: [{ from: "DataExplorer.nuspec" }, { from: "DataExplorer.proj" } ,{ from: "web.config" }, { from: "quickstart/*.zip" }],
     }),
     new EnvironmentPlugin(envVars),
   ];


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/2026?feature.someFeatureFlagYouMightNeed=true)

This change updates the CI action to use dotnet CLI for nuget package operations (i.e. pack and publish) instead of Nuget.exe. This is necessary due to Nuget.exe no longer working on latest Ubuntu images as Mono is no longer installed by default.

More details here: https://github.com/NuGet/setup-nuget/issues/168