### PR TITLE
Use unique names in upload artifacts tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,9 +123,9 @@ jobs:
       - run: dotnet nuget push "bin/Release/*.nupkg" --skip-duplicate --api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget remove source "ADO"
       - uses: actions/upload-artifact@v4
-        name: packages
+        name: prod-package
         with:
-          path: "bin/Release/Azure.Cosmos.DB.Data.Explorer.2.0.0-github-${GITHUB_SHA}.nupkg"
+          path: "bin/Release/*.nupkg"
 
   nugetmpac:
     name: Publish Nuget MPAC
@@ -147,9 +147,9 @@ jobs:
       - run: dotnet nuget push "bin/Release/*.nupkg" --skip-duplicate --api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget remove source "ADO"
       - uses: actions/upload-artifact@v4
-        name: packages
+        name: mpac-package
         with:
-          path: "bin/Release/Azure.Cosmos.DB.Data.Explorer.MPAC.2.0.0-github-${GITHUB_SHA}.nupkg"
+          path: "bin/Release/*.nupkg"
 
   playwright-tests:
     name: "Run Playwright Tests (Shard ${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           PREVIEW_STORAGE_KEY: ${{ secrets.PREVIEW_STORAGE_KEY }}
   nuget:
     name: Publish Nuget
-    #if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
+    if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
     needs: [build]
     runs-on: ubuntu-latest
     env:
@@ -130,7 +130,7 @@ jobs:
 
   nugetmpac:
     name: Publish Nuget MPAC
-    #if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
+    if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
     needs: [build]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           PREVIEW_STORAGE_KEY: ${{ secrets.PREVIEW_STORAGE_KEY }}
   nuget:
     name: Publish Nuget
-    if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
+    #if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
     needs: [build]
     runs-on: ubuntu-latest
     env:
@@ -125,11 +125,11 @@ jobs:
       - uses: actions/upload-artifact@v4
         name: packages
         with:
-          path: "bin/Release/*.nupkg"
+          path: "bin/Release/Azure.Cosmos.DB.Data.Explorer.2.0.0-github-${GITHUB_SHA}.nupkg"
 
   nugetmpac:
     name: Publish Nuget MPAC
-    if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
+    #if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/') || contains(github.ref, 'release/')
     needs: [build]
     runs-on: ubuntu-latest
     env:
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         name: packages
         with:
-          path: "bin/Release/*.nupkg"
+          path: "bin/Release/Azure.Cosmos.DB.Data.Explorer.MPAC.2.0.0-github-${GITHUB_SHA}.nupkg"
 
   playwright-tests:
     name: "Run Playwright Tests (Shard ${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,9 @@ jobs:
       - run: dotnet nuget push "bin/Release/*.nupkg" --skip-duplicate --api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget remove source "ADO"
       - uses: actions/upload-artifact@v4
-        name: prod-package
+        name: Upload package to Artifacts
         with:
+          name: prod-package
           path: "bin/Release/*.nupkg"
 
   nugetmpac:
@@ -147,8 +148,9 @@ jobs:
       - run: dotnet nuget push "bin/Release/*.nupkg" --skip-duplicate --api-key Az --source="$NUGET_SOURCE"
       - run: dotnet nuget remove source "ADO"
       - uses: actions/upload-artifact@v4
-        name: mpac-package
+        name: Upload package to Artifacts
         with:
+          name: mpac-package
           path: "bin/Release/*.nupkg"
 
   playwright-tests:


### PR DESCRIPTION
[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/2030?feature.someFeatureFlagYouMightNeed=true)

This addresses a change in the v4 upload-artifacts action, which fails when duplicate artifact names are used. It was causing Publish Nuget tasks to fail.