### PR TITLE
[Screen Reader- Azure Cosmos DB- Data Explorer]: The Learn more links are not descriptive present under the settings.

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -518,6 +518,11 @@ export class PriorityLevel {
   public static readonly Default = "low";
 }
 
+export class ariaLabelForLearnMoreLink {
+  public static readonly AnalyticalStore = "Learn more about analytical store.";
+  public static readonly AzureSynapseLink = "Learn more about Azure Synapse Link.";
+}
+
 export const QueryCopilotSampleDatabaseId = "CopilotSampleDB";
 export const QueryCopilotSampleContainerId = "SampleContainer";
 

--- a/src/Explorer/Panes/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel.tsx
@@ -865,6 +865,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                     <Link
                       href="https://aka.ms/cosmosdb-synapselink"
                       target="_blank"
+                      aria-label={Constants.ariaLabelForLearnMoreLink.AzureSynapseLink}
                       className="capacitycalculator-link"
                     >
                       Learn more
@@ -1222,7 +1223,11 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
       <Text variant="small">
         Enable analytical store capability to perform near real-time analytics on your operational data, without
         impacting the performance of transactional workloads.{" "}
-        <Link target="_blank" href="https://aka.ms/analytical-store-overview">
+        <Link
+          aria-label={Constants.ariaLabelForLearnMoreLink.AnalyticalStore}
+          target="_blank"
+          href="https://aka.ms/analytical-store-overview"
+        >
           Learn more
         </Link>
       </Text>

--- a/src/Explorer/Panes/__snapshots__/AddCollectionPanel.test.tsx.snap
+++ b/src/Explorer/Panes/__snapshots__/AddCollectionPanel.test.tsx.snap
@@ -319,6 +319,7 @@ exports[`AddCollectionPanel should render Default properly 1`] = `
           Enable analytical store capability to perform near real-time analytics on your operational data, without impacting the performance of transactional workloads.
            
           <StyledLinkBase
+            aria-label="Learn more about analytical store."
             href="https://aka.ms/analytical-store-overview"
             target="_blank"
           >
@@ -383,6 +384,7 @@ exports[`AddCollectionPanel should render Default properly 1`] = `
           . Enable Synapse Link for this Cosmos DB account.
            
           <StyledLinkBase
+            aria-label="Learn more about Azure Synapse Link."
             className="capacitycalculator-link"
             href="https://aka.ms/cosmosdb-synapselink"
             target="_blank"


### PR DESCRIPTION
This PR addresses an issue in Azure Cosmos DB - Data Explorer where the "Learn More" links under the settings were not sufficiently descriptive. The links have now been revised to offer clearer, more specific information, in line with the requirements outlined in the related tickets. Users will now have a better understanding of the relevant settings and their functionality, improving the overall user experience and accessibility.


[Preview this branch](https://cosmos-explorer-preview.azurewebsites.net/pull/2035?feature.someFeatureFlagYouMightNeed=true)


![image](https://github.com/user-attachments/assets/525cc48a-e10c-463f-bab3-8cf4d56d2a03)
