### PR TITLE
Remove feature switch on restore tabs

### DIFF
--- a/src/Platform/Hosted/extractFeatures.ts
+++ b/src/Platform/Hosted/extractFeatures.ts
@@ -38,7 +38,6 @@ export type Features = {
   readonly copilotChatFixedMonacoEditorHeight: boolean;
   readonly enablePriorityBasedExecution: boolean;
   readonly disableConnectionStringLogin: boolean;
-  readonly restoreTabs: boolean;
 
   // can be set via both flight and feature flag
   autoscaleDefault: boolean;
@@ -109,7 +108,6 @@ export function extractFeatures(given = new URLSearchParams(window.location.sear
     copilotChatFixedMonacoEditorHeight: "true" === get("copilotchatfixedmonacoeditorheight"),
     enablePriorityBasedExecution: "true" === get("enableprioritybasedexecution"),
     disableConnectionStringLogin: "true" === get("disableconnectionstringlogin"),
-    restoreTabs: "true" === get("restoretabs"),
   };
 }
 

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -85,9 +85,7 @@ export function useKnockoutExplorer(platform: Platform): Explorer {
           await updateContextForSampleData(explorer);
         }
 
-        if (userContext.features.restoreTabs) {
-          restoreOpenTabs();
-        }
+        restoreOpenTabs();
 
         setExplorer(explorer);
       }


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2039)

Enable restore tabs by default.