### PR TITLE
[Forms and Validation - Azure Cosmos DB- Data Explorer - New Vertex]: Visual Label is not defined for Key, Value and Type input fields under 'New Vertex' pane.

### DIFF
--- a/src/Explorer/Graph/NewVertexComponent/NewVertexComponent.less
+++ b/src/Explorer/Graph/NewVertexComponent/NewVertexComponent.less
@@ -14,10 +14,6 @@
       .flex-direction(@direction: row);
       padding: 4px 5px;
 
-      label {
-        padding: 0px;
-      }
-
       .valueCol {
         flex-grow: 1;
         padding-right: 5px;
@@ -61,6 +57,10 @@
   .rightPaneTrashIcon {
     padding: 4px 1px 0px 4px;
     height: 100%;
+  }
+
+  .customTrashIcon {
+    padding-top: 33px;
   }
 
   .rightPaneTrashIconImg {

--- a/src/Explorer/Graph/NewVertexComponent/NewVertexComponent.tsx
+++ b/src/Explorer/Graph/NewVertexComponent/NewVertexComponent.tsx
@@ -142,10 +142,11 @@ export const NewVertexComponent: FunctionComponent<INewVertexComponentProps> = (
                 <div className="labelCol">
                   <TextField
                     className="edgeInput"
+                    label={index === 0 && "Key"}
                     type="text"
                     id="propertyKeyNewVertexPane"
                     componentRef={input}
-                    aria-required="true"
+                    required
                     placeholder="Key"
                     autoComplete="off"
                     aria-label={`Enter value for propery ${index + 1}`}
@@ -153,11 +154,11 @@ export const NewVertexComponent: FunctionComponent<INewVertexComponentProps> = (
                     onChange={(event: React.ChangeEvent<HTMLInputElement>) => onKeyChange(event, index)}
                   />
                 </div>
-                <span className="mandatoryStar">*&nbsp;</span>
 
                 <div className="valueCol">
                   <TextField
                     className="edgeInput"
+                    label={index === 0 && "Value"}
                     type="text"
                     placeholder="Value"
                     autoComplete="off"
@@ -169,6 +170,8 @@ export const NewVertexComponent: FunctionComponent<INewVertexComponentProps> = (
                 <div>
                   <Dropdown
                     role="combobox"
+                    label={index === 0 && "Type"}
+                    ariaLabel="Type"
                     placeholder="Select an option"
                     defaultSelectedKey={data.values[0].type}
                     style={{ width: 100 }}
@@ -181,7 +184,7 @@ export const NewVertexComponent: FunctionComponent<INewVertexComponentProps> = (
                 </div>
                 <div className="actionCol">
                   <div
-                    className="rightPaneTrashIcon rightPaneBtns"
+                    className={`rightPaneTrashIcon rightPaneBtns ${index === 0 && "customTrashIcon"}`}
                     tabIndex={0}
                     role="button"
                     aria-label={`Delete ${data.key}`}


### PR DESCRIPTION
This PR addresses two accessibility improvements in the 'New Vertex' pane of the Azure Cosmos DB Data Explorer. Firstly, visual labels have been added to the "Key," "Value," and "Type" input fields, ensuring clearer identification of each field for users. Secondly, the 'Type' combo box has been enhanced by adding an aria-label, improving its accessibility for programmatic access and making it more usable for users with assistive technologies.

[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2040?feature.someFeatureFlagYouMightNeed=true)


Before:
![image](https://github.com/user-attachments/assets/8a569ea8-0761-41b7-bde1-1b87d5576d40)
After:
![image](https://github.com/user-attachments/assets/dea45a87-54e7-43e8-8b50-3b68907989ac)
