### PR TITLE
Bug fix: do not auto-open first container if a tab is already open (Fabric only)

### DIFF
--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -181,6 +181,11 @@ async function configureFabric(): Promise<Explorer> {
 }
 
 const openFirstContainer = async (explorer: Explorer, databaseName: string, collectionName?: string) => {
+  if (useTabs.getState().openedTabs.length > 0) {
+    // Don't open any tabs if there are already tabs open
+    return;
+  }
+
   // Expand database first
   databaseName = sessionStorage.getItem("openDatabaseName") ?? databaseName;
   const database = useDatabases.getState().databases.find((db) => db.id() === databaseName);


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2045)

For Fabric mirroring, we always auto-open the first container of the database (the Documents tab shown as "Items") for convenience.
Now that Data Explorer restores open tabs, we prevent DE from auto-opening the first container if a tab is already open.
