### PR TITLE
Remove blocking await on sample database

### DIFF
--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -1127,7 +1127,7 @@ export default class Explorer {
       await this.initNotebooks(userContext.databaseAccount);
     }
 
-    await this.refreshSampleData();
+    this.refreshSampleData();
   }
 
   public async configureCopilot(): Promise<void> {
@@ -1152,26 +1152,27 @@ export default class Explorer {
       .setCopilotSampleDBEnabled(copilotEnabled && copilotUserDBEnabled && copilotSampleDBEnabled);
   }
 
-  public async refreshSampleData(): Promise<void> {
-    try {
-      if (!userContext.sampleDataConnectionInfo) {
-        return;
-      }
-      const collection: DataModels.Collection = await readSampleCollection();
-      if (!collection) {
-        return;
-      }
-
-      const databaseId = userContext.sampleDataConnectionInfo?.databaseId;
-      if (!databaseId) {
-        return;
-      }
-
-      const sampleDataResourceTokenCollection = new ResourceTokenCollection(this, databaseId, collection, true);
-      useDatabases.setState({ sampleDataResourceTokenCollection });
-    } catch (error) {
-      Logger.logError(getErrorMessage(error), "Explorer");
+  public refreshSampleData(): void {
+    if (!userContext.sampleDataConnectionInfo) {
       return;
     }
+
+    const databaseId = userContext.sampleDataConnectionInfo?.databaseId;
+    if (!databaseId) {
+      return;
+    }
+
+    readSampleCollection()
+      .then((collection: DataModels.Collection) => {
+        if (!collection) {
+          return;
+        }
+
+        const sampleDataResourceTokenCollection = new ResourceTokenCollection(this, databaseId, collection, true);
+        useDatabases.setState({ sampleDataResourceTokenCollection });
+      })
+      .catch((error) => {
+        Logger.logError(getErrorMessage(error), "Explorer/refreshSampleData");
+      });
   }
 }

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -820,7 +820,7 @@ async function updateContextForSampleData(explorer: Explorer): Promise<void> {
   const sampleDataConnectionInfo = parseResourceTokenConnectionString(data.connectionString);
   updateUserContext({ sampleDataConnectionInfo });
 
-  await explorer.refreshSampleData();
+  explorer.refreshSampleData();
 }
 
 interface SampledataconnectionResponse {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -248,6 +248,7 @@ module.exports = function (_env = {}, argv = {}) {
         new TerserPlugin({
           terserOptions: {
             // These options increase our initial bundle size by ~5% but the builds are significantly faster and won't run out of memory
+            // Update 2/11/202: we are removing this flag as our bundles sizes grew so that it can remove dead and unreachable code with compromise of build time
             // compress: false,
             mangle: {
               keep_fnames: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -248,7 +248,7 @@ module.exports = function (_env = {}, argv = {}) {
         new TerserPlugin({
           terserOptions: {
             // These options increase our initial bundle size by ~5% but the builds are significantly faster and won't run out of memory
-            compress: false,
+            // compress: false,
             mangle: {
               keep_fnames: true,
               keep_classnames: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -248,7 +248,7 @@ module.exports = function (_env = {}, argv = {}) {
         new TerserPlugin({
           terserOptions: {
             // These options increase our initial bundle size by ~5% but the builds are significantly faster and won't run out of memory
-            // Update 2/11/202: we are removing this flag as our bundles sizes grew so that it can remove dead and unreachable code with compromise of build time
+            // Update 2/11/2025: we are removing this flag as our bundles sizes grew so that it can remove dead and unreachable code with compromise of build time
             // compress: false,
             mangle: {
               keep_fnames: true,


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2047?feature.someFeatureFlagYouMightNeed=true)

This PR addresses a couple of optimizations on the Data Explorer build and runtime.

1. Removed compress:false flag from webpack configuration. This increases the build time at npm run pack:prod by ~75-100%, but it will reduce the bundle size by ~100-150%
2. Removed blocking async/await on the reading sample database call at the initialization.
- This introduces a refresh of the sidebar after the explorer is loaded, but at least they do not have to wait until this HTTP request is completed.

