### PR TITLE
Modify E2E cleanup script to use @azure/identity for AZ credentials.

### DIFF
--- a/utils/cleanupDBs.js
+++ b/utils/cleanupDBs.js
@@ -1,4 +1,4 @@
-const msRestNodeAuth = require("@azure/ms-rest-nodeauth");
+const { AzureCliCredential } = require("@azure/identity");
 const { CosmosDBManagementClient } = require("@azure/arm-cosmosdb");
 const ms = require("ms");
 
@@ -16,7 +16,7 @@ function friendlyTime(date) {
 }
 
 async function main() {
-  const credentials = await msRestNodeAuth.AzureCliCredentials.create();
+  const credentials = new AzureCliCredential();
   const client = new CosmosDBManagementClient(credentials, subscriptionId);
   const accounts = await client.databaseAccounts.list(resourceGroupName);
   for (const account of accounts) {


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2051?feature.someFeatureFlagYouMightNeed=true)

Fix the Action that cleans up E2E test resources - we moved to @azure/identity package recently and this was missed in that change.
