### PR TITLE
[Visual Requirement - Azure Cosmos DB - Add Row]: Ensures the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds.

### DIFF
--- a/less/Common/Constants.less
+++ b/less/Common/Constants.less
@@ -61,6 +61,8 @@
 
 @GalleryBackgroundColor: #fdfdfd;
 
+@LinkColor: #2d6da4;
+
 //Icons
 @InfoIconColor: #0072c6;
 @WarningIconColor: #db7500;

--- a/src/Explorer/Panes/PanelComponent.less
+++ b/src/Explorer/Panes/PanelComponent.less
@@ -94,6 +94,7 @@
     padding-left: @MediumSpace;
 
     .paneErrorLink {
+      color: @LinkColor;
       cursor: pointer;
       font-size: @mediumFontSize;
     }


### PR DESCRIPTION
This update ensures that the color contrast between foreground and background elements complies with the WCAG 2 AA minimum contrast ratio standards. We have applied colors according to the scanner results to guarantee accessibility and readability for users with visual impairments.

[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2054?feature.someFeatureFlagYouMightNeed=true)

![image](https://github.com/user-attachments/assets/b130c4f0-0a8a-43e8-b9fb-18bd90032e5b)
