### PR TITLE
Fixing SelfServeType enum to work in MPAC

### DIFF
--- a/src/SelfServe/SelfServe.tsx
+++ b/src/SelfServe/SelfServe.tsx
@@ -41,13 +41,13 @@ const getDescriptor = async (selfServeType: SelfServeType): Promise<SelfServeDes
     case SelfServeType.example: {
       const SelfServeExample = await import(/* webpackChunkName: "SelfServeExample" */ "./Example/SelfServeExample");
       const selfServeExample = new SelfServeExample.default();
-      await loadTranslations(selfServeExample.constructor.name);
+      await loadTranslations(selfServeType);
       return selfServeExample.toSelfServeDescriptor();
     }
     case SelfServeType.sqlx: {
       const SqlX = await import(/* webpackChunkName: "SqlX" */ "./SqlX/SqlX");
       const sqlX = new SqlX.default();
-      await loadTranslations(sqlX.constructor.name);
+      await loadTranslations(selfServeType);
       return sqlX.toSelfServeDescriptor();
     }
     case SelfServeType.graphapicompute: {
@@ -55,7 +55,7 @@ const getDescriptor = async (selfServeType: SelfServeType): Promise<SelfServeDes
         /* webpackChunkName: "GraphAPICompute" */ "./GraphAPICompute/GraphAPICompute"
       );
       const graphAPICompute = new GraphAPICompute.default();
-      await loadTranslations(graphAPICompute.constructor.name);
+      await loadTranslations(selfServeType);
       return graphAPICompute.toSelfServeDescriptor();
     }
     case SelfServeType.materializedviewsbuilder: {
@@ -63,7 +63,7 @@ const getDescriptor = async (selfServeType: SelfServeType): Promise<SelfServeDes
         /* webpackChunkName: "MaterializedViewsBuilder" */ "./MaterializedViewsBuilder/MaterializedViewsBuilder"
       );
       const materializedViewsBuilder = new MaterializedViewsBuilder.default();
-      await loadTranslations(materializedViewsBuilder.constructor.name);
+      await loadTranslations(selfServeType);
       return materializedViewsBuilder.toSelfServeDescriptor();
     }
     default:
@@ -103,7 +103,7 @@ const handleMessage = async (event: MessageEvent): Promise<void> => {
 
   const urlSearchParams = new URLSearchParams(window.location.search);
   const selfServeTypeText = urlSearchParams.get("selfServeType") || inputs.selfServeType;
-  const selfServeType = SelfServeType[selfServeTypeText?.toLowerCase() as keyof typeof SelfServeType];
+  const selfServeType = SelfServeType[selfServeTypeText.toLocaleLowerCase() as keyof typeof SelfServeType];
   if (
     !inputs.subscriptionId ||
     !inputs.resourceGroup ||

--- a/src/SelfServe/SelfServeUtils.tsx
+++ b/src/SelfServe/SelfServeUtils.tsx
@@ -29,10 +29,11 @@ export enum SelfServeType {
   // Unsupported self serve type passed as feature flag
   invalid = "invalid",
   // Add your self serve types here
+  // NOTE: text and casing of the enum's value must match the corresponding file in Localization\en\
   example = "example",
-  sqlx = "sqlx",
-  graphapicompute = "graphapicompute",
-  materializedviewsbuilder = "materializedviewsbuilder",
+  sqlx = "SqlX",
+  graphapicompute = "GraphAPICompute",
+  materializedviewsbuilder = "MaterializedViewsBuilder",
 }
 
 /**


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2057)

All of the strings used in self serve blades are stored in src/Localization/en/<selfServeTypeName>.json. The previous method to get the name of the  .json was to use SelfServeType.constructor.name. This works as expected in PROD (i.e. for SqlX, sqlx.constructor.name returns "SqlX). But this does not work in MPAC. It seems to return a minified name (i.e. for SqlX it would return "y"). Since there's no file called y.json the method would fail to load the strings for SqlX.

So this switches the method for getting the name by simply returning the value of the enum SelfServeType (which has also been changed to match the casing of the files on disk).

NOTE! If you want to test this PR, you need to change the URL's query string to use the self serve endpoint like this:
https://portal.azure.com/?selfservesource=https%3A%2F%2Fdataexplorer-preview.azurewebsites.net%2Fcommit%2F45402852c7c8651ee7e4c85c66c8128c1cb5d515%2FselfServe.html%3Ffeature.pr%3Dhttps%253A%252F%252Fgithub.com%252FAzure%252Fcosmos-explorer%252Fpull%252F2057%2523users%252Fchskelt%252FfixSelfServeLocalization
