### PR TITLE
[Programmatic access - Cosmos DB Query Copilot - Query Faster with Copilot>Enable Query Advisor]: Element's role present under 'Sample Query1' tab does not support its ARIA attributes.

### DIFF
--- a/src/Explorer/QueryCopilot/QueryCopilotPromptbar.tsx
+++ b/src/Explorer/QueryCopilot/QueryCopilotPromptbar.tsx
@@ -393,8 +393,7 @@ export const QueryCopilotPromptbar: React.FC<QueryCopilotPromptProps> = ({
                 },
               }}
               disabled={isGeneratingQuery}
-              autoComplete="list"
-              aria-expanded={showSamplePrompts}
+              autoComplete="off"
               placeholder="Ask a question in natural language and we’ll generate the query for you."
               aria-labelledby="copilot-textfield-label"
               onRenderSuffix={() => {


### PR DESCRIPTION
This pull request addresses an accessibility issue in the 'Sample Query1' tab of the Cosmos DB Query Copilot. The element's role was not supporting its ARIA attributes correctly. The aria-expanded attribute was used on an element where it is not supported. This has been removed. The autocomplete="list" attribute, which was also problematic, has been updated to autocomplete="off" for better functionality and compliance with accessibility standards. This change ensures improved support for assistive technologies and better user experience.

[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2059?feature.someFeatureFlagYouMightNeed=true)

Before:
![image](https://github.com/user-attachments/assets/c0d59e14-6953-460a-bcdb-e72b543338e8)
![image](https://github.com/user-attachments/assets/9b44f457-eec6-4d68-9ff5-5714ea19ba09)

