### PR TITLE
Change value of the example SelfServeType enum to match file name.

### DIFF
--- a/src/SelfServe/SelfServeUtils.tsx
+++ b/src/SelfServe/SelfServeUtils.tsx
@@ -30,7 +30,7 @@ export enum SelfServeType {
   invalid = "invalid",
   // Add your self serve types here
   // NOTE: text and casing of the enum's value must match the corresponding file in Localization\en\
-  example = "example",
+  example = "SelfServeExample",
   sqlx = "SqlX",
   graphapicompute = "GraphAPICompute",
   materializedviewsbuilder = "MaterializedViewsBuilder",


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2062?feature.someFeatureFlagYouMightNeed=true)

This change updates the value of `example` in the `SelfServeType` enum to match the corresponding localization file name.
This addresses one of the e2e tests which is currently failing.
