### PR TITLE
[Screen reader - Cosmos DB Query Copilot - Query Faster with Copilot>Enable Query Advisor]: Screen reader does not announce the dialog information on invoking 'Clear editor' button.

### DIFF
--- a/src/Explorer/QueryCopilot/Popup/DeletePopup.tsx
+++ b/src/Explorer/QueryCopilot/Popup/DeletePopup.tsx
@@ -22,12 +22,17 @@ export const DeletePopup = ({
   };
 
   return (
-    <Modal isOpen={showDeletePopup} styles={{ main: { minHeight: "122px", minWidth: "880px" } }}>
+    <Modal
+      isOpen={showDeletePopup}
+      styles={{ main: { minHeight: "122px", minWidth: "880px" } }}
+      titleAriaId="deleteDialogTitle"
+      subtitleAriaId="deleteDialogSubTitle"
+    >
       <Stack style={{ padding: "16px 24px", height: "auto" }}>
-        <Text style={{ height: 24, fontSize: "18px" }}>
+        <Text id="deleteDialogTitle" style={{ height: 24, fontSize: "18px" }}>
           <b>Delete code?</b>
         </Text>
-        <Text style={{ marginTop: 10, marginBottom: 20 }}>
+        <Text id="deleteDialogSubTitle" style={{ marginTop: 10, marginBottom: 20 }}>
           This will clear the query from the query builder pane along with all comments and also reset the prompt pane
         </Text>
         <Stack horizontal tokens={{ childrenGap: 10 }} horizontalAlign="start">

--- a/src/Explorer/QueryCopilot/Popup/__snapshots__/DeletePopup.test.tsx.snap
+++ b/src/Explorer/QueryCopilot/Popup/__snapshots__/DeletePopup.test.tsx.snap
@@ -11,6 +11,8 @@ exports[`Delete Popup snapshot test should not render when showDeletePopup is fa
       },
     }
   }
+  subtitleAriaId="deleteDialogSubTitle"
+  titleAriaId="deleteDialogTitle"
 >
   <Stack
     style={
@@ -21,6 +23,7 @@ exports[`Delete Popup snapshot test should not render when showDeletePopup is fa
     }
   >
     <Text
+      id="deleteDialogTitle"
       style={
         {
           "fontSize": "18px",
@@ -33,6 +36,7 @@ exports[`Delete Popup snapshot test should not render when showDeletePopup is fa
       </b>
     </Text>
     <Text
+      id="deleteDialogSubTitle"
       style={
         {
           "marginBottom": 20,
@@ -89,6 +93,8 @@ exports[`Delete Popup snapshot test should render when showDeletePopup is true 1
       },
     }
   }
+  subtitleAriaId="deleteDialogSubTitle"
+  titleAriaId="deleteDialogTitle"
 >
   <Stack
     style={
@@ -99,6 +105,7 @@ exports[`Delete Popup snapshot test should render when showDeletePopup is true 1
     }
   >
     <Text
+      id="deleteDialogTitle"
       style={
         {
           "fontSize": "18px",
@@ -111,6 +118,7 @@ exports[`Delete Popup snapshot test should render when showDeletePopup is true 1
       </b>
     </Text>
     <Text
+      id="deleteDialogSubTitle"
       style={
         {
           "marginBottom": 20,


### PR DESCRIPTION
This PR addresses an accessibility issue in the Cosmos DB Query Copilot, specifically when invoking the 'Clear editor' button. Currently, the screen reader does not announce the dialog information properly when this button is clicked. The changes in this PR ensure that the correct label and sub-label are sent to the modal component, allowing the screen reader to accurately announce the dialog content. This enhancement improves the overall accessibility of the application, providing a better experience for users who rely on assistive technologies.


[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2068?feature.someFeatureFlagYouMightNeed=true)

Before: 
![image](https://github.com/user-attachments/assets/c006f20b-4b66-4d97-b807-9d9ef1ff5954)

After: 
![image](https://github.com/user-attachments/assets/4414961b-46ad-4ce6-a35e-c29aacddeffd)


