### PR TITLE
[Keyboard Navigation - Azure Cosmos DB - Data Explorer - New Graph]: Keyboard focus indicator is not landing on the first interactive control after activating the 'New Graph' control.

### DIFF
--- a/src/Explorer/Panes/AddCollectionPanel/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel/AddCollectionPanel.tsx
@@ -337,7 +337,6 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                     size={40}
                     className="panelTextField"
                     aria-label="New database id, Type a new database id"
-                    autoFocus
                     tabIndex={0}
                     value={this.state.newDatabaseId}
                     onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
@@ -742,7 +741,6 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
                           : "Comma separated paths e.g. /firstName,/address/zipCode"
                       }
                       className="panelTextField"
-                      autoFocus
                       value={uniqueKey}
                       onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                         const uniqueKeys = this.state.uniqueKeys.map((uniqueKey: string, j: number) => {

--- a/src/Explorer/Panes/AddCollectionPanel/__snapshots__/AddCollectionPanel.test.tsx.snap
+++ b/src/Explorer/Panes/AddCollectionPanel/__snapshots__/AddCollectionPanel.test.tsx.snap
@@ -88,7 +88,6 @@ exports[`AddCollectionPanel should render Default properly 1`] = `
           aria-label="New database id, Type a new database id"
           aria-required={true}
           autoComplete="off"
-          autoFocus={true}
           className="panelTextField"
           id="newDatabaseId"
           name="newDatabaseId"


### PR DESCRIPTION
This PR fixes an issue where the keyboard focus indicator did not land on the first interactive control after activating the 'New Graph' control in Azure Cosmos DB Data Explorer. The second interactive autofocus has been removed, ensuring the focus now correctly lands on the first control.

[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2073?feature.someFeatureFlagYouMightNeed=true)
Before: 
![image](https://github.com/user-attachments/assets/00b34b43-8e4a-4e80-88ac-b1db7d127ebd)

After:
https://github.com/user-attachments/assets/42c03333-832d-4a1b-af88-0f3b14b4a51f

