### PR TITLE
fix tab wrapping with a lil' css tweak (#2013)

### DIFF
--- a/less/documentDB.less
+++ b/less/documentDB.less
@@ -1914,13 +1914,20 @@ input::-webkit-calendar-picker-indicator::after {
 }
 
 .nav-tabs-margin {
-  height: 32px;
   background-color: #f2f2f2;
 
   .nav-tabs {
     display: flex;
+    flex-wrap: wrap;
     align-items: flex-end;
     height: 100%;
+    margin-bottom: -0.5px;
+
+    li {
+      // Override the bootstrap defaults here to align with our layout constants.
+      margin-bottom: 0px;
+      height: 32px;
+    }
   }
 }
 


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2076)
Cherry-picking this [fix](https://github.com/Azure/cosmos-explorer/pull/2013) that was merged to [release/holidays2024](https://github.com/Azure/cosmos-explorer/tree/release/holidays2024), but didn't make it to `master`.
