### PR TITLE
Test Cases Update: added explorer as a prop

### DIFF
--- a/src/Explorer/Controls/Settings/SettingsSubComponents/MaterializedViewComponent.test.tsx
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/MaterializedViewComponent.test.tsx
@@ -1,12 +1,13 @@
 import { shallow } from "enzyme";
 import React from "react";
-import { collection } from "../TestUtils";
+import { collection, container } from "../TestUtils";
 import { MaterializedViewComponent } from "./MaterializedViewComponent";
 import { MaterializedViewSourceComponent } from "./MaterializedViewSourceComponent";
 import { MaterializedViewTargetComponent } from "./MaterializedViewTargetComponent";
 
 describe("MaterializedViewComponent", () => {
   let testCollection: typeof collection;
+  let testExplorer: typeof container;
 
   beforeEach(() => {
     testCollection = { ...collection };
@@ -18,7 +19,7 @@ describe("MaterializedViewComponent", () => {
       { id: "view2", _rid: "rid2" },
     ]);
     testCollection.materializedViewDefinition(null);
-    const wrapper = shallow(<MaterializedViewComponent collection={testCollection} />);
+    const wrapper = shallow(<MaterializedViewComponent collection={testCollection} explorer={testExplorer} />);
     expect(wrapper.find(MaterializedViewSourceComponent).exists()).toBe(true);
     expect(wrapper.find(MaterializedViewTargetComponent).exists()).toBe(false);
   });
@@ -30,7 +31,7 @@ describe("MaterializedViewComponent", () => {
       sourceCollectionId: "source1",
       sourceCollectionRid: "rid123",
     });
-    const wrapper = shallow(<MaterializedViewComponent collection={testCollection} />);
+    const wrapper = shallow(<MaterializedViewComponent collection={testCollection} explorer={testExplorer} />);
     expect(wrapper.find(MaterializedViewSourceComponent).exists()).toBe(false);
     expect(wrapper.find(MaterializedViewTargetComponent).exists()).toBe(true);
   });
@@ -38,7 +39,7 @@ describe("MaterializedViewComponent", () => {
   it("renders neither component when both are missing", () => {
     testCollection.materializedViews(null);
     testCollection.materializedViewDefinition(null);
-    const wrapper = shallow(<MaterializedViewComponent collection={testCollection} />);
+    const wrapper = shallow(<MaterializedViewComponent collection={testCollection} explorer={testExplorer} />);
     expect(wrapper.find(MaterializedViewSourceComponent).exists()).toBe(false);
     expect(wrapper.find(MaterializedViewTargetComponent).exists()).toBe(false);
   });

--- a/src/Explorer/Controls/Settings/SettingsSubComponents/MaterializedViewSourceComponent.test.tsx
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/MaterializedViewSourceComponent.test.tsx
@@ -1,37 +1,34 @@
 import { PrimaryButton } from "@fluentui/react";
 import { shallow } from "enzyme";
 import React from "react";
-import { collection } from "../TestUtils";
-import {
-  MaterializedViewSourceComponent,
-  MaterializedViewSourceComponentProps,
-} from "./MaterializedViewSourceComponent";
+import { collection, container } from "../TestUtils";
+import { MaterializedViewSourceComponent } from "./MaterializedViewSourceComponent";
 
 describe("MaterializedViewSourceComponent", () => {
-  const baseProps: MaterializedViewSourceComponentProps = {
-    collection: {
-      ...collection,
-      materializedViews: jest.fn(() => collection.materializedViews()),
-    },
-  };
+  let testCollection: typeof collection;
+  let testExplorer: typeof container;
+
+  beforeEach(() => {
+    testCollection = { ...collection };
+  });
 
   it("renders without crashing", () => {
-    const wrapper = shallow(<MaterializedViewSourceComponent {...baseProps} />);
+    const wrapper = shallow(<MaterializedViewSourceComponent collection={testCollection} explorer={testExplorer} />);
     expect(wrapper.exists()).toBe(true);
   });
 
   it("renders the PrimaryButton", () => {
-    const wrapper = shallow(<MaterializedViewSourceComponent {...baseProps} />);
+    const wrapper = shallow(<MaterializedViewSourceComponent collection={testCollection} explorer={testExplorer} />);
     expect(wrapper.find(PrimaryButton).exists()).toBe(true);
   });
 
   it("updates when new materialized views are provided", () => {
-    const wrapper = shallow(<MaterializedViewSourceComponent {...baseProps} />);
+    const wrapper = shallow(<MaterializedViewSourceComponent collection={testCollection} explorer={testExplorer} />);
 
     // Simulating an update by modifying the observable directly
-    collection.materializedViews([{ id: "view3", _rid: "rid3" }]);
+    testCollection.materializedViews([{ id: "view3", _rid: "rid3" }]);
 
-    wrapper.setProps({ collection: { ...collection } });
+    wrapper.setProps({ collection: testCollection });
     wrapper.update();
 
     expect(wrapper.find(PrimaryButton).exists()).toBe(true);


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
