### PR TITLE
Adding container item refresh button back to upper right corner of page

### DIFF
--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -129,6 +129,7 @@ export const useDocumentsTabStyles = makeStyles({
     top: "6px",
     right: 0,
     float: "right",
+    backgroundColor: "white",
     zIndex: 1,
   },
   refreshBtn: {

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -2152,19 +2152,20 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
                     collection={_collection}
                     isColumnSelectionDisabled={isPreferredApiMongoDB}
                   />
-                </div> 
-                {!isPreferredApiMongoDB && tableContainerSizePx?.width >= calculateOffset(selectedColumnIds.length) + 200 && (
-                  <div
-                    title="Refresh"
-                    className={styles.refreshBtn}
-                    role="button"
-                    onClick={() => refreshDocumentsGrid(false)}
-                    aria-label="Refresh"
-                    tabIndex={0}
-                  >
-                    <img src={RefreshIcon} alt="Refresh" />
-                  </div>
-                )}
+                </div>
+                {!isPreferredApiMongoDB &&
+                  tableContainerSizePx?.width >= calculateOffset(selectedColumnIds.length) + 200 && (
+                    <div
+                      title="Refresh"
+                      className={styles.refreshBtn}
+                      role="button"
+                      onClick={() => refreshDocumentsGrid(false)}
+                      aria-label="Refresh"
+                      tabIndex={0}
+                    >
+                      <img src={RefreshIcon} alt="Refresh" />
+                    </div>
+                  )}
               </div>
               {tableItems.length > 0 && (
                 <a

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -55,6 +55,7 @@ import DeleteDocumentIcon from "../../../../images/DeleteDocument.svg";
 import NewDocumentIcon from "../../../../images/NewDocument.svg";
 import UploadIcon from "../../../../images/Upload_16x16.svg";
 import DiscardIcon from "../../../../images/discard.svg";
+import RefreshIcon from "../../../../images/refresh-cosmos.svg";
 import SaveIcon from "../../../../images/save-cosmos.svg";
 import * as Constants from "../../../Common/Constants";
 import * as HeadersUtility from "../../../Common/HeadersUtility";
@@ -128,8 +129,15 @@ export const useDocumentsTabStyles = makeStyles({
     top: "6px",
     right: 0,
     float: "right",
-    backgroundColor: "white",
     zIndex: 1,
+  },
+  refreshBtn: {
+    position: "absolute",
+    top: "3px",
+    right: "4px",
+    float: "right",
+    zIndex: 1,
+    backgroundColor: "transparent",
   },
   deleteProgressContent: {
     paddingTop: tokens.spacingVerticalL,
@@ -2145,6 +2153,18 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
                   />
                 </div>
               </div>
+              {!isPreferredApiMongoDB && (
+                <a
+                  title="Refresh"
+                  className={styles.refreshBtn}
+                  role="button"
+                  onClick={() => refreshDocumentsGrid(false)}
+                  aria-label="Refresh"
+                  tabIndex={0}
+                >
+                  <img src={RefreshIcon} alt="Refresh" />
+                </a>
+              )}
               {tableItems.length > 0 && (
                 <a
                   className={styles.loadMore}

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -2152,20 +2152,20 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
                     collection={_collection}
                     isColumnSelectionDisabled={isPreferredApiMongoDB}
                   />
-                </div>
+                </div> 
+                {!isPreferredApiMongoDB && tableContainerSizePx?.width >= calculateOffset(selectedColumnIds.length) + 200 && (
+                  <div
+                    title="Refresh"
+                    className={styles.refreshBtn}
+                    role="button"
+                    onClick={() => refreshDocumentsGrid(false)}
+                    aria-label="Refresh"
+                    tabIndex={0}
+                  >
+                    <img src={RefreshIcon} alt="Refresh" />
+                  </div>
+                )}
               </div>
-              {!isPreferredApiMongoDB && (
-                <a
-                  title="Refresh"
-                  className={styles.refreshBtn}
-                  role="button"
-                  onClick={() => refreshDocumentsGrid(false)}
-                  aria-label="Refresh"
-                  tabIndex={0}
-                >
-                  <img src={RefreshIcon} alt="Refresh" />
-                </a>
-              )}
               {tableItems.length > 0 && (
                 <a
                   className={styles.loadMore}

--- a/src/Explorer/Tabs/DocumentsTabV2/__snapshots__/DocumentsTabV2.test.tsx.snap
+++ b/src/Explorer/Tabs/DocumentsTabV2/__snapshots__/DocumentsTabV2.test.tsx.snap
@@ -120,19 +120,6 @@ exports[`Documents tab (noSql API) when rendered should render the page 1`] = `
               />
             </div>
           </div>
-          <a
-            aria-label="Refresh"
-            className="___v9fv2r0_0000000 f1euv43f fudbr5a fiv86kb f150nix6 f19g0ac f3rmtva"
-            onClick={[Function]}
-            role="button"
-            tabIndex={0}
-            title="Refresh"
-          >
-            <img
-              alt="Refresh"
-              src={{}}
-            />
-          </a>
         </div>
       </Allotment.Pane>
       <Allotment.Pane

--- a/src/Explorer/Tabs/DocumentsTabV2/__snapshots__/DocumentsTabV2.test.tsx.snap
+++ b/src/Explorer/Tabs/DocumentsTabV2/__snapshots__/DocumentsTabV2.test.tsx.snap
@@ -120,6 +120,19 @@ exports[`Documents tab (noSql API) when rendered should render the page 1`] = `
               />
             </div>
           </div>
+          <a
+            aria-label="Refresh"
+            className="___v9fv2r0_0000000 f1euv43f fudbr5a fiv86kb f150nix6 f19g0ac f3rmtva"
+            onClick={[Function]}
+            role="button"
+            tabIndex={0}
+            title="Refresh"
+          >
+            <img
+              alt="Refresh"
+              src={{}}
+            />
+          </a>
         </div>
       </Allotment.Pane>
       <Allotment.Pane


### PR DESCRIPTION
Users want the container item "Refresh" button added back to outside the ellipses so it's easier to find and click.

We are keeping the "Refresh" button within the ellipses.

[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2083?feature.someFeatureFlagYouMightNeed=true)
