### PR TITLE
Add refresh button to Mongo DB RU and adjust ellipsis so refresh button on single column container doesn't hide it

### DIFF
--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -2158,8 +2158,7 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
                     isColumnSelectionDisabled={isPreferredApiMongoDB}
                   />
                 </div>
-                {!isPreferredApiMongoDB &&
-                  tableContainerSizePx?.width >= calculateOffset(selectedColumnIds.length) + 200 && (
+                {tableContainerSizePx?.width >= calculateOffset(selectedColumnIds.length) + 200 && (
                     <div
                       title="Refresh"
                       className={styles.refreshBtn}

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -2159,17 +2159,17 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
                   />
                 </div>
                 {tableContainerSizePx?.width >= calculateOffset(selectedColumnIds.length) + 200 && (
-                    <div
-                      title="Refresh"
-                      className={styles.refreshBtn}
-                      role="button"
-                      onClick={() => refreshDocumentsGrid(false)}
-                      aria-label="Refresh"
-                      tabIndex={0}
-                    >
-                      <img src={RefreshIcon} alt="Refresh" />
-                    </div>
-                  )}
+                  <div
+                    title="Refresh"
+                    className={styles.refreshBtn}
+                    role="button"
+                    onClick={() => refreshDocumentsGrid(false)}
+                    aria-label="Refresh"
+                    tabIndex={0}
+                  >
+                    <img src={RefreshIcon} alt="Refresh" />
+                  </div>
+                )}
               </div>
               {tableItems.length > 0 && (
                 <a

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTableComponent.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTableComponent.tsx
@@ -233,7 +233,7 @@ export const DocumentsTableComponent: React.FC<IDocumentsTableComponentProps> = 
                     aria-label="Select column"
                     size="small"
                     icon={<MoreHorizontalRegular />}
-                    style={{ position: "absolute", right: 0, backgroundColor: tokens.colorNeutralBackground1 }}
+                    style={{ position: "absolute", right: 12, backgroundColor: tokens.colorNeutralBackground1 }}
                   />
                 </MenuTrigger>
                 <MenuPopover>

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTableComponent.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTableComponent.tsx
@@ -233,7 +233,7 @@ export const DocumentsTableComponent: React.FC<IDocumentsTableComponentProps> = 
                     aria-label="Select column"
                     size="small"
                     icon={<MoreHorizontalRegular />}
-                    style={{ position: "absolute", right: 12, backgroundColor: tokens.colorNeutralBackground1 }}
+                    style={{ position: "absolute", right: 10, backgroundColor: tokens.colorNeutralBackground1 }}
                   />
                 </MenuTrigger>
                 <MenuPopover>


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2089?feature.someFeatureFlagYouMightNeed=true)

- Added the refresh button to Mongo DB
- Shifted the ellipsis so the refresh button doesn't hide it when only a single column exists

![image](https://github.com/user-attachments/assets/29fa4b64-1cd3-414b-991b-8194cc2bc8d4)
![image](https://github.com/user-attachments/assets/5d3f6689-4ce0-47b5-a9e6-6d9db41a60f5)

vs.

1 column
![image](https://github.com/user-attachments/assets/7818afae-7b4a-4686-b334-7912b86f2ecb)

