### PR TITLE
Update cleanupDBs.js to skip certain database accounts in test subscription

### DIFF
--- a/utils/cleanupDBs.js
+++ b/utils/cleanupDBs.js
@@ -20,6 +20,10 @@ async function main() {
   const client = new CosmosDBManagementClient(credentials, subscriptionId);
   const accounts = await client.databaseAccounts.list(resourceGroupName);
   for (const account of accounts) {
+    if (account.name.endsWith("-readonly")) {
+      console.log(`SKIPPED: ${account.name}`);
+      continue;
+    }
     if (account.kind === "MongoDB") {
       const mongoDatabases = await client.mongoDBResources.listMongoDBDatabases(resourceGroupName, account.name);
       for (const database of mongoDatabases) {


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Update cleanupDBs.js to skip certain database accounts in test subscription.
Currently set to account swith -readonly prefix
