### PR TITLE
Pk missing fix

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig, devices } from "@playwright/test";
-
 /**
  * See https://playwright.dev/docs/test-configuration.
  */

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -1028,6 +1028,7 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
     );
 
     const selectedDocumentId = documentIds[clickedRowIndex as number];
+    const originalPartitionKeyValue = selectedDocumentId.partitionKeyValue;
     selectedDocumentId.partitionKeyValue = partitionKeyValueArray;
 
     onExecutionErrorChange(false);
@@ -1063,6 +1064,10 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
           setColumnDefinitionsFromDocument(documentContent);
         },
         (error) => {
+          // in case of any kind of failures of accidently changing partition key, restore the original
+          // so that when user navigates away from current document and comes back,
+          // it doesnt fail to load due to using the invalid partition keys
+          selectedDocumentId.partitionKeyValue = originalPartitionKeyValue;
           onExecutionErrorChange(true);
           const errorMessage = getErrorMessage(error);
           useDialog.getState().showOkModalDialog("Update document failed", errorMessage);

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -2079,8 +2079,8 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
 
   return (
     <CosmosFluentProvider className={styles.container}>
-      <div className="tab-pane active" role="tabpanel" style={{ display: "flex" }}>
-        <div className={styles.filterRow}>
+      <div data-test={"DocumentsTab"} className="tab-pane active" role="tabpanel" style={{ display: "flex" }}>
+        <div data-test={"DocumentsTab/Filter"} className={styles.filterRow}>
           {!isPreferredApiMongoDB && <span> SELECT * FROM c </span>}
           <InputDataList
             dropdownOptions={getFilterChoices()}
@@ -2122,7 +2122,11 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
           }}
         >
           <Allotment.Pane preferredSize={`${tabStateData.leftPaneWidthPercent}%`} minSize={55}>
-            <div style={{ height: "100%", width: "100%", overflow: "hidden" }} ref={tableContainerRef}>
+            <div
+              data-test={"DocumentsTab/DocumentsPane"}
+              style={{ height: "100%", width: "100%", overflow: "hidden" }}
+              ref={tableContainerRef}
+            >
               <div className={styles.tableContainer}>
                 <div
                   style={
@@ -2164,7 +2168,7 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
             </div>
           </Allotment.Pane>
           <Allotment.Pane minSize={30}>
-            <div style={{ height: "100%", width: "100%" }}>
+            <div data-test={"DocumentsTab/ResultsPane"} style={{ height: "100%", width: "100%" }}>
               {isTabActive && selectedDocumentContent && selectedRows.size <= 1 && (
                 <EditorReact
                   language={"json"}

--- a/src/Explorer/Tabs/DocumentsTabV2/__snapshots__/DocumentsTabV2.test.tsx.snap
+++ b/src/Explorer/Tabs/DocumentsTabV2/__snapshots__/DocumentsTabV2.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Documents tab (noSql API) when rendered should render the page 1`] = `
 >
   <div
     className="tab-pane active"
+    data-test="DocumentsTab"
     role="tabpanel"
     style={
       {
@@ -15,6 +16,7 @@ exports[`Documents tab (noSql API) when rendered should render the page 1`] = `
   >
     <div
       className="___11ktxfv_0000000 f1o614cb fy9rknc f22iagw fsnqrgy f1f5gg8d fjodcmx f122n59 f1f09k3d fg706s2 frpde29"
+      data-test="DocumentsTab/Filter"
     >
       <span>
          SELECT * FROM c 
@@ -65,6 +67,7 @@ exports[`Documents tab (noSql API) when rendered should render the page 1`] = `
         preferredSize="35%"
       >
         <div
+          data-test="DocumentsTab/DocumentsPane"
           style={
             {
               "height": "100%",
@@ -126,6 +129,7 @@ exports[`Documents tab (noSql API) when rendered should render the page 1`] = `
         minSize={30}
       >
         <div
+          data-test="DocumentsTab/ResultsPane"
           style={
             {
               "height": "100%",

--- a/src/Utils/QueryUtils.ts
+++ b/src/Utils/QueryUtils.ts
@@ -47,6 +47,7 @@ export function buildDocumentsQueryPartitionProjections(
   for (const index in partitionKey.paths) {
     // TODO: Handle "/" in partition key definitions
     const projectedProperties: string[] = partitionKey.paths[index].split("/").slice(1);
+    const isSystemPartitionKey: boolean = partitionKey.systemKey || false;
     let projectedProperty = "";
 
     projectedProperties.forEach((property: string) => {
@@ -62,8 +63,12 @@ export function buildDocumentsQueryPartitionProjections(
       }
     });
     const fullAccess = `${collectionAlias}${projectedProperty}`;
-    const wrappedProjection = `IIF(IS_DEFINED(${fullAccess}), ${fullAccess}, {})`;
-    projections.push(wrappedProjection);
+    if (!isSystemPartitionKey) {
+      const wrappedProjection = `IIF(IS_DEFINED(${fullAccess}), ${fullAccess}, {})`;
+      projections.push(wrappedProjection);
+    } else {
+      projections.push(fullAccess);
+    }
   }
 
   return projections.join(",");

--- a/src/Utils/QueryUtils.ts
+++ b/src/Utils/QueryUtils.ts
@@ -61,8 +61,9 @@ export function buildDocumentsQueryPartitionProjections(
         projectedProperty += `[${projection}]`;
       }
     });
-
-    projections.push(`${collectionAlias}${projectedProperty}`);
+    const fullAccess = `${collectionAlias}${projectedProperty}`;
+    const wrappedProjection = `IIF(IS_DEFINED(${fullAccess}), ${fullAccess}, {})`;
+    projections.push(wrappedProjection);
   }
 
   return projections.join(",");
@@ -130,6 +131,8 @@ export const extractPartitionKeyValues = (
 
     if (value !== undefined) {
       partitionKeyValues.push(value);
+    } else {
+      partitionKeyValues.push({});
     }
   });
 

--- a/src/Utils/QueryUtils.ts
+++ b/src/Utils/QueryUtils.ts
@@ -124,7 +124,7 @@ export const extractPartitionKeyValues = (
   documentContent: any,
   partitionKeyDefinition: PartitionKeyDefinition,
 ): PartitionKey[] => {
-  if (!partitionKeyDefinition.paths || partitionKeyDefinition.paths.length === 0) {
+  if (!partitionKeyDefinition.paths || partitionKeyDefinition.paths.length === 0 || partitionKeyDefinition.systemKey) {
     return undefined;
   }
 

--- a/test/fx.ts
+++ b/test/fx.ts
@@ -26,7 +26,7 @@ export function getAzureCLICredentials(): AzureCliCredential {
 
 export async function getAzureCLICredentialsToken(): Promise<string> {
   const credentials = getAzureCLICredentials();
-  const token = (await credentials.getToken("https://management.core.windows.net//.default")).token;
+  const token = (await credentials.getToken("https://management.core.windows.net//.default"))?.token || "";
   return token;
 }
 
@@ -37,6 +37,7 @@ export enum TestAccount {
   Mongo = "Mongo",
   Mongo32 = "Mongo32",
   SQL = "SQL",
+  SQLReadOnly = "SQLReadOnly",
 }
 
 export const defaultAccounts: Record<TestAccount, string> = {
@@ -46,6 +47,7 @@ export const defaultAccounts: Record<TestAccount, string> = {
   [TestAccount.Mongo]: "github-e2etests-mongo",
   [TestAccount.Mongo32]: "github-e2etests-mongo32",
   [TestAccount.SQL]: "github-e2etests-sql",
+  [TestAccount.SQLReadOnly]: "github-e2etests-sql-readonly",
 };
 
 export const resourceGroupName = process.env.DE_TEST_RESOURCE_GROUP ?? "de-e2e-tests";
@@ -214,6 +216,25 @@ export class QueryTab {
   }
 }
 
+export class DocumentsTab {
+  documentsFilter: Locator;
+  documentsListPane: Locator;
+  documentResultsPane: Locator;
+  resultsEditor: Editor;
+
+  constructor(
+    public frame: Frame,
+    public tabId: string,
+    public tab: Locator,
+    public locator: Locator,
+  ) {
+    this.documentsFilter = this.locator.getByTestId("DocumentsTab/Filter");
+    this.documentsListPane = this.locator.getByTestId("DocumentsTab/DocumentsPane");
+    this.documentResultsPane = this.locator.getByTestId("DocumentsTab/ResultsPane");
+    this.resultsEditor = new Editor(this.frame, this.documentResultsPane.getByTestId("EditorReact/Host/Loaded"));
+  }
+}
+
 type PanelOpenOptions = {
   closeTimeout?: number;
 };
@@ -230,6 +251,12 @@ export class DataExplorer {
     const tab = this.tab(tabId);
     const queryTab = tab.getByTestId("QueryTab");
     return new QueryTab(this.frame, tabId, tab, queryTab);
+  }
+
+  documentsTab(tabId: string): DocumentsTab {
+    const tab = this.tab(tabId);
+    const documentsTab = tab.getByTestId("DocumentsTab");
+    return new DocumentsTab(this.frame, tabId, tab, documentsTab);
   }
 
   /** Select the primary global command button.
@@ -292,6 +319,10 @@ export class DataExplorer {
     await databaseNode.expand();
 
     return await this.waitForNode(`${databaseId}/${containerId}`);
+  }
+
+  async waitForContainerItemsNode(databaseId: string, containerId: string): Promise<TreeNode> {
+    return await this.waitForNode(`${databaseId}/${containerId}/Items`);
   }
 
   /** Select the tree node with the specified id */

--- a/test/sql/document.spec.ts
+++ b/test/sql/document.spec.ts
@@ -26,14 +26,12 @@ for (const { name, databaseId, containerId, expectedDocumentIds } of documentTes
 
     for (const docId of expectedDocumentIds) {
       test.describe(`Document ID: ${docId}`, () => {
-        test(`should load and view document ${docId}`, async ({ page }) => {
+        test(`should load and view document ${docId}`, async () => {
           const span = documentsTab.documentsListPane.getByText(docId, { exact: true }).nth(0);
           await span.waitFor();
           await expect(span).toBeVisible();
-          // await page.waitForTimeout(3000);
 
           await span.click();
-          // await page.waitForTimeout(5000);
           await expect(documentsTab.resultsEditor.locator).toBeAttached({ timeout: 60 * 1000 });
 
           const resultText = await documentsTab.resultsEditor.text();

--- a/test/sql/document.spec.ts
+++ b/test/sql/document.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+
+import { DataExplorer, DocumentsTab, TestAccount } from "../fx";
+import { documentTestCases } from "./testCases";
+
+let explorer: DataExplorer = null!;
+let documentsTab: DocumentsTab = null!;
+
+for (const { name, databaseId, containerId, expectedDocumentIds } of documentTestCases) {
+  test.describe(`Test Documents with ${name}`, () => {
+    test.beforeEach("Open documents tab", async ({ page }) => {
+      explorer = await DataExplorer.open(page, TestAccount.SQLReadOnly);
+
+      const containerNode = await explorer.waitForContainerNode(databaseId, containerId);
+      await containerNode.expand();
+
+      const containerMenuNode = await explorer.waitForContainerItemsNode(databaseId, containerId);
+      await containerMenuNode.element.click();
+
+      documentsTab = explorer.documentsTab("tab0");
+
+      await documentsTab.documentsFilter.waitFor();
+      await documentsTab.documentsListPane.waitFor();
+      await expect(documentsTab.resultsEditor.locator).toBeAttached({ timeout: 60 * 1000 });
+    });
+
+    for (const docId of expectedDocumentIds) {
+      test.describe(`Document ID: ${docId}`, () => {
+        test(`should load and view document ${docId}`, async ({ page }) => {
+          const span = documentsTab.documentsListPane.getByText(docId, { exact: true }).nth(0);
+          await span.waitFor();
+          await expect(span).toBeVisible();
+          // await page.waitForTimeout(3000);
+
+          await span.click();
+          // await page.waitForTimeout(5000);
+          await expect(documentsTab.resultsEditor.locator).toBeAttached({ timeout: 60 * 1000 });
+
+          const resultText = await documentsTab.resultsEditor.text();
+          const resultData = JSON.parse(resultText!);
+          expect(resultText).not.toBeNull();
+          expect(resultData?.id).toEqual(docId);
+        });
+      });
+    }
+  });
+}

--- a/test/sql/testCases.ts
+++ b/test/sql/testCases.ts
@@ -1,0 +1,88 @@
+type ContainerTestCase = {
+  name: string;
+  databaseId: string;
+  containerId: string;
+  expectedDocumentIds: string[];
+};
+
+export const documentTestCases: ContainerTestCase[] = [
+  {
+    name: "System Partition Key",
+    databaseId: "e2etests-sql-readonly",
+    containerId: "systemPartitionKey",
+    expectedDocumentIds: ["systempartition"],
+  },
+  {
+    name: "Single Partition Key",
+    databaseId: "e2etests-sql-readonly",
+    containerId: "singlePartitionKey",
+    expectedDocumentIds: [
+      "singlePartitionKey",
+      "singlePartitionKey_empty_string",
+      "singlePartitionKey_null",
+      "singlePartitionKey_missing",
+    ],
+  },
+  {
+    name: "Single Nested Partition Key",
+    databaseId: "e2etests-sql-readonly",
+    containerId: "singleNestedPartitionKey",
+    expectedDocumentIds: [
+      "singlePartitionKey_nested",
+      "singlePartitionKey_nested_empty_string",
+      "singlePartitionKey_nested_null",
+      "singlePartitionKey_nested_missing",
+    ],
+  },
+  {
+    name: "2-Level Hierarchical Partition Key",
+    databaseId: "e2etests-sql-readonly",
+    containerId: "twoLevelPartitionKey",
+    expectedDocumentIds: [
+      "twoLevelPartitionKey_value_empty",
+      "twoLevelPartitionKey_value_null",
+      "twoLevelPartitionKey_value_missing",
+      "twoLevelPartitionKey_empty_null",
+      "twoLevelPartitionKey_null_missing",
+      "twoLevelPartitionKey_missing_value",
+    ],
+  },
+  {
+    name: "2-Level Hierarchical Nested Partition Key",
+    databaseId: "e2etests-sql-readonly",
+    containerId: "twoLevelNestedPartitionKey",
+    expectedDocumentIds: [
+      "twoLevelNestedPartitionKey_nested_value_empty",
+      "twoLevelNestedPartitionKey_nested_null_missing",
+      "twoLevelNestedPartitionKey_nested_missing_value",
+    ],
+  },
+  {
+    name: "3-Level Hierarchical Partition Key",
+    databaseId: "e2etests-sql-readonly",
+    containerId: "threeLevelPartitionKey",
+    expectedDocumentIds: [
+      "threeLevelPartitionKey_value_empty_null",
+      "threeLevelPartitionKey_value_null_missing",
+      "threeLevelPartitionKey_value_missing_null",
+      "threeLevelPartitionKey_null_empty_value",
+      "threeLevelPartitionKey_missing_value_value",
+      "threeLevelPartitionKey_empty_value_missing",
+    ],
+  },
+  {
+    name: "3-Level Nested Hierarchical Partition Key",
+    databaseId: "e2etests-sql-readonly",
+    containerId: "threeLevelNestedPartitionKey",
+    expectedDocumentIds: [
+      "threeLevelNestedPartitionKey_nested_empty_value_null",
+      "threeLevelNestedPartitionKey_nested_null_value_missing",
+      "threeLevelNestedPartitionKey_nested_missing_value_null",
+      "threeLevelNestedPartitionKey_nested_null_empty_missing",
+      "threeLevelNestedPartitionKey_nested_value_missing_empty",
+      "threeLevelNestedPartitionKey_nested_missing_null_empty",
+      "threeLevelNestedPartitionKey_nested_empty_null_value",
+      "threeLevelNestedPartitionKey_nested_value_null_empty",
+    ],
+  },
+];


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2094?feature.someFeatureFlagYouMightNeed=true)

- This is to address the issue where the partition key was missing, causing the document to fail to load.
Previously we have made changes for paritition key null or "" cases, however when the partition key is entirely missing, which CosmosDB allows, passing in subset of the existing partitionkeys to the SDK will fail to load the document,
So adding the logic to always pull all partitionkeys in paths and always pass all partitionkeys in paths to the SDK as {} if missing.

- If system partition key, the SDK will not support passing the system partition key value, so skipping the system partition key.

- E2E tests are written for testing different collections with different partition keys
  - listing the documents in DE
  - viewing a specific document in DE


