### PR TITLE
Fabric native support: implement refreshResourceTree message and hide refresh button above resource tree

### DIFF
--- a/src/Contracts/FabricMessagesContract.ts
+++ b/src/Contracts/FabricMessagesContract.ts
@@ -81,6 +81,13 @@ export type FabricMessageV3 =
         error: string | undefined;
         data: { accessToken: string };
       };
+    }
+  | {
+      type: "refreshResourceTree";
+      message: {
+        id: string;
+        error: string | undefined;
+      };
     };
 
 export enum CosmosDbArtifactType {

--- a/src/Explorer/Sidebar.tsx
+++ b/src/Explorer/Sidebar.tsx
@@ -315,16 +315,18 @@ export const SidebarContainer: React.FC<SidebarProps> = ({ explorer }) => {
                   <>
                     <div className={styles.floatingControlsContainer}>
                       <div className={styles.floatingControls}>
-                        <button
-                          type="button"
-                          data-test="Sidebar/RefreshButton"
-                          className={styles.floatingControlButton}
-                          disabled={loading}
-                          title="Refresh"
-                          onClick={onRefreshClick}
-                        >
-                          <ArrowSync12Regular />
-                        </button>
+                        {!isFabricNative() && (
+                          <button
+                            type="button"
+                            data-test="Sidebar/RefreshButton"
+                            className={styles.floatingControlButton}
+                            disabled={loading}
+                            title="Refresh"
+                            onClick={onRefreshClick}
+                          >
+                            <ArrowSync12Regular />
+                          </button>
+                        )}
                         <button
                           type="button"
                           className={styles.floatingControlButton}

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -215,6 +215,10 @@ async function configureFabric(): Promise<Explorer> {
             }
             break;
           }
+          case "refreshResourceTree": {
+            explorer.onRefreshResourcesClick();
+            break;
+          }
           default:
             console.error(`Unknown Fabric message type: ${JSON.stringify(data)}`);
             break;


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

In Fabric native, the refresh button is in the ribbon (below the "Home" tab label).
This makes the small circular refresh button redundant, so we hide this button only for Fabric native.
<img width="430" alt="image" src="https://github.com/user-attachments/assets/3591fd92-de45-4a95-96fa-f7f37c54d5d9" />
