### PR TITLE
Update cleanup schedule from once per day to every six hours.

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -6,8 +6,8 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   schedule:
-    # Once every hour
-    - cron: "0 15 * * *"
+    # Once every six hours
+    - cron: "0 */6 * * *"
 
 permissions:
   id-token: write


### PR DESCRIPTION
This change updates the scheduling of the E2E database cleanup task from once per day to every 6 hours. We need to be more aggressive as buildup of databases is causing E2E tests to fail when we hit account limitations.




