### PR TITLE
Fix Fabric Native ReadOnly mode

### DIFF
--- a/src/Explorer/Sidebar.tsx
+++ b/src/Explorer/Sidebar.tsx
@@ -27,7 +27,7 @@ import { CosmosFluentProvider, cosmosShorthands, tokens } from "Explorer/Theme/T
 import { ResourceTree } from "Explorer/Tree/ResourceTree";
 import { useDatabases } from "Explorer/useDatabases";
 import { KeyboardAction, KeyboardActionGroup, KeyboardActionHandler, useKeyboardActionGroup } from "KeyboardShortcuts";
-import { isFabric, isFabricMirrored, isFabricNative } from "Platform/Fabric/FabricUtil";
+import { isFabric, isFabricMirrored, isFabricNative, isFabricNativeReadOnly } from "Platform/Fabric/FabricUtil";
 import { userContext } from "UserContext";
 import { getCollectionName, getDatabaseName } from "Utils/APITypeUtils";
 import { Allotment, AllotmentHandle } from "allotment";
@@ -318,6 +318,7 @@ export const SidebarContainer: React.FC<SidebarProps> = ({ explorer }) => {
 
   const hasGlobalCommands = !(
     isFabricMirrored() ||
+    isFabricNativeReadOnly() ||
     userContext.apiType === "Postgres" ||
     userContext.apiType === "VCoreMongo"
   );

--- a/src/Explorer/SplashScreen/FabricHome.tsx
+++ b/src/Explorer/SplashScreen/FabricHome.tsx
@@ -5,7 +5,7 @@ import { Link, makeStyles, tokens } from "@fluentui/react-components";
 import { DocumentAddRegular, LinkMultipleRegular } from "@fluentui/react-icons";
 import { SampleDataImportDialog } from "Explorer/SplashScreen/SampleDataImportDialog";
 import { CosmosFluentProvider } from "Explorer/Theme/ThemeUtil";
-import { isFabricNative } from "Platform/Fabric/FabricUtil";
+import { isFabricNative, isFabricNativeReadOnly } from "Platform/Fabric/FabricUtil";
 import * as React from "react";
 import { userContext } from "UserContext";
 import CosmosDbBlackIcon from "../../../images/CosmosDB_black.svg";
@@ -59,6 +59,15 @@ const useStyles = makeStyles({
     "& svg": {
       width: "32px",
       height: "32px",
+      margin: "auto",
+    },
+  },
+  single: {
+    gridColumn: "1 / 4",
+    gridRow: "1 / 3",
+    "& svg": {
+      width: "64px",
+      height: "64px",
       margin: "auto",
     },
   },
@@ -150,7 +159,11 @@ export const FabricHomeScreen: React.FC<SplashScreenProps> = (props: SplashScree
       },
     ];
 
-    return (
+    return isFabricNativeReadOnly() ? (
+      <div className={styles.buttonsContainer}>
+        <FabricHomeScreenButton className={styles.single} {...buttons[2]} />
+      </div>
+    ) : (
       <div className={styles.buttonsContainer}>
         <FabricHomeScreenButton className={styles.one} {...buttons[0]} />
         <FabricHomeScreenButton className={styles.two} {...buttons[1]} />
@@ -159,7 +172,7 @@ export const FabricHomeScreen: React.FC<SplashScreenProps> = (props: SplashScree
     );
   };
 
-  const title = "Build your database";
+  const title = isFabricNativeReadOnly() ? "Use your database" : "Build your database";
   return (
     <>
       <CosmosFluentProvider className={styles.homeContainer}>

--- a/src/Explorer/Tree/treeNodeUtil.tsx
+++ b/src/Explorer/Tree/treeNodeUtil.tsx
@@ -6,7 +6,7 @@ import StoredProcedure from "Explorer/Tree/StoredProcedure";
 import Trigger from "Explorer/Tree/Trigger";
 import UserDefinedFunction from "Explorer/Tree/UserDefinedFunction";
 import { useDatabases } from "Explorer/useDatabases";
-import { isFabric, isFabricMirrored, isFabricNative } from "Platform/Fabric/FabricUtil";
+import { isFabric, isFabricMirrored, isFabricNative, isFabricNativeReadOnly } from "Platform/Fabric/FabricUtil";
 import { getItemName } from "Utils/APITypeUtils";
 import { isServerlessAccount } from "Utils/CapabilityUtils";
 import { useTabs } from "hooks/useTabs";
@@ -292,7 +292,7 @@ const buildCollectionNodeChildren = (
     contextMenu: ResourceTreeContextMenuButtonFactory.createCollectionContextMenuButton(container, collection),
   });
 
-  if (userContext.apiType !== "Cassandra" || !isServerlessAccount()) {
+  if ((userContext.apiType !== "Cassandra" || !isServerlessAccount()) && !isFabricNativeReadOnly()) {
     let id = "";
     if (collection.isSampleCollection) {
       id = database.isDatabaseShared() ? "sampleSettings" : "sampleScaleSettings";

--- a/src/Platform/Fabric/FabricUtil.ts
+++ b/src/Platform/Fabric/FabricUtil.ts
@@ -136,3 +136,4 @@ export const isFabricMirroredAAD = (): boolean =>
 export const isFabricMirrored = (): boolean => isFabricMirroredKey() || isFabricMirroredAAD();
 export const isFabricNative = (): boolean =>
   isFabric() && userContext.fabricContext?.artifactType === CosmosDbArtifactType.NATIVE;
+export const isFabricNativeReadOnly = (): boolean => isFabricNative() && userContext.fabricContext?.isReadOnly;

--- a/src/Platform/Fabric/FabricUtil.ts
+++ b/src/Platform/Fabric/FabricUtil.ts
@@ -136,4 +136,4 @@ export const isFabricMirroredAAD = (): boolean =>
 export const isFabricMirrored = (): boolean => isFabricMirroredKey() || isFabricMirroredAAD();
 export const isFabricNative = (): boolean =>
   isFabric() && userContext.fabricContext?.artifactType === CosmosDbArtifactType.NATIVE;
-export const isFabricNativeReadOnly = (): boolean => isFabricNative() && userContext.fabricContext?.isReadOnly;
+export const isFabricNativeReadOnly = (): boolean => isFabricNative() && !!userContext.fabricContext?.isReadOnly;


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2123)

Fabric native can be read-only if the user is shared an existing artifact as Viewer. The read-only flag is passed during initialization to data explorer and stored in the fabric user context.

* Fix resource tree css issue
* Fix Fabric home page (remove Sample Data and Create container buttons)
* Remove Settings item in container tree

![image](https://github.com/user-attachments/assets/9d5f6bb5-d2a6-4785-814e-edad5c338742)


