### PR TITLE
fix: Correct documentId method call in error logging for deletion failures

### DIFF
--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -729,7 +729,7 @@ export const DocumentsTabComponent: React.FunctionComponent<IDocumentsTabCompone
             } else if (result.statusCode >= 400) {
               newFailed.push(result.documentId);
               logConsoleError(
-                `Failed to delete document ${result.documentId.id} with status code ${result.statusCode}`,
+                `Failed to delete document ${result.documentId.id()} with status code ${result.statusCode}`,
               );
             }
           });


### PR DESCRIPTION
[ADO](https://msdata.visualstudio.com/CosmosDB/_workitems/edit/4123680)

[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2132?feature.someFeatureFlagYouMightNeed=true)
