### PR TITLE
get the user defined system key value for updating

### DIFF
--- a/src/Utils/QueryUtils.ts
+++ b/src/Utils/QueryUtils.ts
@@ -124,7 +124,7 @@ export const extractPartitionKeyValues = (
   documentContent: any,
   partitionKeyDefinition: PartitionKeyDefinition,
 ): PartitionKey[] => {
-  if (!partitionKeyDefinition.paths || partitionKeyDefinition.paths.length === 0 || partitionKeyDefinition.systemKey) {
+  if (!partitionKeyDefinition.paths || partitionKeyDefinition.paths.length === 0) {
     return undefined;
   }
 

--- a/src/Utils/QueryUtils.ts
+++ b/src/Utils/QueryUtils.ts
@@ -136,7 +136,7 @@ export const extractPartitionKeyValues = (
 
     if (value !== undefined) {
       partitionKeyValues.push(value);
-    } else {
+    } else if (!partitionKeyDefinition.systemKey) {
       partitionKeyValues.push({});
     }
   });


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2134?feature.someFeatureFlagYouMightNeed=true)

This is to handle the scenario of user-defined system partition key
- for update doc, will need to pass the user-defined key
- for updating doc with non-user-defined system key, we have to omit from the partitionkey header but in all other cases, we will need to provide a default value "{}"
