### PR TITLE
Default New Global Secondary Index Panel to be sharded

### DIFF
--- a/src/Explorer/Panes/AddGlobalSecondaryIndexPanel/AddGlobalSecondaryIndexPanel.tsx
+++ b/src/Explorer/Panes/AddGlobalSecondaryIndexPanel/AddGlobalSecondaryIndexPanel.tsx
@@ -175,11 +175,6 @@ export const AddGlobalSecondaryIndexPanel = (props: AddGlobalSecondaryIndexPanel
       return false;
     }
 
-    if (globalSecondaryIndexThroughput > CollectionCreation.MaxRUPerPartition) {
-      setErrorMessage("Unsharded collections support up to 10,000 RUs");
-      return false;
-    }
-
     if (showVectorSearchParameters()) {
       if (!vectorPolicyValidated) {
         setErrorMessage("Please fix errors in container vector policy");

--- a/src/Explorer/Panes/AddGlobalSecondaryIndexPanel/Components/ThroughputComponent.tsx
+++ b/src/Explorer/Panes/AddGlobalSecondaryIndexPanel/Components/ThroughputComponent.tsx
@@ -47,7 +47,7 @@ export const ThroughputComponent = (props: ThroughputComponentProps): JSX.Elemen
         <ThroughputInput
           showFreeTierExceedThroughputTooltip={isFreeTierAccount() && !useDatabases.getState().isFirstResourceCreated()}
           isDatabase={false}
-          isSharded={false}
+          isSharded={true}
           isFreeTier={isFreeTierAccount()}
           isQuickstart={false}
           isGlobalSecondaryIndex={true}


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2138)

When adding Global Secondary Index and setting a throughput of > 10k RU/s, the following error appears: 
![image](https://github.com/user-attachments/assets/c5c6acd6-a1e9-41d2-84a5-3a06ad142e41)


This change is to remove this error for SQL accounts default to `sharded ` in Data Explorer.
