### PR TITLE
Incorrect cost estimation for Manual Throughput

### DIFF
--- a/src/Explorer/Controls/Settings/SettingsSubComponents/ThroughputInputComponents/ThroughputInputAutoPilotV3Component.tsx
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/ThroughputInputComponents/ThroughputInputAutoPilotV3Component.tsx
@@ -285,7 +285,7 @@ export class ThroughputInputAutoPilotV3Component extends React.Component<
         serverId,
         numberOfRegions,
         isMultimaster,
-        true,
+        false,
       );
       return (
         <div>


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2141?feature.someFeatureFlagYouMightNeed=true)

Updating the number of RUs in manual mode, used to estimate incorrect cost
Reason: we were applying cost for Autoscale by marking false in the manual update function

PRODUCTION
![image](https://github.com/user-attachments/assets/e3df6478-29b0-449b-8069-f15f79ddf28f)

FIXED
![AFTER](https://github.com/user-attachments/assets/356819d1-e0d8-4314-aa54-0c85b7db3407)


