### PR TITLE
Hide throughput bucket settings conditionally

### DIFF
--- a/src/Explorer/Controls/Settings/SettingsComponent.tsx
+++ b/src/Explorer/Controls/Settings/SettingsComponent.tsx
@@ -1071,11 +1071,11 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
         databaseId: this.collection.databaseId,
         collectionId: this.collection.id(),
         currentOffer: this.collection.offer(),
-        autopilotThroughput: this.collection.offer().autoscaleMaxThroughput
-          ? this.collection.offer().autoscaleMaxThroughput
+        autopilotThroughput: this.collection.offer?.()?.autoscaleMaxThroughput
+          ? this.collection.offer?.()?.autoscaleMaxThroughput
           : undefined,
-        manualThroughput: this.collection.offer().manualThroughput
-          ? this.collection.offer().manualThroughput
+        manualThroughput: this.collection.offer?.()?.manualThroughput
+          ? this.collection.offer?.()?.manualThroughput
           : undefined,
         throughputBuckets: this.state.throughputBuckets,
       });
@@ -1341,7 +1341,7 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
       });
     }
 
-    if (this.throughputBucketsEnabled) {
+    if (this.throughputBucketsEnabled && !hasDatabaseSharedThroughput(this.collection) && this.offer) {
       tabs.push({
         tab: SettingsV2TabTypes.ThroughputBucketsTab,
         content: <ThroughputBucketsComponent {...throughputBucketsComponentProps} />,


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2146?feature.someFeatureFlagYouMightNeed=true)

Need to hide the throughput bucketting settings for non shared non dedicated throughput container as it's not supported