### PR TITLE
[Visual Requirements - Azure Cosmos DB - Data Explorer]: After setting the viewport to 320*256px, the "New container" and "Connect" button text is misplaced.

### DIFF
--- a/src/Explorer/SplashScreen/SplashScreen.less
+++ b/src/Explorer/SplashScreen/SplashScreen.less
@@ -30,6 +30,21 @@
       margin: 0px auto;
       text-align: center;
     }
+    .splashStackContainer {
+      .splashStackRow {
+        display: flex;
+        gap: 0 16px;
+
+        @media (max-width: 768px) {
+          flex-direction: column;
+          gap: 16px 0;
+        }
+      }
+
+      @media (max-width: 768px) {
+        width: 85% !important;
+      }
+    }
 
     .mainButtonsContainer {
       .flex-display();

--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -126,8 +126,12 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
       useDatabases.getState().sampleDataResourceTokenCollection
     ) {
       return (
-        <Stack style={{ width: "66%", cursor: "pointer", margin: "40px auto" }} tokens={{ childrenGap: 16 }}>
-          <Stack horizontal tokens={{ childrenGap: 16 }}>
+        <Stack
+          className="splashStackContainer"
+          style={{ width: "66%", cursor: "pointer", margin: "40px auto" }}
+          tokens={{ childrenGap: 16 }}
+        >
+          <Stack className="splashStackRow" horizontal>
             <SplashScreenButton
               imgSrc={QuickStartIcon}
               title={"Launch quick start"}
@@ -147,7 +151,7 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
               }}
             />
           </Stack>
-          <Stack horizontal tokens={{ childrenGap: 16 }}>
+          <Stack className="splashStackRow" horizontal>
             {useQueryCopilot.getState().copilotEnabled && (
               <SplashScreenButton
                 imgSrc={CopilotIcon}


### PR DESCRIPTION
This PR fixes an issue in Azure Cosmos DB Data Explorer where the "New Container" and "Connect" button text was misaligned at a 320×256px viewport. The layout now properly adjusts to small screen sizes, ensuring correct button text alignment. It also handles cases where the user has set the display scaling to 200%

Before: 
![image](https://github.com/user-attachments/assets/41692189-69ec-4078-81ac-029e6f20ca9b)

After:
![image](https://github.com/user-attachments/assets/cc278a02-deb8-4a90-8dc5-0155b4f1708b)


[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2159?feature.someFeatureFlagYouMightNeed=true)
