### PR TITLE
[Supporting the Platform - Azure Cosmos DB- Data Explorer - Graphs]: When page viewport is set to 320x256px, Content under 'Notification' section is not properly visible.

### DIFF
--- a/src/Explorer/Menus/NotificationConsole/NotificationConsole.less
+++ b/src/Explorer/Menus/NotificationConsole/NotificationConsole.less
@@ -179,4 +179,14 @@
             }
         }
     }
+
+  @media (max-width: 768px) {
+    .notificationConsoleContents {
+      overflow-y: auto;
+
+      .notificationConsoleData {
+        overflow: visible;
+      }
+    }
+  }
 }

--- a/src/Explorer/Menus/NotificationConsole/NotificationConsole.less
+++ b/src/Explorer/Menus/NotificationConsole/NotificationConsole.less
@@ -173,6 +173,8 @@
                 .message {
                     flex-grow: 1;
                     white-space:pre-wrap;
+                    overflow-wrap: break-word;
+                    word-break: break-word;
                 }
             }
         }


### PR DESCRIPTION
This update fixes a UI issue in the Azure Cosmos DB Data Explorer (Graphs) where the 'Notification' section content was not properly visible at a 320x256px viewport. The layout has been adjusted to ensure proper visibility and responsiveness on small screens.


Before: 
![image](https://github.com/user-attachments/assets/8a06d3b2-c066-40b9-8127-03a37bbcb107)
After: 
![image](https://github.com/user-attachments/assets/d5a43563-da79-4e78-9b66-cb58bd0b0297)


[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2161?feature.someFeatureFlagYouMightNeed=true)
