### PR TITLE
[Supporting the Platform - Azure Cosmos DB- Data Explorer - New Vertex]: When page viewport is set to 320x256px, Content under 'New Vertex' pane is not properly visible.

### DIFF
--- a/src/Explorer/Graph/NewVertexComponent/NewVertexComponent.less
+++ b/src/Explorer/Graph/NewVertexComponent/NewVertexComponent.less
@@ -95,3 +95,10 @@
     white-space: nowrap;
   }
 }
+
+@media (max-width: 768px) {
+  .newVertexComponent {
+    padding: 0;
+    width: 100%;
+  }
+}

--- a/src/Explorer/Panes/PanelComponent.less
+++ b/src/Explorer/Panes/PanelComponent.less
@@ -11,10 +11,10 @@
     margin: 20px 0;
     overflow-x: hidden;
 
-    & > :not(.collapsibleSection) {
+    &> :not(.collapsibleSection) {
       margin-bottom: @DefaultSpace;
 
-      & > :not(:last-child) {
+      &> :not(:last-child) {
         margin-bottom: @DefaultSpace;
       }
     }
@@ -54,6 +54,14 @@
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .panelMainContent {
+      padding: 0 24px;
+      margin: 0;
+      overflow-x: auto;
     }
   }
 }
@@ -113,70 +121,87 @@
 .deleteCollectionFeedback {
   margin-top: 12px;
 }
+
 .addRemoveIcon {
   margin-left: 4px !important;
 }
+
 .addRemoveIconLabel {
   margin-top: 28px;
   margin-left: 4px !important;
 }
+
 .addRemoveIcon [alt="editEntity"]:focus,
 .addRemoveIconLabel [alt="editEntity"]:focus {
   border: 1px dashed #605e5c;
 }
+
 .addNewParamStyle {
   margin-top: 5px;
   margin-left: 5px !important;
   cursor: pointer;
 }
 
-.panelGroupSpacing > :not(:last-child) {
+.panelGroupSpacing> :not(:last-child) {
   margin-bottom: @DefaultSpace;
 }
+
 .fileUpload {
   display: none !important;
 }
+
 .customFileUpload {
   padding: 25px 0px 0px 10px;
   cursor: pointer;
   display: flex;
 }
+
 .fileIcon {
   align-self: center;
 }
+
 .panelAddIconLabel {
   font-size: 20px;
   width: 20px;
   margin: 30px 0 0 10px;
   cursor: default;
 }
+
 .panelAddIcon {
   font-size: 20px;
   width: 20px;
   margin: 30px 0 0 10px;
   cursor: default;
 }
+
 .removeIcon {
   color: @InfoIconColor;
 }
+
 .backImageIcon {
   margin-top: 8px;
 }
+
 [alt="back"]:focus {
   border: 1px solid #605e5c;
 }
+
 .addEntityDatePicker {
   max-width: 145px;
 }
+
 .addEntityTextField {
   width: 237px;
 }
+
 .addButtonEntiy {
   width: 25%;
 }
+
 .column-select-view {
   margin: 20px 0px 0px 0px;
 }
+
 .panelSeparator::before {
   background-color: #edebe9;
 }


### PR DESCRIPTION
This PR fixes a UI issue in the New Vertex pane of Azure Cosmos DB - Data Explorer. When the page viewport is set to 320x256px, the content under the New Vertex pane was not fully visible due to layout constraints. This update improves responsiveness and ensures that content remains accessible at small screen sizes.

Before: 
![image](https://github.com/user-attachments/assets/b507fca3-598e-4988-a844-c5eb6ecf4edc)
After:
![image](https://github.com/user-attachments/assets/e75ffcc3-7424-458b-bf93-134a5a3bc8f3)

[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2163?feature.someFeatureFlagYouMightNeed=true)
