### PR TITLE
Add login.microsoftonline.com to CSP.

### DIFF
--- a/web.config
+++ b/web.config
@@ -30,7 +30,7 @@
         <clear />
         <add name="X-Xss-Protection" value="1; mode=block" />
         <add name="X-Content-Type-Options" value="nosniff" />
-        <add name="Content-Security-Policy" value="frame-src 'vscode:' frame-ancestors 'self' portal.azure.com *.portal.azure.com portal.azure.us portal.azure.cn portal.microsoftazure.de df.onecloud.azure-test.net *.fabric.microsoft.com *.powerbi.com *.analysis-df.windows.net dataexplorer-preview.azurewebsites.net" />
+        <add name="Content-Security-Policy" value="frame-src 'vscode:' login.microsoftonline.com frame-ancestors 'self' portal.azure.com *.portal.azure.com portal.azure.us portal.azure.cn portal.microsoftazure.de df.onecloud.azure-test.net *.fabric.microsoft.com *.powerbi.com *.analysis-df.windows.net dataexplorer-preview.azurewebsites.net login.microsoftonline.com" />
       </customHeaders>
       <redirectHeaders>
         <clear />


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2167?feature.someFeatureFlagYouMightNeed=true)

This change addresses CSP errors seen recently when user's refresh token expires.
e.g. 

Refused to frame 'https://login.microsoftonline.com/' because it violates the following Content Security Policy directive: "frame-src 'self' frame-ancestors portal.azure.com *.portal.azure.com portal.azure.us portal.azure.cn portal.microsoftazure.de df.onecloud.azure-test.net *.fabric.microsoft.com *.powerbi.com *.analysis-df.windows.net dataexplorer-preview.azurewebsites.net".