### PR TITLE
Fix issues with Content-Security-Policy in web.config

### DIFF
--- a/web.config
+++ b/web.config
@@ -30,7 +30,7 @@
         <clear />
         <add name="X-Xss-Protection" value="1; mode=block" />
         <add name="X-Content-Type-Options" value="nosniff" />
-        <add name="Content-Security-Policy" value="frame-src 'vscode:' login.microsoftonline.com frame-ancestors 'self' portal.azure.com *.portal.azure.com portal.azure.us portal.azure.cn portal.microsoftazure.de df.onecloud.azure-test.net *.fabric.microsoft.com *.powerbi.com *.analysis-df.windows.net dataexplorer-preview.azurewebsites.net login.microsoftonline.com" />
+        <add name="Content-Security-Policy" value="frame-src vscode: login.microsoftonline.com; frame-ancestors 'self' portal.azure.com *.portal.azure.com portal.azure.us portal.azure.cn portal.microsoftazure.de df.onecloud.azure-test.net *.fabric.microsoft.com *.powerbi.com *.analysis-df.windows.net dataexplorer-preview.azurewebsites.net login.microsoftonline.com" />
       </customHeaders>
       <redirectHeaders>
         <clear />


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2168?feature.someFeatureFlagYouMightNeed=true)

Fixes these issues being reported as console errors, regarding the Content-Security-Policy value:
- Remove quotes from vscode: (previously reported as an invalid value)
- Add semi-colon to separate frame-src from frame-ancestors
