### PR TITLE
Enable Container Vector Policy for Fabric Native

### DIFF
--- a/src/Explorer/Panes/AddCollectionPanel/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel/AddCollectionPanel.tsx
@@ -123,7 +123,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
       isSharded: userContext.apiType !== "Tables",
       partitionKey: getPartitionKey(props.isQuickstart),
       subPartitionKeys: [],
-      enableDedicatedThroughput: false,
+      enableDedicatedThroughput: isFabricNative(), // Dedicated throughput is only enabled in Fabric Native by default
       createMongoWildCardIndex:
         isCapabilityEnabled("EnableMongo") && !isCapabilityEnabled("EnableMongo16MBDocumentSupport"),
       useHashV1: false,
@@ -708,7 +708,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
             </Stack>
           )}
 
-          {this.shouldShowCollectionThroughputInput() && (
+          {this.shouldShowCollectionThroughputInput() && !isFabricNative() && (
             <ThroughputInput
               showFreeTierExceedThroughputTooltip={isFreeTierAccount() && !isFirstResourceCreated}
               isDatabase={false}
@@ -1130,7 +1130,7 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
   // }
 
   private shouldShowCollectionThroughputInput(): boolean {
-    if (isFabricNative() || isServerlessAccount()) {
+    if (isServerlessAccount()) {
       return false;
     }
 

--- a/src/Utils/CapabilityUtils.ts
+++ b/src/Utils/CapabilityUtils.ts
@@ -1,3 +1,4 @@
+import { isFabricNative } from "Platform/Fabric/FabricUtil";
 import * as Constants from "../Common/Constants";
 import { userContext } from "../UserContext";
 
@@ -18,5 +19,8 @@ export const isServerlessAccount = (): boolean => {
 };
 
 export const isVectorSearchEnabled = (): boolean => {
-  return userContext.apiType === "SQL" && isCapabilityEnabled(Constants.CapabilityNames.EnableNoSQLVectorSearch);
+  return (
+    userContext.apiType === "SQL" &&
+    (isCapabilityEnabled(Constants.CapabilityNames.EnableNoSQLVectorSearch) || isFabricNative())
+  );
 };


### PR DESCRIPTION
This pull request introduces changes to enable Container Vector Policy configuration when creating containers for Fabric Native accounts and adjusts related logic in the `AddCollectionPanel` component and capability utility functions. The most important changes include updates to the throughput input visibility and the logic for vector search enablement.

Important: Fabric does not provide information for account capabilities, so we need to assume it's enabled in Fabric Native accounts.

![image](https://github.com/user-attachments/assets/05a498cf-2df6-43b3-ad53-0788f79b374d)

![image](https://github.com/user-attachments/assets/c86a9783-686a-4740-80ac-2da8e29a1695)


### Changes related to Fabric Native accounts:

* [`src/Explorer/Panes/AddCollectionPanel/AddCollectionPanel.tsx`](diffhunk://#diff-70feb4e3cc6de1d96040d1af8d5f4c10b55de9056e667c29571135c1be7f7fb1L126-R126): Updated `enableDedicatedThroughput` to default to `true` for Fabric Native accounts using the `isFabricNative()` function.
* [`src/Explorer/Panes/AddCollectionPanel/AddCollectionPanel.tsx`](diffhunk://#diff-70feb4e3cc6de1d96040d1af8d5f4c10b55de9056e667c29571135c1be7f7fb1L711-R711): Modified the visibility logic for the collection throughput input visibility which is used for both throughput and vector search. Now the logic to show the throughput settings has a dedicated check for fabric. [[1]](diffhunk://#diff-70feb4e3cc6de1d96040d1af8d5f4c10b55de9056e667c29571135c1be7f7fb1L711-R711) [[2]](diffhunk://#diff-70feb4e3cc6de1d96040d1af8d5f4c10b55de9056e667c29571135c1be7f7fb1L1133-R1133)

### Updates to capability utilities:

* [`src/Utils/CapabilityUtils.ts`](diffhunk://#diff-0f2da414abf40711ee9e426ac452d0ebc0427e787f5e054b190575e51f09e29cL21-R25): Adjusted the `isVectorSearchEnabled` function to enable vector search for Fabric Native accounts in addition to accounts with the `EnableNoSQLVectorSearch` capability.

[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
