### PR TITLE
Upgrade ARM Client API version to 2025-05-01-preview & Fetch enableMaterializedViews account property from ARM

### DIFF
--- a/src/Common/dataAccess/readCollections.ts
+++ b/src/Common/dataAccess/readCollections.ts
@@ -126,12 +126,5 @@ async function readCollectionsWithARM(databaseId: string): Promise<DataModels.Co
       throw new Error(`Unsupported default experience type: ${apiType}`);
   }
 
-  // TO DO: Remove when we get RP API Spec with materializedViews
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  return rpResponse?.value?.map((collection: any) => {
-    const collectionDataModel: DataModels.Collection = collection.properties?.resource as DataModels.Collection;
-    collectionDataModel.materializedViews = collection.properties?.resource?.materializedViews;
-    collectionDataModel.materializedViewDefinition = collection.properties?.resource?.materializedViewDefinition;
-    return collectionDataModel;
-  });
+  return rpResponse?.value?.map((collection) => collection.properties?.resource as DataModels.Collection);
 }

--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -7,6 +7,7 @@ export interface ArmEntity {
   type: string;
   kind: string;
   tags?: Tags;
+  resourceGroup?: string;
 }
 
 export interface DatabaseAccount extends ArmEntity {

--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -389,7 +389,7 @@ export interface VectorEmbeddingPolicy {
 }
 
 export interface VectorEmbedding {
-  dataType: "float16" | "float32" | "uint8" | "int8";
+  dataType: "float32" | "uint8" | "int8";
   dimensions: number;
   distanceFunction: "euclidean" | "cosine" | "dotproduct";
   path: string;

--- a/src/Utils/arm/generatedClients/cosmos/cassandraResources.ts
+++ b/src/Utils/arm/generatedClients/cosmos/cassandraResources.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Lists the Cassandra keyspaces under an existing Azure Cosmos DB database account. */
 export async function listCassandraKeyspaces(

--- a/src/Utils/arm/generatedClients/cosmos/collection.ts
+++ b/src/Utils/arm/generatedClients/cosmos/collection.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Retrieves the metrics determined by the given filter for the given database account and collection. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/cosmos/collectionPartition.ts
+++ b/src/Utils/arm/generatedClients/cosmos/collectionPartition.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Retrieves the metrics determined by the given filter for the given collection, split by partition. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/cosmos/collectionPartitionRegion.ts
+++ b/src/Utils/arm/generatedClients/cosmos/collectionPartitionRegion.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Retrieves the metrics determined by the given filter for the given collection and region, split by partition. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/cosmos/collectionRegion.ts
+++ b/src/Utils/arm/generatedClients/cosmos/collectionRegion.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Retrieves the metrics determined by the given filter for the given database account, collection and region. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/cosmos/database.ts
+++ b/src/Utils/arm/generatedClients/cosmos/database.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Retrieves the metrics determined by the given filter for the given database account and database. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/cosmos/databaseAccountRegion.ts
+++ b/src/Utils/arm/generatedClients/cosmos/databaseAccountRegion.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Retrieves the metrics determined by the given filter for the given database account and region. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/cosmos/databaseAccounts.ts
+++ b/src/Utils/arm/generatedClients/cosmos/databaseAccounts.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Retrieves the properties of an existing Azure Cosmos DB database account. */
 export async function get(

--- a/src/Utils/arm/generatedClients/cosmos/graphResources.ts
+++ b/src/Utils/arm/generatedClients/cosmos/graphResources.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Lists the graphs under an existing Azure Cosmos DB database account. */
 export async function listGraphs(

--- a/src/Utils/arm/generatedClients/cosmos/gremlinResources.ts
+++ b/src/Utils/arm/generatedClients/cosmos/gremlinResources.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Lists the Gremlin databases under an existing Azure Cosmos DB database account. */
 export async function listGremlinDatabases(

--- a/src/Utils/arm/generatedClients/cosmos/locations.ts
+++ b/src/Utils/arm/generatedClients/cosmos/locations.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* List Cosmos DB locations and their properties */
 export async function list(subscriptionId: string): Promise<Types.LocationListResult | Types.CloudError> {

--- a/src/Utils/arm/generatedClients/cosmos/mongoDBResources.ts
+++ b/src/Utils/arm/generatedClients/cosmos/mongoDBResources.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Lists the MongoDB databases under an existing Azure Cosmos DB database account. */
 export async function listMongoDBDatabases(

--- a/src/Utils/arm/generatedClients/cosmos/operations.ts
+++ b/src/Utils/arm/generatedClients/cosmos/operations.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Lists all of the available Cosmos DB Resource Provider operations. */
 export async function list(): Promise<Types.OperationListResult> {

--- a/src/Utils/arm/generatedClients/cosmos/partitionKeyRangeId.ts
+++ b/src/Utils/arm/generatedClients/cosmos/partitionKeyRangeId.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Retrieves the metrics determined by the given filter for the given partition key range id. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/cosmos/partitionKeyRangeIdRegion.ts
+++ b/src/Utils/arm/generatedClients/cosmos/partitionKeyRangeIdRegion.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Retrieves the metrics determined by the given filter for the given partition key range id and region. */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/cosmos/percentile.ts
+++ b/src/Utils/arm/generatedClients/cosmos/percentile.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Retrieves the metrics determined by the given filter for the given database account. This url is only for PBS and Replication Latency data */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/cosmos/percentileSourceTarget.ts
+++ b/src/Utils/arm/generatedClients/cosmos/percentileSourceTarget.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Retrieves the metrics determined by the given filter for the given account, source and target region. This url is only for PBS and Replication Latency data */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/cosmos/percentileTarget.ts
+++ b/src/Utils/arm/generatedClients/cosmos/percentileTarget.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Retrieves the metrics determined by the given filter for the given account target region. This url is only for PBS and Replication Latency data */
 export async function listMetrics(

--- a/src/Utils/arm/generatedClients/cosmos/sqlResources.ts
+++ b/src/Utils/arm/generatedClients/cosmos/sqlResources.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Lists the SQL databases under an existing Azure Cosmos DB database account. */
 export async function listSqlDatabases(

--- a/src/Utils/arm/generatedClients/cosmos/tableResources.ts
+++ b/src/Utils/arm/generatedClients/cosmos/tableResources.ts
@@ -3,13 +3,13 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
-import { configContext } from "../../../../ConfigContext";
 import { armRequest } from "../../request";
 import * as Types from "./types";
-const apiVersion = "2024-12-01-preview";
+import { configContext } from "../../../../ConfigContext";
+const apiVersion = "2025-05-01-preview";
 
 /* Lists the Tables under an existing Azure Cosmos DB database account. */
 export async function listTables(

--- a/src/Utils/arm/generatedClients/cosmos/types.ts
+++ b/src/Utils/arm/generatedClients/cosmos/types.ts
@@ -3,7 +3,7 @@
   Run "npm run generateARMClients" to regenerate
   Edting this file directly should be done with extreme caution as not to diverge from ARM REST specs
 
-  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-12-01-preview/cosmos-db.json
+  Generated from: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-05-01-preview/cosmos-db.json
 */
 
 /* The List operation response, that contains the client encryption keys and their properties. */
@@ -580,6 +580,8 @@ export interface DatabaseAccountGetProperties {
 
   /* Flag to indicate enabling/disabling of Per-Region Per-partition autoscale Preview feature on the account */
   enablePerRegionPerPartitionAutoscale?: boolean;
+  /* Flag to indicate if All Versions and Deletes Change feed feature is enabled on the account */
+  enableAllVersionsAndDeletesChangeFeed?: boolean;
 }
 
 /* Properties to create and update Azure Cosmos DB database accounts. */
@@ -682,6 +684,8 @@ export interface DatabaseAccountCreateUpdateProperties {
 
   /* Flag to indicate enabling/disabling of Per-Region Per-partition autoscale Preview feature on the account */
   enablePerRegionPerPartitionAutoscale?: boolean;
+  /* Flag to indicate if All Versions and Deletes Change feed feature is enabled on the account */
+  enableAllVersionsAndDeletesChangeFeed?: boolean;
 }
 
 /* Parameters to create and update Cosmos DB database accounts. */
@@ -787,6 +791,8 @@ export interface DatabaseAccountUpdateProperties {
 
   /* Flag to indicate enabling/disabling of Per-Region Per-partition autoscale Preview feature on the account */
   enablePerRegionPerPartitionAutoscale?: boolean;
+  /* Flag to indicate if All Versions and Deletes Change feed feature is enabled on the account */
+  enableAllVersionsAndDeletesChangeFeed?: boolean;
 }
 
 /* Parameters for patching Azure Cosmos DB database account properties. */
@@ -1216,6 +1222,8 @@ export interface PhysicalPartitionThroughputInfoResource {
   id: string;
   /* Throughput of a physical partition */
   throughput?: number;
+  /* Target throughput of a physical partition */
+  targetThroughput?: number;
 }
 
 /* Cosmos DB client encryption key resource object. */
@@ -1285,12 +1293,16 @@ export interface SqlContainerResource {
   /* The configuration for defining Materialized Views. This must be specified only for creating a Materialized View container. */
   materializedViewDefinition?: MaterializedViewDefinition;
 
+  /* Materialized Views defined on the container. */
+  materializedViews?: MaterializedViewDetails[];
+
   /* List of computed properties */
   computedProperties?: ComputedProperty[];
 
   /* The vector embedding policy for the container. */
   vectorEmbeddingPolicy?: VectorEmbeddingPolicy;
 
+  /* The FullText policy for the container. */
   fullTextPolicy?: FullTextPolicy;
 }
 
@@ -1321,6 +1333,14 @@ export interface IndexingPolicy {
 export interface VectorEmbeddingPolicy {
   /* List of vector embeddings */
   vectorEmbeddings?: VectorEmbedding[];
+}
+
+/* Cosmos DB FullText Policy */
+export interface FullTextPolicy {
+  /* The default language for a full text paths. */
+  defaultLanguage?: string;
+  /* List of FullText Paths */
+  fullTextPaths?: FullTextPath[];
 }
 
 /* undocumented */
@@ -1361,7 +1381,7 @@ export interface VectorEmbedding {
   /* The path to the vector field in the document. */
   path: string;
   /* Indicates the data type of vector. */
-  dataType: "float16" | "float32" | "uint8" | "int8";
+  dataType: "float32" | "uint8" | "int8";
 
   /* The distance function to use for distance calculation in between vectors. */
   distanceFunction: "euclidean" | "cosine" | "dotproduct";
@@ -1370,26 +1390,12 @@ export interface VectorEmbedding {
   dimensions: number;
 }
 
-export interface FullTextPolicy {
-  /**
-   * The default language for the full text .
-   */
-  defaultLanguage: string;
-  /**
-   * The paths to be indexed for full text search.
-   */
-  fullTextPaths: FullTextPath[];
-}
-
+/* Represents the full text path specification. */
 export interface FullTextPath {
-  /**
-   * The path to be indexed for full text search.
-   */
+  /* The path to the full text field in the document. */
   path: string;
-  /**
-   * The language for the full text path.
-   */
-  language: string;
+  /* The language of the full text field in the document. */
+  language?: string;
 }
 
 /* List of composite path */
@@ -1491,6 +1497,14 @@ export interface MaterializedViewDefinition {
   sourceCollectionId: string;
   /* The definition should be an SQL query which would be used to fetch data from the source container to populate into the Materialized View container. */
   definition: string;
+}
+
+/* MaterializedViewDetails, contains Id & _rid fields of materialized view. */
+export interface MaterializedViewDetails {
+  /* Id field of Materialized container. */
+  id?: string;
+  /* _rid field of Materialized container. */
+  _rid?: string;
 }
 
 /* Cosmos DB SQL storedProcedure resource object */

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -64,7 +64,8 @@ import {
   getMsalInstance,
 } from "../Utils/AuthorizationUtils";
 import { isInvalidParentFrameOrigin, shouldProcessMessage } from "../Utils/MessageValidation";
-import { getReadOnlyKeys, listKeys } from "../Utils/arm/generatedClients/cosmos/databaseAccounts";
+import { get, getReadOnlyKeys, listKeys } from "../Utils/arm/generatedClients/cosmos/databaseAccounts";
+import * as Types from "../Utils/arm/generatedClients/cosmos/types";
 import { applyExplorerBindings } from "../applyExplorerBindings";
 
 // This hook will create a new instance of Explorer.ts and bind it to the DOM
@@ -346,6 +347,14 @@ async function configureHostedWithAAD(config: AAD): Promise<Explorer> {
     }
   }
   try {
+    // TO DO - Remove once we have ARG API support for enableMaterializedViews property
+    const databaseAccount: Types.DatabaseAccountGetResults = await get(
+      subscriptionId,
+      account.resourceGroup,
+      account.name,
+    );
+    config.databaseAccount.properties.enableMaterializedViews = databaseAccount.properties?.enableMaterializedViews;
+
     updateUserContext({
       databaseAccount: config.databaseAccount,
     });

--- a/utils/armClientGenerator/generator.ts
+++ b/utils/armClientGenerator/generator.ts
@@ -16,7 +16,7 @@ Results of this file should be checked into the repo.
 */
 
 // CHANGE THESE VALUES TO GENERATE NEW CLIENTS
-const version = "2024-12-01-preview";
+const version = "2025-05-01-preview";
 /* The following are legal options for resourceName but you generally will only use cosmos:
 "cosmos" | "managedCassandra" | "mongorbac" | "notebook" | "privateEndpointConnection" | "privateLinkResources" |
 "rbac" | "restorable" | "services" | "dataTransferService"


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2171)

1. Upgrade ARM Client API version to 2025-05-01-preview

This is needed because when we fetch containers, we need to read their `materializedViews` property which is available in this API version. Previously we were working around this by not using strict types.

2.  Fetch `enableMaterializedViews` account property from ARM

This flag was not available via ARG and thus standalone Data Explorer for it retrieves account properties from there. This is hack to fetch flag from ARM until it is supported in ARG.