### PR TITLE
Do not set disableNonStreamingOrderByQuery flag

### DIFF
--- a/src/Common/dataAccess/__snapshots__/queryDocuments.test.ts.snap
+++ b/src/Common/dataAccess/__snapshots__/queryDocuments.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`getCommonQueryOptions builds the correct default options objects 1`] = `
 {
-  "disableNonStreamingOrderByQuery": true,
   "enableQueryControl": false,
   "enableScanInQuery": true,
   "forceQueryPlan": true,
@@ -14,7 +13,6 @@ exports[`getCommonQueryOptions builds the correct default options objects 1`] = 
 
 exports[`getCommonQueryOptions reads from localStorage 1`] = `
 {
-  "disableNonStreamingOrderByQuery": true,
   "enableQueryControl": false,
   "enableScanInQuery": true,
   "forceQueryPlan": true,

--- a/src/Common/dataAccess/queryDocuments.ts
+++ b/src/Common/dataAccess/queryDocuments.ts
@@ -1,5 +1,4 @@
 import { FeedOptions, ItemDefinition, QueryIterator, Resource } from "@azure/cosmos";
-import { isVectorSearchEnabled } from "Utils/CapabilityUtils";
 import { LocalStorageUtility, StorageKey } from "../../Shared/StorageUtility";
 import { Queries } from "../Constants";
 import { client } from "../CosmosClient";
@@ -28,6 +27,5 @@ export const getCommonQueryOptions = (options: FeedOptions): FeedOptions => {
     Queries.itemsPerPage;
   options.enableQueryControl = LocalStorageUtility.getEntryBoolean(StorageKey.QueryControlEnabled);
   options.maxDegreeOfParallelism = LocalStorageUtility.getEntryNumber(StorageKey.MaxDegreeOfParellism);
-  options.disableNonStreamingOrderByQuery = !isVectorSearchEnabled();
   return options;
 };


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2179)

Data Explorer currently sets `disableNonStreamingOrderByQuery` documents query flag to tree if vector search is not enabled on an account. This is no longer required.