### PR TITLE
Use Config.json to Set Environment Specific AAD Auth Settings

### DIFF
--- a/src/HostedExplorer.tsx
+++ b/src/HostedExplorer.tsx
@@ -35,7 +35,7 @@ const App: React.FunctionComponent = () => {
   const config = useConfig();
 
   const { isLoggedIn, armToken, graphToken, account, tenantId, logout, login, switchTenant, authFailure } =
-    useAADAuth();
+    useAADAuth(config);
 
   const [databaseAccount, setDatabaseAccount] = React.useState<DatabaseAccount>();
   const [authType, setAuthType] = React.useState<AuthType>(encryptedToken ? AuthType.EncryptedToken : undefined);

--- a/src/HostedExplorer.tsx
+++ b/src/HostedExplorer.tsx
@@ -1,4 +1,4 @@
-import { initializeIcons } from "@fluentui/react";
+import { initializeIcons, Spinner } from "@fluentui/react";
 import { useBoolean } from "@fluentui/react-hooks";
 import { AadAuthorizationFailure } from "Platform/Hosted/Components/AadAuthorizationFailure";
 import * as React from "react";
@@ -33,8 +33,10 @@ const App: React.FunctionComponent = () => {
   // For showing/hiding panel
   const [isOpen, { setTrue: openPanel, setFalse: dismissPanel }] = useBoolean(false);
   const config = useConfig();
+
   const { isLoggedIn, armToken, graphToken, account, tenantId, logout, login, switchTenant, authFailure } =
     useAADAuth();
+
   const [databaseAccount, setDatabaseAccount] = React.useState<DatabaseAccount>();
   const [authType, setAuthType] = React.useState<AuthType>(encryptedToken ? AuthType.EncryptedToken : undefined);
   const [connectionString, setConnectionString] = React.useState<string>();
@@ -75,6 +77,10 @@ const App: React.FunctionComponent = () => {
       }
     }
   });
+
+  if (!config) {
+    return <Spinner label="Loading configuration..." />;
+  }
 
   const showExplorer =
     (config && isLoggedIn && databaseAccount) ||

--- a/src/HostedExplorer.tsx
+++ b/src/HostedExplorer.tsx
@@ -1,4 +1,4 @@
-import { initializeIcons, Spinner } from "@fluentui/react";
+import { initializeIcons } from "@fluentui/react";
 import { useBoolean } from "@fluentui/react-hooks";
 import { AadAuthorizationFailure } from "Platform/Hosted/Components/AadAuthorizationFailure";
 import * as React from "react";
@@ -33,7 +33,6 @@ const App: React.FunctionComponent = () => {
   // For showing/hiding panel
   const [isOpen, { setTrue: openPanel, setFalse: dismissPanel }] = useBoolean(false);
   const config = useConfig();
-
   const { isLoggedIn, armToken, graphToken, account, tenantId, logout, login, switchTenant, authFailure } =
     useAADAuth(config);
 
@@ -77,10 +76,6 @@ const App: React.FunctionComponent = () => {
       }
     }
   });
-
-  if (!config) {
-    return <Spinner label="Loading configuration..." />;
-  }
 
   const showExplorer =
     (config && isLoggedIn && databaseAccount) ||

--- a/src/hooks/useAADAuth.ts
+++ b/src/hooks/useAADAuth.ts
@@ -26,114 +26,66 @@ export interface AadAuthFailure {
 
 export function useAADAuth(config?: ConfigContext): ReturnType {
   const [msalInstance, setMsalInstance] = React.useState<msal.PublicClientApplication | null>(null);
-  const [cachedAccount, setCachedAccount] = React.useState<msal.AccountInfo | null>(null);
-  const [hasInteractiveLogin, setHasInteractiveLogin] = React.useState<boolean>(false);
+  const [isLoggedIn, { setTrue: setLoggedIn, setFalse: setLoggedOut }] = useBoolean(false);
+  const [account, setAccount] = React.useState<msal.AccountInfo>(null);
+  const [tenantId, setTenantId] = React.useState<string>(cachedTenantId);
+  const [graphToken, setGraphToken] = React.useState<string>();
+  const [armToken, setArmToken] = React.useState<string>();
+  const [authFailure, setAuthFailure] = React.useState<AadAuthFailure>(undefined);
 
   // Initialize MSAL instance when config is available
   React.useEffect(() => {
     if (config && !msalInstance) {
       getMsalInstance().then((instance) => {
         setMsalInstance(instance);
-        const account = instance.getAllAccounts()?.[0];
-        setCachedAccount(account);
+        const cachedAccount = instance.getAllAccounts()?.[0];
+        if (cachedAccount && cachedTenantId) {
+          setAccount(cachedAccount);
+          setLoggedIn();
+          instance.setActiveAccount(cachedAccount);
+        }
       });
     }
   }, [config, msalInstance]);
 
-  const [isLoggedIn, { setTrue: setLoggedIn, setFalse: setLoggedOut }] = useBoolean(false);
-  const [account, setAccount] = React.useState<msal.AccountInfo>(cachedAccount);
-  const [tenantId, setTenantId] = React.useState<string>(cachedTenantId);
-  const [graphToken, setGraphToken] = React.useState<string>();
-  const [armToken, setArmToken] = React.useState<string>();
-  const [authFailure, setAuthFailure] = React.useState<AadAuthFailure>(undefined);
-
-  // Update account state when cachedAccount changes
   React.useEffect(() => {
-    if (cachedAccount) {
-      setAccount(cachedAccount);
+    if (msalInstance && account) {
+      msalInstance.setActiveAccount(account);
     }
-  }, [cachedAccount]);
+  }, [msalInstance, account]);
 
-  // Initialize logged in state based on cached values when we have the config
-  React.useEffect(() => {
-    if (config && cachedAccount && cachedTenantId) {
-      // Don't automatically set as logged in just because we have cached values
-      // The user should explicitly log in, and then we'll have hasInteractiveLogin = true
-      // Note: Found cached account and tenant, but user needs to sign in
-    }
-  }, [config, cachedAccount]);
-
-  // Update login state when we have both account and tenant
-  React.useEffect(() => {
-    // Only consider user as logged in if they have completed interactive login
-    // or if we successfully have both account/tenant AND tokens
-    if (account && tenantId && (hasInteractiveLogin || (armToken && graphToken))) {
-      setLoggedIn();
-    } else {
-      setLoggedOut();
-    }
-  }, [account, tenantId, setLoggedIn, setLoggedOut, hasInteractiveLogin, armToken, graphToken]);
-
-  if (msalInstance && account) {
-    msalInstance.setActiveAccount(account);
-  }
   const login = React.useCallback(async () => {
-    if (!msalInstance || !config) {
-      return;
-    }
+    if (!msalInstance || !config) return;
 
-    try {
-      const response = await msalInstance.loginPopup({
-        redirectUri: config.msalRedirectURI,
-        scopes: [],
-      });
-      setLoggedIn();
-      setAccount(response.account);
-      setTenantId(response.tenantId);
-      setHasInteractiveLogin(true);
-      localStorage.setItem("cachedTenantId", response.tenantId);
-    } catch (error) {
-      console.error("Login failed:", error);
-      setAuthFailure({
-        failureMessage: `Login failed: ${JSON.stringify(error)}`,
-      });
-    }
-  }, [msalInstance, config, setLoggedIn]);
+    const response = await msalInstance.loginPopup({
+      redirectUri: config.msalRedirectURI,
+      scopes: [],
+    });
+    setLoggedIn();
+    setAccount(response.account);
+    setTenantId(response.tenantId);
+    localStorage.setItem("cachedTenantId", response.tenantId);
+  }, [msalInstance, config]);
 
   const logout = React.useCallback(() => {
-    if (!msalInstance) {
-      return;
-    }
-
+    if (!msalInstance) return;
     setLoggedOut();
-    setHasInteractiveLogin(false);
-    setAuthFailure(null);
     localStorage.removeItem("cachedTenantId");
     msalInstance.logoutRedirect();
-  }, [msalInstance, setLoggedOut]);
+  }, [msalInstance]);
 
   const switchTenant = React.useCallback(
     async (id) => {
-      if (!msalInstance || !config) {
-        return;
-      }
+      if (!msalInstance || !config) return;
 
-      try {
-        const response = await msalInstance.loginPopup({
-          redirectUri: config.msalRedirectURI,
-          authority: `${config.AAD_ENDPOINT}${id}`,
-          scopes: [],
-        });
-        setTenantId(response.tenantId);
-        setAccount(response.account);
-        setHasInteractiveLogin(true);
-        localStorage.setItem("cachedTenantId", response.tenantId);
-      } catch (error) {
-        console.error("Tenant switch failed:", error);
-        setAuthFailure({
-          failureMessage: `Tenant switch failed: ${JSON.stringify(error)}`,
-        });
-      }
+      const response = await msalInstance.loginPopup({
+        redirectUri: config.msalRedirectURI,
+        authority: `${config.AAD_ENDPOINT}${id}`,
+        scopes: [],
+      });
+      setTenantId(response.tenantId);
+      setAccount(response.account);
+      localStorage.setItem("cachedTenantId", response.tenantId);
     },
     [msalInstance, config],
   );
@@ -152,15 +104,7 @@ export function useAADAuth(config?: ConfigContext): ReturnType {
       setArmToken(armToken);
       setAuthFailure(null);
     } catch (error) {
-      // ARM token acquisition error logged for debugging
-
-      if (error instanceof msal.InteractionRequiredAuthError) {
-        // This is expected when there are no cached tokens - don't show an error for this
-        // Interactive login required for ARM token
-      } else if (
-        error instanceof msal.AuthError &&
-        error.errorCode === msal.BrowserAuthErrorMessage.popUpWindowError.code
-      ) {
+      if (error instanceof msal.AuthError && error.errorCode === msal.BrowserAuthErrorMessage.popUpWindowError.code) {
         // This error can occur when acquireTokenWithMsal() has attempted to acquire token interactively
         // and user has popups disabled in browser. This fails as the popup is not the result of a explicit user
         // action. In this case, we display the failure and a link to repeat the operation. Clicking on the
@@ -172,23 +116,8 @@ export function useAADAuth(config?: ConfigContext): ReturnType {
           failureLinkTitle: "Retry Authorization",
           failureLinkAction: acquireTokens,
         });
-      } else if (
-        error instanceof msal.AuthError &&
-        (error.errorCode === "no_tokens_found" || error.errorCode === "no_account_error")
-      ) {
-        // This happens when there are no cached tokens - this is normal for first-time users
-        // Only show this as an error if we expected to have tokens (i.e., after interactive login)
-        if (hasInteractiveLogin) {
-          // No tokens found after interactive login
-          setAuthFailure({
-            failureMessage: `Authorization tokens were not found. Please try signing in again.`,
-          });
-        } else {
-          // No cached tokens found, user needs to sign in
-        }
       } else {
         const errorJson = JSON.stringify(error);
-        // ARM token acquisition failed with error
         setAuthFailure({
           failureMessage: `We were unable to establish authorization for this account, due to the following error: \n${errorJson}`,
         });
@@ -207,21 +136,13 @@ export function useAADAuth(config?: ConfigContext): ReturnType {
       // it's not critical if this fails.
       console.warn("Error acquiring graph token: " + error);
     }
-  }, [account, tenantId, msalInstance, config, hasInteractiveLogin]);
+  }, [account, tenantId, msalInstance, config]);
 
   React.useEffect(() => {
-    // Only try to acquire tokens after an interactive login or if we have a cached account with tenant
-    if (
-      account &&
-      tenantId &&
-      !authFailure &&
-      msalInstance &&
-      config &&
-      (hasInteractiveLogin || (cachedAccount && cachedTenantId))
-    ) {
+    if (account && tenantId && !authFailure) {
       acquireTokens();
     }
-  }, [account, tenantId, acquireTokens, authFailure, msalInstance, config, hasInteractiveLogin, cachedAccount]);
+  }, [account, tenantId, acquireTokens, authFailure]);
 
   return {
     account,

--- a/src/hooks/useAADAuth.ts
+++ b/src/hooks/useAADAuth.ts
@@ -55,7 +55,9 @@ export function useAADAuth(config?: ConfigContext): ReturnType {
   }, [msalInstance, account]);
 
   const login = React.useCallback(async () => {
-    if (!msalInstance || !config) return;
+    if (!msalInstance || !config) {
+      return;
+    }
 
     const response = await msalInstance.loginPopup({
       redirectUri: config.msalRedirectURI,
@@ -68,7 +70,9 @@ export function useAADAuth(config?: ConfigContext): ReturnType {
   }, [msalInstance, config]);
 
   const logout = React.useCallback(() => {
-    if (!msalInstance) return;
+    if (!msalInstance) {
+      return;
+    }
     setLoggedOut();
     localStorage.removeItem("cachedTenantId");
     msalInstance.logoutRedirect();
@@ -76,8 +80,9 @@ export function useAADAuth(config?: ConfigContext): ReturnType {
 
   const switchTenant = React.useCallback(
     async (id) => {
-      if (!msalInstance || !config) return;
-
+      if (!msalInstance || !config) {
+        return;
+      }
       const response = await msalInstance.loginPopup({
         redirectUri: config.msalRedirectURI,
         authority: `${config.AAD_ENDPOINT}${id}`,
@@ -94,7 +99,6 @@ export function useAADAuth(config?: ConfigContext): ReturnType {
     if (!(account && tenantId && msalInstance && config)) {
       return;
     }
-
     try {
       const armToken = await acquireTokenWithMsal(msalInstance, {
         authority: `${config.AAD_ENDPOINT}${tenantId}`,

--- a/src/hooks/useAADAuth.ts
+++ b/src/hooks/useAADAuth.ts
@@ -59,14 +59,20 @@ export function useAADAuth(config?: ConfigContext): ReturnType {
       return;
     }
 
-    const response = await msalInstance.loginPopup({
-      redirectUri: config.msalRedirectURI,
-      scopes: [],
-    });
-    setLoggedIn();
-    setAccount(response.account);
-    setTenantId(response.tenantId);
-    localStorage.setItem("cachedTenantId", response.tenantId);
+    try {
+      const response = await msalInstance.loginPopup({
+        redirectUri: config.msalRedirectURI,
+        scopes: [],
+      });
+      setLoggedIn();
+      setAccount(response.account);
+      setTenantId(response.tenantId);
+      localStorage.setItem("cachedTenantId", response.tenantId);
+    } catch (error) {
+      setAuthFailure({
+        failureMessage: `Login failed: ${JSON.stringify(error)}`,
+      });
+    }
   }, [msalInstance, config]);
 
   const logout = React.useCallback(() => {
@@ -83,14 +89,20 @@ export function useAADAuth(config?: ConfigContext): ReturnType {
       if (!msalInstance || !config) {
         return;
       }
-      const response = await msalInstance.loginPopup({
-        redirectUri: config.msalRedirectURI,
-        authority: `${config.AAD_ENDPOINT}${id}`,
-        scopes: [],
-      });
-      setTenantId(response.tenantId);
-      setAccount(response.account);
-      localStorage.setItem("cachedTenantId", response.tenantId);
+      try {
+        const response = await msalInstance.loginPopup({
+          redirectUri: config.msalRedirectURI,
+          authority: `${config.AAD_ENDPOINT}${id}`,
+          scopes: [],
+        });
+        setTenantId(response.tenantId);
+        setAccount(response.account);
+        localStorage.setItem("cachedTenantId", response.tenantId);
+      } catch (error) {
+        setAuthFailure({
+          failureMessage: `Tenant switch failed: ${JSON.stringify(error)}`,
+        });
+      }
     },
     [msalInstance, config],
   );

--- a/src/hooks/useAADAuth.ts
+++ b/src/hooks/useAADAuth.ts
@@ -1,12 +1,9 @@
 import * as msal from "@azure/msal-browser";
 import { useBoolean } from "@fluentui/react-hooks";
 import * as React from "react";
-import { configContext } from "../ConfigContext";
+import { ConfigContext } from "../ConfigContext";
 import { acquireTokenWithMsal, getMsalInstance } from "../Utils/AuthorizationUtils";
 
-const msalInstance = await getMsalInstance();
-
-const cachedAccount = msalInstance.getAllAccounts()?.[0];
 const cachedTenantId = localStorage.getItem("cachedTenantId");
 
 interface ReturnType {
@@ -27,63 +24,137 @@ export interface AadAuthFailure {
   failureLinkAction?: () => void;
 }
 
-export function useAADAuth(): ReturnType {
-  const [isLoggedIn, { setTrue: setLoggedIn, setFalse: setLoggedOut }] = useBoolean(
-    Boolean(cachedAccount && cachedTenantId) || false,
-  );
+export function useAADAuth(config?: ConfigContext): ReturnType {
+  const [msalInstance, setMsalInstance] = React.useState<msal.PublicClientApplication | null>(null);
+  const [cachedAccount, setCachedAccount] = React.useState<msal.AccountInfo | null>(null);
+  const [hasInteractiveLogin, setHasInteractiveLogin] = React.useState<boolean>(false);
+
+  // Initialize MSAL instance when config is available
+  React.useEffect(() => {
+    if (config && !msalInstance) {
+      getMsalInstance().then((instance) => {
+        setMsalInstance(instance);
+        const account = instance.getAllAccounts()?.[0];
+        setCachedAccount(account);
+      });
+    }
+  }, [config, msalInstance]);
+
+  const [isLoggedIn, { setTrue: setLoggedIn, setFalse: setLoggedOut }] = useBoolean(false);
   const [account, setAccount] = React.useState<msal.AccountInfo>(cachedAccount);
   const [tenantId, setTenantId] = React.useState<string>(cachedTenantId);
   const [graphToken, setGraphToken] = React.useState<string>();
   const [armToken, setArmToken] = React.useState<string>();
   const [authFailure, setAuthFailure] = React.useState<AadAuthFailure>(undefined);
 
-  msalInstance.setActiveAccount(account);
+  // Update account state when cachedAccount changes
+  React.useEffect(() => {
+    if (cachedAccount) {
+      setAccount(cachedAccount);
+    }
+  }, [cachedAccount]);
+
+  // Initialize logged in state based on cached values when we have the config
+  React.useEffect(() => {
+    if (config && cachedAccount && cachedTenantId) {
+      // Don't automatically set as logged in just because we have cached values
+      // The user should explicitly log in, and then we'll have hasInteractiveLogin = true
+      console.log("Found cached account and tenant, but user needs to sign in");
+    }
+  }, [config, cachedAccount, cachedTenantId, setLoggedIn]);
+
+  // Update login state when we have both account and tenant
+  React.useEffect(() => {
+    // Only consider user as logged in if they have completed interactive login
+    // or if we successfully have both account/tenant AND tokens
+    if (Boolean(account && tenantId && (hasInteractiveLogin || (armToken && graphToken)))) {
+      setLoggedIn();
+    } else {
+      setLoggedOut();
+    }
+  }, [account, tenantId, setLoggedIn, setLoggedOut, hasInteractiveLogin, armToken, graphToken]);
+
+  if (msalInstance && account) {
+    msalInstance.setActiveAccount(account);
+  }
   const login = React.useCallback(async () => {
-    const response = await msalInstance.loginPopup({
-      redirectUri: configContext.msalRedirectURI,
-      scopes: [],
-    });
-    setLoggedIn();
-    setAccount(response.account);
-    setTenantId(response.tenantId);
-    localStorage.setItem("cachedTenantId", response.tenantId);
-  }, []);
+    if (!msalInstance || !config) return;
+
+    try {
+      const response = await msalInstance.loginPopup({
+        redirectUri: config.msalRedirectURI,
+        scopes: [],
+      });
+      setLoggedIn();
+      setAccount(response.account);
+      setTenantId(response.tenantId);
+      setHasInteractiveLogin(true);
+      localStorage.setItem("cachedTenantId", response.tenantId);
+    } catch (error) {
+      console.error("Login failed:", error);
+      setAuthFailure({
+        failureMessage: `Login failed: ${JSON.stringify(error)}`,
+      });
+    }
+  }, [msalInstance, config, setLoggedIn]);
 
   const logout = React.useCallback(() => {
+    if (!msalInstance) return;
+
     setLoggedOut();
+    setHasInteractiveLogin(false);
+    setAuthFailure(null);
     localStorage.removeItem("cachedTenantId");
     msalInstance.logoutRedirect();
-  }, []);
+  }, [msalInstance, setLoggedOut]);
 
   const switchTenant = React.useCallback(
     async (id) => {
-      const response = await msalInstance.loginPopup({
-        redirectUri: configContext.msalRedirectURI,
-        authority: `${configContext.AAD_ENDPOINT}${id}`,
-        scopes: [],
-      });
-      setTenantId(response.tenantId);
-      setAccount(response.account);
-      localStorage.setItem("cachedTenantId", response.tenantId);
+      if (!msalInstance || !config) return;
+
+      try {
+        const response = await msalInstance.loginPopup({
+          redirectUri: config.msalRedirectURI,
+          authority: `${config.AAD_ENDPOINT}${id}`,
+          scopes: [],
+        });
+        setTenantId(response.tenantId);
+        setAccount(response.account);
+        setHasInteractiveLogin(true);
+        localStorage.setItem("cachedTenantId", response.tenantId);
+      } catch (error) {
+        console.error("Tenant switch failed:", error);
+        setAuthFailure({
+          failureMessage: `Tenant switch failed: ${JSON.stringify(error)}`,
+        });
+      }
     },
-    [account, tenantId],
+    [account, tenantId, msalInstance, config],
   );
 
   const acquireTokens = React.useCallback(async () => {
-    if (!(account && tenantId)) {
+    if (!(account && tenantId && msalInstance && config)) {
       return;
     }
 
     try {
       const armToken = await acquireTokenWithMsal(msalInstance, {
-        authority: `${configContext.AAD_ENDPOINT}${tenantId}`,
-        scopes: [`${configContext.ARM_ENDPOINT}/.default`],
+        authority: `${config.AAD_ENDPOINT}${tenantId}`,
+        scopes: [`${config.ARM_ENDPOINT}/.default`],
       });
 
       setArmToken(armToken);
       setAuthFailure(null);
     } catch (error) {
-      if (error instanceof msal.AuthError && error.errorCode === msal.BrowserAuthErrorMessage.popUpWindowError.code) {
+      console.log("ARM token acquisition error:", error);
+
+      if (error instanceof msal.InteractionRequiredAuthError) {
+        // This is expected when there are no cached tokens - don't show an error for this
+        console.log("Interactive login required for ARM token");
+      } else if (
+        error instanceof msal.AuthError &&
+        error.errorCode === msal.BrowserAuthErrorMessage.popUpWindowError.code
+      ) {
         // This error can occur when acquireTokenWithMsal() has attempted to acquire token interactively
         // and user has popups disabled in browser. This fails as the popup is not the result of a explicit user
         // action. In this case, we display the failure and a link to repeat the operation. Clicking on the
@@ -95,8 +166,23 @@ export function useAADAuth(): ReturnType {
           failureLinkTitle: "Retry Authorization",
           failureLinkAction: acquireTokens,
         });
+      } else if (
+        error instanceof msal.AuthError &&
+        (error.errorCode === "no_tokens_found" || error.errorCode === "no_account_error")
+      ) {
+        // This happens when there are no cached tokens - this is normal for first-time users
+        // Only show this as an error if we expected to have tokens (i.e., after interactive login)
+        if (hasInteractiveLogin) {
+          console.error("No tokens found after interactive login:", error);
+          setAuthFailure({
+            failureMessage: `Authorization tokens were not found. Please try signing in again.`,
+          });
+        } else {
+          console.log("No cached tokens found, user needs to sign in");
+        }
       } else {
         const errorJson = JSON.stringify(error);
+        console.error("ARM token acquisition failed:", errorJson);
         setAuthFailure({
           failureMessage: `We were unable to establish authorization for this account, due to the following error: \n${errorJson}`,
         });
@@ -105,8 +191,8 @@ export function useAADAuth(): ReturnType {
 
     try {
       const graphToken = await acquireTokenWithMsal(msalInstance, {
-        authority: `${configContext.AAD_ENDPOINT}${tenantId}`,
-        scopes: [`${configContext.GRAPH_ENDPOINT}/.default`],
+        authority: `${config.AAD_ENDPOINT}${tenantId}`,
+        scopes: [`${config.GRAPH_ENDPOINT}/.default`],
       });
 
       setGraphToken(graphToken);
@@ -115,13 +201,31 @@ export function useAADAuth(): ReturnType {
       // it's not critical if this fails.
       console.warn("Error acquiring graph token: " + error);
     }
-  }, [account, tenantId]);
+  }, [account, tenantId, msalInstance, config]);
 
   React.useEffect(() => {
-    if (account && tenantId && !authFailure) {
+    // Only try to acquire tokens after an interactive login or if we have a cached account with tenant
+    if (
+      account &&
+      tenantId &&
+      !authFailure &&
+      msalInstance &&
+      config &&
+      (hasInteractiveLogin || (cachedAccount && cachedTenantId))
+    ) {
       acquireTokens();
     }
-  }, [account, tenantId, acquireTokens, authFailure]);
+  }, [
+    account,
+    tenantId,
+    acquireTokens,
+    authFailure,
+    msalInstance,
+    config,
+    hasInteractiveLogin,
+    cachedAccount,
+    cachedTenantId,
+  ]);
 
   return {
     account,


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2184?feature.someFeatureFlagYouMightNeed=true)

**_Problem:_**
Currently, the useAADAuth hook is called by HostedExplorer to perform auth in Standalone Data Explorer.  useAADAuth creates an msalInstance as module-level state and calls getMsalInstance.  getMsalInstance uses the AAD_ENDPOINT in the configContext as the authority.  

Since the msalInstance is created as module-level state, it loads and uses the default AAD_ENDPOINT in the configContext before the useConfig() hook can retrieve state from config.json and other sources.  We need to force useAADAuth to only continue after the configContext is fully initialized.

**_Approach:_**
Move the MSAL instance creation into a useEffect within the useAADAuth hook and only instantiate the MSAL instance on a render where the configContext is fully available.

This was largely covered by [this ](https://github.com/Azure/cosmos-explorer/pull/2184/commits/09b6a6e9ad5938ac41dab815b805440d49653ac8) commit of this PR, but would encounter unhandled auth errors if the user cancelled the login popup prematurely.  Added some error handling for that.

As of right now, if the incorrect AAD_ENDPOINT is provided at deployment, then that leads to persistent auth issues and displays the error with the previously introduced error handlers.  The user can still sign out and use connection strings.

That error should not happen as long as the config.json is correct.  We shouldn't be using an authority not suited for the environment that instance of data explorer is running.