### PR TITLE
Remove unneeded and misleading console log

### DIFF
--- a/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
+++ b/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
@@ -433,9 +433,6 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
       );
     }
 
-    logConsoleInfo(
-      `Updated query setting to ${LocalStorageUtility.getEntryString(StorageKey.SetPartitionKeyUndefined)}`,
-    );
     refreshExplorer && (await explorer.refreshExplorer());
     closeSidePanel();
   };


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

When applying changes in the Settings pane, the console logs message `Updated query setting to null` no matter which setting is edited. This log will now be removed as it does not provide useful information.

<img width="469" height="152" alt="image" src="https://github.com/user-attachments/assets/d2c7d619-ef83-4c9c-931a-4e00803df694" />
