### PR TITLE
Fix CloudShell terminal hanging for Mongo and Cassandra shells due to missing updateTerminalData method

### DIFF
--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/MongoShellHandler.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/MongoShellHandler.test.tsx
@@ -33,6 +33,7 @@ jest.mock("../../../../UserContext", () => ({
 }));
 
 jest.mock("../Utils/CommonUtils", () => ({
+  ...jest.requireActual("../Utils/CommonUtils"),
   getHostFromUrl: jest.fn().mockReturnValue("test-mongo.documents.azure.com"),
 }));
 
@@ -124,7 +125,10 @@ describe("MongoShellHandler", () => {
 
   describe("getTerminalSuppressedData", () => {
     it("should return the correct warning message", () => {
-      expect(mongoShellHandler.getTerminalSuppressedData()).toEqual(["Warning: Non-Genuine MongoDB Detected"]);
+      expect(mongoShellHandler.getTerminalSuppressedData()).toEqual([
+        "Warning: Non-Genuine MongoDB Detected",
+        "Telemetry is now disabled.",
+      ]);
     });
   });
 });

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/MongoShellHandler.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/MongoShellHandler.tsx
@@ -1,10 +1,11 @@
 import { userContext } from "../../../../UserContext";
-import { getHostFromUrl } from "../Utils/CommonUtils";
+import { filterAndCleanTerminalOutput, getHostFromUrl, getMongoShellRemoveInfoText } from "../Utils/CommonUtils";
 import { AbstractShellHandler, DISABLE_TELEMETRY_COMMAND } from "./AbstractShellHandler";
 
 export class MongoShellHandler extends AbstractShellHandler {
   private _key: string;
   private _endpoint: string | undefined;
+  private _removeInfoText: string[] = getMongoShellRemoveInfoText();
   constructor(private key: string) {
     super();
     this._key = key;
@@ -44,6 +45,10 @@ export class MongoShellHandler extends AbstractShellHandler {
   }
 
   public getTerminalSuppressedData(): string[] {
-    return ["Warning: Non-Genuine MongoDB Detected"];
+    return ["Warning: Non-Genuine MongoDB Detected", "Telemetry is now disabled."];
+  }
+
+  updateTerminalData(data: string): string {
+    return filterAndCleanTerminalOutput(data, this._removeInfoText);
   }
 }

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/VCoreMongoShellHandler.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/VCoreMongoShellHandler.tsx
@@ -1,13 +1,10 @@
 import { userContext } from "../../../../UserContext";
+import { filterAndCleanTerminalOutput, getMongoShellRemoveInfoText } from "../Utils/CommonUtils";
 import { AbstractShellHandler, DISABLE_TELEMETRY_COMMAND } from "./AbstractShellHandler";
 
 export class VCoreMongoShellHandler extends AbstractShellHandler {
   private _endpoint: string | undefined;
-  private _textFilterRules: string[] = [
-    "For mongosh info see: https://www.mongodb.com/docs/mongodb-shell/",
-    "disableTelemetry() command",
-    "https://www.mongodb.com/legal/privacy-policy",
-  ];
+  private _removeInfoText: string[] = getMongoShellRemoveInfoText();
 
   constructor() {
     super();
@@ -38,12 +35,7 @@ export class VCoreMongoShellHandler extends AbstractShellHandler {
     return ["Warning: Non-Genuine MongoDB Detected", "Telemetry is now disabled."];
   }
 
-  updateTerminalData(content: string): string {
-    const updatedContent = content
-      .split("\n")
-      .filter((line) => !this._textFilterRules.some((part) => line.includes(part)))
-      .filter((line, idx, arr) => (arr.length > 3 && idx <= arr.length - 3 ? !["", "\r"].includes(line) : true)) // Filter out empty lines and carriage returns, but keep the last 3 lines if they exist
-      .join("\n");
-    return updatedContent;
+  updateTerminalData(data: string): string {
+    return filterAndCleanTerminalOutput(data, this._removeInfoText);
   }
 }

--- a/src/Explorer/Tabs/CloudShellTab/Utils/AttachAddOn.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/Utils/AttachAddOn.tsx
@@ -135,7 +135,11 @@ export class AttachAddon implements ITerminalAddon {
         }
 
         if (this._allowTerminalWrite) {
-          const updatedData = this._shellHandler?.updateTerminalData(data) ?? data;
+          const updatedData =
+            typeof this._shellHandler?.updateTerminalData === "function"
+              ? this._shellHandler.updateTerminalData(data)
+              : data;
+
           const suppressedData = this._shellHandler?.getTerminalSuppressedData();
 
           const shouldNotWrite = suppressedData.filter(Boolean).some((item) => updatedData.includes(item));

--- a/src/Explorer/Tabs/CloudShellTab/Utils/CommonUtils.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/Utils/CommonUtils.tsx
@@ -50,3 +50,34 @@ export const getShellNameForDisplay = (terminalKind: TerminalKind): string => {
       return "";
   }
 };
+
+/**
+ * Get MongoDB shell information text that should be removed from terminal output
+ */
+export const getMongoShellRemoveInfoText = (): string[] => {
+  return [
+    "For mongosh info see: https://www.mongodb.com/docs/mongodb-shell/",
+    "disableTelemetry() command",
+    "https://www.mongodb.com/legal/privacy-policy",
+  ];
+};
+
+export const filterAndCleanTerminalOutput = (data: string, removeInfoText: string[]): string => {
+  if (!data || removeInfoText.length === 0) {
+    return data;
+  }
+
+  const lines = data.split("\n");
+  const filteredLines: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const shouldRemove = removeInfoText.some((text) => line.includes(text));
+
+    if (!shouldRemove) {
+      filteredLines.push(line);
+    }
+  }
+
+  return filteredLines.join("\n").replace(/((\r\n)|\n|\r){2,}/g, "\r\n");
+};


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

## Summary
Mongo and Cassandra CloudShell terminals were hanging during initialization with the error:

This occurred because the **`AttachAddOn`** was calling `updateTerminalData` on shell handlers without checking if the method existed. Only `VCoreMongoShellHandler` had implemented this optional method, while `MongoShellHandler` and `CassandraShellHandler` were missing it.

## Solution
- Added defensive check in **AttachAddOn**: Added a type check before calling `updateTerminalData` to prevent runtime errors when the method doesn't exist
- Implemented missing method in **MongoShellHandler**: Added `updateTerminalData` method to filter out MongoDB informational text
- Created shared utilities: Extracted common MongoDB text filtering logic into reusable utility functions:
     - getMongoShellRemoveInfoText(): Returns array of text patterns to remove
     - filterAndCleanTerminalOutput(): Filters terminal output and cleans up formatting
- Refactored **VCoreMongoShellHandler**: Updated to use the new shared utility functions for consistency
- Updated tests: Fixed Jest mocks and updated test expectations to include the new "Telemetry is now disabled." message

## Testing screenshots

**MongoDB vCore API**
<img width="2409" height="1026" alt="Screenshot 2025-08-08 111205" src="https://github.com/user-attachments/assets/f97a9460-9b97-49d9-a8ea-81ff7adb9440" />

**MongoDB RU API**
<img width="2459" height="986" alt="Screenshot 2025-08-08 110948" src="https://github.com/user-attachments/assets/caddbc43-931b-4974-9eca-5a12b2ef3ec2" />

**Cassandra API**
<img width="2406" height="1016" alt="Screenshot 2025-08-08 112906" src="https://github.com/user-attachments/assets/5cbeb183-e81a-4d61-8df6-4b87dccac1d3" />

**Postgresql API**
<img width="2350" height="949" alt="Screenshot 2025-08-09 121729" src="https://github.com/user-attachments/assets/bfc06b58-2e30-4f37-8fcb-0b0739daf8e8" />
