### PR TITLE
Fix fairfax default cloud shell region.

### DIFF
--- a/src/Explorer/Tabs/CloudShellTab/CloudShellTerminalCore.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/CloudShellTerminalCore.tsx
@@ -22,6 +22,7 @@ import { formatErrorMessage, formatInfoMessage, formatWarningMessage } from "./U
 
 // Constants
 const DEFAULT_CLOUDSHELL_REGION = "westus";
+const DEFAULT_FAIRFAX_CLOUDSHELL_REGION = "usgovvirginia";
 const POLLING_INTERVAL_MS = 2000;
 const MAX_RETRY_COUNT = 10;
 const MAX_PING_COUNT = 120 * 60; // 120 minutes (60 seconds/minute)
@@ -153,7 +154,9 @@ export const ensureCloudShellProviderRegistered = async (): Promise<void> => {
  * Determines the appropriate CloudShell region
  */
 export const determineCloudShellRegion = (): string => {
-  return getNormalizedRegion(userContext.databaseAccount?.location, DEFAULT_CLOUDSHELL_REGION);
+  const defaultRegion =
+    userContext.portalEnv === "fairfax" ? DEFAULT_FAIRFAX_CLOUDSHELL_REGION : DEFAULT_CLOUDSHELL_REGION;
+  return getNormalizedRegion(userContext.databaseAccount?.location, defaultRegion);
 };
 
 /**

--- a/src/Explorer/Tabs/CloudShellTab/Utils/RegionUtils.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/Utils/RegionUtils.tsx
@@ -8,6 +8,8 @@ const validCloudShellRegions = new Set([
   "centralindia",
   "southeastasia",
   "westcentralus",
+  "usgovvirginia",
+  "usgovarizona",
 ]);
 
 /**


### PR DESCRIPTION
This pull request updates the logic for determining and validating CloudShell regions, with a particular focus on supporting the "fairfax" environment and US government regions. The main changes include adding new region constants, updating the region selection logic, and expanding the set of valid regions.

Region selection improvements:

* Added the `DEFAULT_FAIRFAX_CLOUDSHELL_REGION` constant to `CloudShellTerminalCore.tsx` to support the "fairfax" environment.
* Updated the `determineCloudShellRegion` function to select `usgovvirginia` as the default region when the portal environment is "fairfax", otherwise defaulting to `westus`.

Region validation updates:

* Added `usgovvirginia` and `usgovarizona` to the set of valid CloudShell regions in `RegionUtils.tsx`.

[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
