### PR TITLE
chore: Update help link in FabricHome component to point to the new documentation

### DIFF
--- a/src/Explorer/SplashScreen/FabricHome.tsx
+++ b/src/Explorer/SplashScreen/FabricHome.tsx
@@ -1,8 +1,8 @@
 /**
  * Accordion top class
  */
-import { makeStyles, tokens } from "@fluentui/react-components";
-import { DocumentAddRegular, LinkMultipleRegular } from "@fluentui/react-icons";
+import { Link, makeStyles, tokens } from "@fluentui/react-components";
+import { DocumentAddRegular, LinkMultipleRegular, OpenRegular } from "@fluentui/react-icons";
 import { SampleDataImportDialog } from "Explorer/SplashScreen/SampleDataImportDialog";
 import { CosmosFluentProvider } from "Explorer/Theme/ThemeUtil";
 import { isFabricNative, isFabricNativeReadOnly } from "Platform/Fabric/FabricUtil";
@@ -185,12 +185,14 @@ export const FabricHomeScreen: React.FC<SplashScreenProps> = (props: SplashScree
           {title}
         </div>
         {getSplashScreenButtons()}
-        {/* <div className={styles.footer}>
-          Need help?{" "}
-          <Link href="https://aka.ms/cosmosdbfabricdocs" target="_blank">
-            Learn more <img src={LinkIcon} alt="Learn more" />
-          </Link>
-        </div> */}
+        {
+          <div className={styles.footer}>
+            Need help?{" "}
+            <Link href="https://learn.microsoft.com/fabric/database/cosmos-db/overview" target="_blank">
+              Learn more <OpenRegular />
+            </Link>
+          </div>
+        }
       </CosmosFluentProvider>
     </>
   );


### PR DESCRIPTION
Fixes: [ADO](https://msdata.visualstudio.com/CosmosDB/_workitems/edit/4223825/)

[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2206?feature.someFeatureFlagYouMightNeed=true)


<img width="1552" height="906" alt="image" src="https://github.com/user-attachments/assets/51378c87-7240-42bd-b6c6-f6ce1670d562" />
