### PR TITLE
Commenting or deleting UI references to Query Advisor

### DIFF
--- a/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
+++ b/src/Explorer/Panes/SettingsPane/SettingsPane.tsx
@@ -1099,15 +1099,15 @@ export const SettingsPane: FunctionComponent<{ explorer: Explorer }> = ({
                   <div className={styles.settingsSectionContainer}>
                     <div className={styles.settingsSectionDescription}>
                       This is a sample database and collection with synthetic product data you can use to explore using
-                      NoSQL queries and Query Advisor. This will appear as another database in the Data Explorer UI, and
-                      is created by, and maintained by Microsoft at no cost to you.
+                      NoSQL queries. This will appear as another database in the Data Explorer UI, and is created by,
+                      and maintained by Microsoft at no cost to you.
                     </div>
                     <Checkbox
                       styles={{
                         label: { padding: 0 },
                       }}
                       className="padding"
-                      ariaLabel="Enable sample db for Query Advisor"
+                      ariaLabel="Enable sample db for query exploration"
                       checked={copilotSampleDBEnabled}
                       onChange={handleSampleDatabaseChange}
                       label="Enable sample database"

--- a/src/Explorer/QueryCopilot/QueryCopilotTab.tsx
+++ b/src/Explorer/QueryCopilot/QueryCopilotTab.tsx
@@ -11,7 +11,6 @@ import { QueryCopilotResults } from "Explorer/QueryCopilot/Shared/QueryCopilotRe
 import { userContext } from "UserContext";
 import { QueryCopilotState, useQueryCopilot } from "hooks/useQueryCopilot";
 import { useSidePanel } from "hooks/useSidePanel";
-import { ReactTabKind, TabsState, useTabs } from "hooks/useTabs";
 import React, { useState } from "react";
 import SplitterLayout from "react-splitter-layout";
 import QueryCommandIcon from "../../../images/CopilotCommand.svg";
@@ -24,7 +23,8 @@ export const QueryCopilotTab: React.FC<QueryCopilotProps> = ({ explorer }: Query
   const [copilotActive, setCopilotActive] = useState<boolean>(() =>
     readCopilotToggleStatus(userContext.databaseAccount),
   );
-  const [tabActive, setTabActive] = useState<boolean>(true);
+  //TODO: Uncomment this useState when query copilot is reinstated in DE
+  // const [tabActive, setTabActive] = useState<boolean>(true);
 
   const getCommandbarButtons = (): CommandButtonComponentProps[] => {
     const executeQueryBtnLabel = selectedQuery ? "Execute Selection" : "Execute Query";
@@ -68,17 +68,18 @@ export const QueryCopilotTab: React.FC<QueryCopilotProps> = ({ explorer }: Query
     useCommandBar.getState().setContextButtons(getCommandbarButtons());
   }, [query, selectedQuery, copilotActive]);
 
-  React.useEffect(() => {
-    return () => {
-      useTabs.subscribe((state: TabsState) => {
-        if (state.activeReactTab === ReactTabKind.QueryCopilot) {
-          setTabActive(true);
-        } else {
-          setTabActive(false);
-        }
-      });
-    };
-  }, []);
+  //TODO: Uncomment this effect when query copilot is reinstated in DE
+  // React.useEffect(() => {
+  //   return () => {
+  //     useTabs.subscribe((state: TabsState) => {
+  //       if (state.activeReactTab === ReactTabKind.QueryCopilot) {
+  //         setTabActive(true);
+  //       } else {
+  //         setTabActive(false);
+  //       }
+  //     });
+  //   };
+  // }, []);
 
   const toggleCopilot = (toggle: boolean) => {
     setCopilotActive(toggle);

--- a/src/Explorer/QueryCopilot/QueryCopilotTab.tsx
+++ b/src/Explorer/QueryCopilot/QueryCopilotTab.tsx
@@ -1,11 +1,9 @@
 /* eslint-disable no-console */
 import { Stack } from "@fluentui/react";
-import { QueryCopilotSampleContainerId, QueryCopilotSampleDatabaseId } from "Common/Constants";
 import { CommandButtonComponentProps } from "Explorer/Controls/CommandButton/CommandButtonComponent";
 import { EditorReact } from "Explorer/Controls/Editor/EditorReact";
 import { useCommandBar } from "Explorer/Menus/CommandBar/CommandBarComponentAdapter";
 import { SaveQueryPane } from "Explorer/Panes/SaveQueryPane/SaveQueryPane";
-import { QueryCopilotPromptbar } from "Explorer/QueryCopilot/QueryCopilotPromptbar";
 import { readCopilotToggleStatus, saveCopilotToggleStatus } from "Explorer/QueryCopilot/QueryCopilotUtilities";
 import { OnExecuteQueryClick } from "Explorer/QueryCopilot/Shared/QueryCopilotClient";
 import { QueryCopilotProps } from "Explorer/QueryCopilot/Shared/QueryCopilotInterfaces";
@@ -90,6 +88,7 @@ export const QueryCopilotTab: React.FC<QueryCopilotProps> = ({ explorer }: Query
   return (
     <Stack className="tab-pane" style={{ width: "100%" }}>
       <div style={isGeneratingQuery ? { height: "100%" } : { overflowY: "auto", height: "100%" }}>
+        {/*TODO: Uncomment this section when query copilot is reinstated in DE
         {tabActive && copilotActive && (
           <QueryCopilotPromptbar
             explorer={explorer}
@@ -97,7 +96,7 @@ export const QueryCopilotTab: React.FC<QueryCopilotProps> = ({ explorer }: Query
             databaseId={QueryCopilotSampleDatabaseId}
             containerId={QueryCopilotSampleContainerId}
           ></QueryCopilotPromptbar>
-        )}
+        )} */}
         <Stack className="tabPaneContentContainer">
           <SplitterLayout percentage={true} vertical={true} primaryIndex={0} primaryMinSize={30} secondaryMinSize={70}>
             <EditorReact

--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -24,6 +24,7 @@ import { ReactTabKind, useTabs } from "hooks/useTabs";
 import * as React from "react";
 import ConnectIcon from "../../../images/Connect_color.svg";
 import ContainersIcon from "../../../images/Containers.svg";
+import CosmosDBIcon from "../../../images/CosmosDB-logo.svg";
 import LinkIcon from "../../../images/Link_blue.svg";
 import PowerShellIcon from "../../../images/PowerShell.svg";
 import CopilotIcon from "../../../images/QueryCopilotNewLogo.svg";
@@ -120,6 +121,57 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
   };
 
   private getSplashScreenButtons = (): JSX.Element => {
+    if (userContext.apiType === "SQL") {
+      return (
+        <Stack
+          className="splashStackContainer"
+          style={{ width: "66%", cursor: "pointer", margin: "40px auto" }}
+          tokens={{ childrenGap: 16 }}
+        >
+          <Stack className="splashStackRow" horizontal>
+            <SplashScreenButton
+              imgSrc={QuickStartIcon}
+              title={"Launch quick start"}
+              description={"Launch a quick start tutorial to get started with sample data"}
+              onClick={() => {
+                this.container.onNewCollectionClicked({ isQuickstart: true });
+                traceOpen(Action.LaunchQuickstart, { apiType: userContext.apiType });
+              }}
+            />
+            <SplashScreenButton
+              imgSrc={ContainersIcon}
+              title={`New ${getCollectionName()}`}
+              description={"Create a new container for storage and throughput"}
+              onClick={() => {
+                this.container.onNewCollectionClicked();
+                traceOpen(Action.NewContainerHomepage, { apiType: userContext.apiType });
+              }}
+            />
+          </Stack>
+          <Stack className="splashStackRow" horizontal>
+            <SplashScreenButton
+              imgSrc={CosmosDBIcon}
+              imgSize={35}
+              title={"Azure Cosmos DB Samples Gallery"}
+              description={
+                "Discover samples that showcase scalable, intelligent app patterns. Try one now to see how fast you can go from concept to code with Cosmos DB"
+              }
+              onClick={() => {
+                window.open("https://azurecosmosdb.github.io/gallery/?tags=example", "_blank");
+                traceOpen(Action.LearningResourcesClicked, { apiType: userContext.apiType });
+              }}
+            />
+            <SplashScreenButton
+              imgSrc={ConnectIcon}
+              title={"Connect"}
+              description={"Prefer using your own choice of tooling? Find the connection string you need to connect"}
+              onClick={() => useTabs.getState().openAndActivateReactTab(ReactTabKind.Connect)}
+            />
+          </Stack>
+        </Stack>
+      );
+    }
+
     const mainItems = this.createMainItems();
     return (
       <div className="mainButtonsContainer">

--- a/src/Explorer/SplashScreen/SplashScreen.tsx
+++ b/src/Explorer/SplashScreen/SplashScreen.tsx
@@ -120,68 +120,6 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
   };
 
   private getSplashScreenButtons = (): JSX.Element => {
-    if (
-      userContext.apiType === "SQL" &&
-      useQueryCopilot.getState().copilotEnabled &&
-      useDatabases.getState().sampleDataResourceTokenCollection
-    ) {
-      return (
-        <Stack
-          className="splashStackContainer"
-          style={{ width: "66%", cursor: "pointer", margin: "40px auto" }}
-          tokens={{ childrenGap: 16 }}
-        >
-          <Stack className="splashStackRow" horizontal>
-            <SplashScreenButton
-              imgSrc={QuickStartIcon}
-              title={"Launch quick start"}
-              description={"Launch a quick start tutorial to get started with sample data"}
-              onClick={() => {
-                this.container.onNewCollectionClicked({ isQuickstart: true });
-                traceOpen(Action.LaunchQuickstart, { apiType: userContext.apiType });
-              }}
-            />
-            <SplashScreenButton
-              imgSrc={ContainersIcon}
-              title={`New ${getCollectionName()}`}
-              description={"Create a new container for storage and throughput"}
-              onClick={() => {
-                this.container.onNewCollectionClicked();
-                traceOpen(Action.NewContainerHomepage, { apiType: userContext.apiType });
-              }}
-            />
-          </Stack>
-          <Stack className="splashStackRow" horizontal>
-            {useQueryCopilot.getState().copilotEnabled && (
-              <SplashScreenButton
-                imgSrc={CopilotIcon}
-                title={"Query faster with Query Advisor"}
-                description={
-                  "Query Advisor is your AI buddy that helps you write Azure Cosmos DB queries like a pro. Try it using our sample data set now!"
-                }
-                onClick={() => {
-                  const copilotVersion = userContext.features.copilotVersion;
-                  if (copilotVersion === "v1.0") {
-                    useTabs.getState().openAndActivateReactTab(ReactTabKind.QueryCopilot);
-                  } else if (copilotVersion === "v2.0") {
-                    const sampleCollection = useDatabases.getState().sampleDataResourceTokenCollection;
-                    sampleCollection.onNewQueryClick(sampleCollection, undefined);
-                  }
-                  traceOpen(Action.OpenQueryCopilotFromSplashScreen, { apiType: userContext.apiType });
-                }}
-              />
-            )}
-            <SplashScreenButton
-              imgSrc={ConnectIcon}
-              title={"Connect"}
-              description={"Prefer using your own choice of tooling? Find the connection string you need to connect"}
-              onClick={() => useTabs.getState().openAndActivateReactTab(ReactTabKind.Connect)}
-            />
-          </Stack>
-        </Stack>
-      );
-    }
-
     const mainItems = this.createMainItems();
     return (
       <div className="mainButtonsContainer">
@@ -212,6 +150,7 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
               sample data, query.
             </TeachingBubble>
           )}
+        {/*TODO: convert below to use SplashScreenButton */}
         {mainItems.map((item) => (
           <Stack
             id={`mainButton-${item.id}`}
@@ -476,6 +415,34 @@ export class SplashScreen extends React.Component<SplashScreenProps> {
       onClick: onClick,
     };
   }
+
+  //TODO: Re-enable lint rule when query copilot is reinstated in DE
+  /* eslint-disable-next-line no-unused-vars */
+  private getQueryCopilotCard = (): JSX.Element => {
+    return (
+      <>
+        {useQueryCopilot.getState().copilotEnabled && (
+          <SplashScreenButton
+            imgSrc={CopilotIcon}
+            title={"Query faster with Query Advisor"}
+            description={
+              "Query Advisor is your AI buddy that helps you write Azure Cosmos DB queries like a pro. Try it using our sample data set now!"
+            }
+            onClick={() => {
+              const copilotVersion = userContext.features.copilotVersion;
+              if (copilotVersion === "v1.0") {
+                useTabs.getState().openAndActivateReactTab(ReactTabKind.QueryCopilot);
+              } else if (copilotVersion === "v2.0") {
+                const sampleCollection = useDatabases.getState().sampleDataResourceTokenCollection;
+                sampleCollection.onNewQueryClick(sampleCollection, undefined);
+              }
+              traceOpen(Action.OpenQueryCopilotFromSplashScreen, { apiType: userContext.apiType });
+            }}
+          />
+        )}
+      </>
+    );
+  };
 
   private decorateOpenCollectionActivity({ databaseId, collectionId }: MostRecentActivity.OpenCollectionItem) {
     return {

--- a/src/Explorer/SplashScreen/SplashScreenButton.tsx
+++ b/src/Explorer/SplashScreen/SplashScreenButton.tsx
@@ -7,6 +7,7 @@ interface SplashScreenButtonProps {
   title: string;
   description: string;
   onClick: () => void;
+  imgSize?: number;
 }
 
 export const SplashScreenButton: React.FC<SplashScreenButtonProps> = ({
@@ -14,6 +15,7 @@ export const SplashScreenButton: React.FC<SplashScreenButtonProps> = ({
   title,
   description,
   onClick,
+  imgSize,
 }: SplashScreenButtonProps): JSX.Element => {
   return (
     <Stack
@@ -39,7 +41,7 @@ export const SplashScreenButton: React.FC<SplashScreenButtonProps> = ({
       role="button"
     >
       <div>
-        <img src={imgSrc} alt={title} aria-hidden="true" />
+        <img src={imgSrc} alt={title} aria-hidden="true" {...(imgSize ? { height: imgSize, width: imgSize } : {})} />
       </div>
       <Stack style={{ marginLeft: 16 }}>
         <Text style={{ fontSize: 18, fontWeight: 600 }}>{title}</Text>

--- a/src/Explorer/Tabs/QueryTab/QueryTabComponent.test.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTabComponent.test.tsx
@@ -106,6 +106,6 @@ describe("QueryTabComponent", () => {
         <QueryTabCopilotComponent {...propsMock} />
       </CopilotProvider>,
     );
-    expect(container.find(QueryCopilotPromptbar).exists()).toBe(true);
+    expect(container.find(QueryCopilotPromptbar).exists()).toBe(false);
   });
 });

--- a/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
@@ -9,7 +9,6 @@ import { useDialog } from "Explorer/Controls/Dialog";
 import { monaco } from "Explorer/LazyMonaco";
 import { QueryCopilotFeedbackModal } from "Explorer/QueryCopilot/Modal/QueryCopilotFeedbackModal";
 import { useCopilotStore } from "Explorer/QueryCopilot/QueryCopilotContext";
-import { QueryCopilotPromptbar } from "Explorer/QueryCopilot/QueryCopilotPromptbar";
 import { readCopilotToggleStatus, saveCopilotToggleStatus } from "Explorer/QueryCopilot/QueryCopilotUtilities";
 import { OnExecuteQueryClick, QueryDocumentsPerPage } from "Explorer/QueryCopilot/Shared/QueryCopilotClient";
 import { QueryCopilotSidebar } from "Explorer/QueryCopilot/V2/Sidebar/QueryCopilotSidebar";
@@ -28,6 +27,9 @@ import { TabsState, useTabs } from "hooks/useTabs";
 import React, { Fragment, createRef } from "react";
 import "react-splitter-layout/lib/index.css";
 import { format } from "react-string-format";
+//TODO: Uncomment next two lines when query copilot is reinstated in DE
+// import QueryCommandIcon from "../../../../images/CopilotCommand.svg";
+// import LaunchCopilot from "../../../../images/CopilotTabIcon.svg";
 import DownloadQueryIcon from "../../../../images/DownloadQuery.svg";
 import CancelQueryIcon from "../../../../images/Entity_cancel.svg";
 import ExecuteQueryIcon from "../../../../images/ExecuteQuery.svg";
@@ -725,6 +727,7 @@ class QueryTabComponentImpl extends React.Component<QueryTabComponentImplProps, 
     return (
       <Fragment>
         <CosmosFluentProvider id={this.props.tabId} className={this.props.styles.queryTab} role="tabpanel">
+          {/*TODO: Uncomment this section when query copilot is reinstated in DE
           {this.props.copilotEnabled && this.state.currentTabActive && this.state.copilotActive && (
             <QueryCopilotPromptbar
               explorer={this.props.collection.container}
@@ -732,7 +735,7 @@ class QueryTabComponentImpl extends React.Component<QueryTabComponentImplProps, 
               databaseId={this.props.collection.databaseId}
               containerId={this.props.collection.id()}
             ></QueryCopilotPromptbar>
-          )}
+          )} */}
           {/* Set 'key' to the value of vertical to force re-rendering when vertical changes, to work around https://github.com/johnwalley/allotment/issues/457 */}
           <Allotment
             key={vertical.toString()}

--- a/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTabComponent.tsx
@@ -28,8 +28,6 @@ import { TabsState, useTabs } from "hooks/useTabs";
 import React, { Fragment, createRef } from "react";
 import "react-splitter-layout/lib/index.css";
 import { format } from "react-string-format";
-import QueryCommandIcon from "../../../../images/CopilotCommand.svg";
-import LaunchCopilot from "../../../../images/CopilotTabIcon.svg";
 import DownloadQueryIcon from "../../../../images/DownloadQuery.svg";
 import CancelQueryIcon from "../../../../images/Entity_cancel.svg";
 import ExecuteQueryIcon from "../../../../images/ExecuteQuery.svg";
@@ -494,53 +492,55 @@ class QueryTabComponentImpl extends React.Component<QueryTabComponentImplProps, 
       });
     }
 
-    if (this.launchCopilotButton.visible && this.isCopilotTabActive) {
-      const mainButtonLabel = "Launch Copilot";
-      const chatPaneLabel = "Open Copilot in chat pane (ALT+C)";
-      const copilotSettingLabel = "Copilot settings";
+    //TODO: Uncomment next section when query copilot is reinstated in DE
+    // if (this.launchCopilotButton.visible && this.isCopilotTabActive) {
+    //   const mainButtonLabel = "Launch Copilot";
+    //   const chatPaneLabel = "Open Copilot in chat pane (ALT+C)";
+    //   const copilotSettingLabel = "Copilot settings";
 
-      const openCopilotChatButton: CommandButtonComponentProps = {
-        iconAlt: chatPaneLabel,
-        onCommandClick: this.launchQueryCopilotChat,
-        commandButtonLabel: chatPaneLabel,
-        ariaLabel: chatPaneLabel,
-        hasPopup: false,
-      };
+    //   const openCopilotChatButton: CommandButtonComponentProps = {
+    //     iconAlt: chatPaneLabel,
+    //     onCommandClick: this.launchQueryCopilotChat,
+    //     commandButtonLabel: chatPaneLabel,
+    //     ariaLabel: chatPaneLabel,
+    //     hasPopup: false,
+    //   };
 
-      const copilotSettingsButton: CommandButtonComponentProps = {
-        iconAlt: copilotSettingLabel,
-        onCommandClick: () => undefined,
-        commandButtonLabel: copilotSettingLabel,
-        ariaLabel: copilotSettingLabel,
-        hasPopup: false,
-      };
+    //   const copilotSettingsButton: CommandButtonComponentProps = {
+    //     iconAlt: copilotSettingLabel,
+    //     onCommandClick: () => undefined,
+    //     commandButtonLabel: copilotSettingLabel,
+    //     ariaLabel: copilotSettingLabel,
+    //     hasPopup: false,
+    //   };
 
-      const launchCopilotButton: CommandButtonComponentProps = {
-        iconSrc: LaunchCopilot,
-        iconAlt: mainButtonLabel,
-        onCommandClick: this.launchQueryCopilotChat,
-        commandButtonLabel: mainButtonLabel,
-        ariaLabel: mainButtonLabel,
-        hasPopup: false,
-        children: [openCopilotChatButton, copilotSettingsButton],
-      };
-      buttons.push(launchCopilotButton);
-    }
+    //   const launchCopilotButton: CommandButtonComponentProps = {
+    //     iconSrc: LaunchCopilot,
+    //     iconAlt: mainButtonLabel,
+    //     onCommandClick: this.launchQueryCopilotChat,
+    //     commandButtonLabel: mainButtonLabel,
+    //     ariaLabel: mainButtonLabel,
+    //     hasPopup: false,
+    //     children: [openCopilotChatButton, copilotSettingsButton],
+    //   };
+    //   buttons.push(launchCopilotButton);
+    // }
 
-    if (this.props.copilotEnabled) {
-      const toggleCopilotButton: CommandButtonComponentProps = {
-        iconSrc: QueryCommandIcon,
-        iconAlt: "Query Advisor",
-        keyboardAction: KeyboardAction.TOGGLE_COPILOT,
-        onCommandClick: () => {
-          this._toggleCopilot(!this.state.copilotActive);
-        },
-        commandButtonLabel: this.state.copilotActive ? "Disable Query Advisor" : "Enable Query Advisor",
-        ariaLabel: this.state.copilotActive ? "Disable Query Advisor" : "Enable Query Advisor",
-        hasPopup: false,
-      };
-      buttons.push(toggleCopilotButton);
-    }
+    //TODO: Uncomment next section when query copilot is reinstated in DE
+    // if (this.props.copilotEnabled) {
+    //   const toggleCopilotButton: CommandButtonComponentProps = {
+    //     iconSrc: QueryCommandIcon,
+    //     iconAlt: "Query Advisor",
+    //     keyboardAction: KeyboardAction.TOGGLE_COPILOT,
+    //     onCommandClick: () => {
+    //       this._toggleCopilot(!this.state.copilotActive);
+    //     },
+    //     commandButtonLabel: this.state.copilotActive ? "Disable Query Advisor" : "Enable Query Advisor",
+    //     ariaLabel: this.state.copilotActive ? "Disable Query Advisor" : "Enable Query Advisor",
+    //     hasPopup: false,
+    //   };
+    //   buttons.push(toggleCopilotButton);
+    // }
 
     if (!this.props.isPreferredApiMongoDB && this.state.isExecuting) {
       const label = "Cancel query";


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2209)

This PR hides any instance of Query Advisor (known internally as Query Copilot). However, none of the functionality was removed. In fact, it is likely that this feature will be reintroduced. So I have opted to comment references rather than delete them. A major reason to comment as opposed to delete is that often, there are some checks or conditions which might not be obvious to a future dev who reinstates this feature.

The following areas are affected with a screenshot of the old then the new:
Splash screen
<img width="809" height="500" alt="image" src="https://github.com/user-attachments/assets/2dbc8824-c831-487b-a5fd-8a2bb5aec5c8" />
<img width="842" height="514" alt="image" src="https://github.com/user-attachments/assets/97a3daf2-1c55-4906-a7fe-6e033c62ad99" />

Settings
<img width="384" height="232" alt="image" src="https://github.com/user-attachments/assets/8618b4dc-bce0-4e17-b836-e1697f1cdf82" />
<img width="370" height="206" alt="image" src="https://github.com/user-attachments/assets/53011fa5-b3a2-4ebd-8fb2-5a6e1dff2d45" />

Query tab
<img width="649" height="208" alt="image" src="https://github.com/user-attachments/assets/0dacf579-43fa-416d-adde-68d72a238166" />
<img width="462" height="147" alt="image" src="https://github.com/user-attachments/assets/31dece31-01cf-4096-a7b0-bca425cc2c76" />


