### PR TITLE
Support RBAC in E2E tests for Mongo & Cassandra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,20 +198,18 @@ jobs:
             GREMLIN_TESTACCOUNT_TOKEN=$(az account get-access-token --scope "https://github-e2etests-gremlin.documents.azure.com/.default" -o tsv --query accessToken)
             echo "::add-mask::$GREMLIN_TESTACCOUNT_TOKEN"
             echo GREMLIN_TESTACCOUNT_TOKEN=$GREMLIN_TESTACCOUNT_TOKEN >> $GITHUB_ENV
-
             CASSANDRA_TESTACCOUNT_TOKEN=$(az account get-access-token --scope "https://github-e2etests-cassandra.documents.azure.com/.default" -o tsv --query accessToken)
             echo "::add-mask::$CASSANDRA_TESTACCOUNT_TOKEN"
             echo CASSANDRA_TESTACCOUNT_TOKEN=$CASSANDRA_TESTACCOUNT_TOKEN >> $GITHUB_ENV
-
-            # MONGO_TESTACCOUNT_TOKEN=$(az account get-access-token --scope "https://github-e2etests-mongo.documents.azure.com/.default" -o tsv --query accessToken)
-            # echo "::add-mask::$MONGO_TESTACCOUNT_TOKEN"
-            # echo MONGO_TESTACCOUNT_TOKEN=$MONGO_TESTACCOUNT_TOKEN >> $GITHUB_ENV
-            # MONGO32_TESTACCOUNT_TOKEN=$(az account get-access-token --scope "https://github-e2etests-mongo32.documents.azure.com/.default" -o tsv --query accessToken)
-            # echo "::add-mask::$MONGO32_TESTACCOUNT_TOKEN"
-            # echo MONGO32_TESTACCOUNT_TOKEN=$MONGO32_TESTACCOUNT_TOKEN >> $GITHUB_ENV
-            # MONGO_READONLY_TESTACCOUNT_TOKEN=$(az account get-access-token --scope "https://github-e2etests-mongo-readonly.documents.azure.com/.default" -o tsv --query accessToken)
-            # echo "::add-mask::$MONGO_READONLY_TESTACCOUNT_TOKEN"
-            # echo MONGO_READONLY_TESTACCOUNT_TOKEN=$MONGO_READONLY_TESTACCOUNT_TOKEN >> $GITHUB_ENV
+            MONGO_TESTACCOUNT_TOKEN=$(az account get-access-token --scope "https://github-e2etests-mongo.documents.azure.com/.default" -o tsv --query accessToken)
+            echo "::add-mask::$MONGO_TESTACCOUNT_TOKEN"
+            echo MONGO_TESTACCOUNT_TOKEN=$MONGO_TESTACCOUNT_TOKEN >> $GITHUB_ENV
+            MONGO32_TESTACCOUNT_TOKEN=$(az account get-access-token --scope "https://github-e2etests-mongo32.documents.azure.com/.default" -o tsv --query accessToken)
+            echo "::add-mask::$MONGO32_TESTACCOUNT_TOKEN"
+            echo MONGO32_TESTACCOUNT_TOKEN=$MONGO32_TESTACCOUNT_TOKEN >> $GITHUB_ENV
+            MONGO_READONLY_TESTACCOUNT_TOKEN=$(az account get-access-token --scope "https://github-e2etests-mongo-readonly.documents.azure.com/.default" -o tsv --query accessToken)
+            echo "::add-mask::$MONGO_READONLY_TESTACCOUNT_TOKEN"
+            echo MONGO_READONLY_TESTACCOUNT_TOKEN=$MONGO_READONLY_TESTACCOUNT_TOKEN >> $GITHUB_ENV
       - name: Run test shard ${{ matrix['shardIndex'] }} of ${{ matrix['shardTotal']}}
         run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers=3
       - name: Upload blob report to GitHub Actions Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,20 @@ jobs:
             GREMLIN_TESTACCOUNT_TOKEN=$(az account get-access-token --scope "https://github-e2etests-gremlin.documents.azure.com/.default" -o tsv --query accessToken)
             echo "::add-mask::$GREMLIN_TESTACCOUNT_TOKEN"
             echo GREMLIN_TESTACCOUNT_TOKEN=$GREMLIN_TESTACCOUNT_TOKEN >> $GITHUB_ENV
+
+            CASSANDRA_TESTACCOUNT_TOKEN=$(az account get-access-token --scope "https://github-e2etests-cassandra.documents.azure.com/.default" -o tsv --query accessToken)
+            echo "::add-mask::$CASSANDRA_TESTACCOUNT_TOKEN"
+            echo CASSANDRA_TESTACCOUNT_TOKEN=$CASSANDRA_TESTACCOUNT_TOKEN >> $GITHUB_ENV
+
+            # MONGO_TESTACCOUNT_TOKEN=$(az account get-access-token --scope "https://github-e2etests-mongo.documents.azure.com/.default" -o tsv --query accessToken)
+            # echo "::add-mask::$MONGO_TESTACCOUNT_TOKEN"
+            # echo MONGO_TESTACCOUNT_TOKEN=$MONGO_TESTACCOUNT_TOKEN >> $GITHUB_ENV
+            # MONGO32_TESTACCOUNT_TOKEN=$(az account get-access-token --scope "https://github-e2etests-mongo32.documents.azure.com/.default" -o tsv --query accessToken)
+            # echo "::add-mask::$MONGO32_TESTACCOUNT_TOKEN"
+            # echo MONGO32_TESTACCOUNT_TOKEN=$MONGO32_TESTACCOUNT_TOKEN >> $GITHUB_ENV
+            # MONGO_READONLY_TESTACCOUNT_TOKEN=$(az account get-access-token --scope "https://github-e2etests-mongo-readonly.documents.azure.com/.default" -o tsv --query accessToken)
+            # echo "::add-mask::$MONGO_READONLY_TESTACCOUNT_TOKEN"
+            # echo MONGO_READONLY_TESTACCOUNT_TOKEN=$MONGO_READONLY_TESTACCOUNT_TOKEN >> $GITHUB_ENV
       - name: Run test shard ${{ matrix['shardIndex'] }} of ${{ matrix['shardTotal']}}
         run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers=3
       - name: Upload blob report to GitHub Actions Artifacts

--- a/test/fx.ts
+++ b/test/fx.ts
@@ -110,6 +110,30 @@ export async function getTestExplorerUrl(accountType: TestAccount, iframeSrc?: s
     params.set("enableaaddataplane", "true");
   }
 
+  const cassandraRbacToken = process.env.CASSANDRA_TESTACCOUNT_TOKEN;
+  if (cassandraRbacToken) {
+    params.set("cassandraRbacToken", cassandraRbacToken);
+    params.set("enableaaddataplane", "true");
+  }
+
+  const mongoRbacToken = process.env.MONGO_TESTACCOUNT_TOKEN;
+  if (mongoRbacToken) {
+    params.set("mongoRbacToken", mongoRbacToken);
+    params.set("enableaaddataplane", "true");
+  }
+
+  const mongo32RbacToken = process.env.MONGO32_TESTACCOUNT_TOKEN;
+  if (mongo32RbacToken) {
+    params.set("mongo32RbacToken", mongo32RbacToken);
+    params.set("enableaaddataplane", "true");
+  }
+
+  const mongoReadOnlyRbacToken = process.env.MONGO_READONLY_TESTACCOUNT_TOKEN;
+  if (mongoReadOnlyRbacToken) {
+    params.set("mongoReadOnlyRbacToken", mongoReadOnlyRbacToken);
+    params.set("enableaaddataplane", "true");
+  }
+
   if (iframeSrc) {
     params.set("iframeSrc", iframeSrc);
   }

--- a/test/fx.ts
+++ b/test/fx.ts
@@ -87,51 +87,70 @@ export async function getTestExplorerUrl(accountType: TestAccount, iframeSrc?: s
   params.set("feature.enableCopilot", "false");
 
   const nosqlRbacToken = process.env.NOSQL_TESTACCOUNT_TOKEN;
-  if (nosqlRbacToken) {
-    params.set("nosqlRbacToken", nosqlRbacToken);
-    params.set("enableaaddataplane", "true");
-  }
-
   const nosqlReadOnlyRbacToken = process.env.NOSQL_READONLY_TESTACCOUNT_TOKEN;
-  if (nosqlReadOnlyRbacToken) {
-    params.set("nosqlReadOnlyRbacToken", nosqlReadOnlyRbacToken);
-    params.set("enableaaddataplane", "true");
-  }
-
   const tableRbacToken = process.env.TABLE_TESTACCOUNT_TOKEN;
-  if (tableRbacToken) {
-    params.set("tableRbacToken", tableRbacToken);
-    params.set("enableaaddataplane", "true");
-  }
-
   const gremlinRbacToken = process.env.GREMLIN_TESTACCOUNT_TOKEN;
-  if (gremlinRbacToken) {
-    params.set("gremlinRbacToken", gremlinRbacToken);
-    params.set("enableaaddataplane", "true");
-  }
-
   const cassandraRbacToken = process.env.CASSANDRA_TESTACCOUNT_TOKEN;
-  if (cassandraRbacToken) {
-    params.set("cassandraRbacToken", cassandraRbacToken);
-    params.set("enableaaddataplane", "true");
-  }
-
   const mongoRbacToken = process.env.MONGO_TESTACCOUNT_TOKEN;
-  if (mongoRbacToken) {
-    params.set("mongoRbacToken", mongoRbacToken);
-    params.set("enableaaddataplane", "true");
-  }
-
   const mongo32RbacToken = process.env.MONGO32_TESTACCOUNT_TOKEN;
-  if (mongo32RbacToken) {
-    params.set("mongo32RbacToken", mongo32RbacToken);
-    params.set("enableaaddataplane", "true");
-  }
-
   const mongoReadOnlyRbacToken = process.env.MONGO_READONLY_TESTACCOUNT_TOKEN;
-  if (mongoReadOnlyRbacToken) {
-    params.set("mongoReadOnlyRbacToken", mongoReadOnlyRbacToken);
-    params.set("enableaaddataplane", "true");
+
+  switch (accountType) {
+    case TestAccount.SQL:
+      if (nosqlRbacToken) {
+        params.set("nosqlRbacToken", nosqlRbacToken);
+        params.set("enableaaddataplane", "true");
+      }
+      break;
+
+    case TestAccount.SQLReadOnly:
+      if (nosqlReadOnlyRbacToken) {
+        params.set("nosqlReadOnlyRbacToken", nosqlReadOnlyRbacToken);
+        params.set("enableaaddataplane", "true");
+      }
+      break;
+
+    case TestAccount.Tables:
+      if (tableRbacToken) {
+        params.set("tableRbacToken", tableRbacToken);
+        params.set("enableaaddataplane", "true");
+      }
+      break;
+
+    case TestAccount.Gremlin:
+      if (gremlinRbacToken) {
+        params.set("gremlinRbacToken", gremlinRbacToken);
+        params.set("enableaaddataplane", "true");
+      }
+      break;
+
+    case TestAccount.Cassandra:
+      if (cassandraRbacToken) {
+        params.set("cassandraRbacToken", cassandraRbacToken);
+        params.set("enableaaddataplane", "true");
+      }
+      break;
+
+    case TestAccount.Mongo:
+      if (mongoRbacToken) {
+        params.set("mongoRbacToken", mongoRbacToken);
+        params.set("enableaaddataplane", "true");
+      }
+      break;
+
+    case TestAccount.Mongo32:
+      if (mongo32RbacToken) {
+        params.set("mongo32RbacToken", mongo32RbacToken);
+        params.set("enableaaddataplane", "true");
+      }
+      break;
+
+    case TestAccount.MongoReadonly:
+      if (mongoReadOnlyRbacToken) {
+        params.set("mongoReadOnlyRbacToken", mongoReadOnlyRbacToken);
+        params.set("enableaaddataplane", "true");
+      }
+      break;
   }
 
   if (iframeSrc) {

--- a/test/testExplorer/TestExplorer.ts
+++ b/test/testExplorer/TestExplorer.ts
@@ -18,6 +18,13 @@ const nosqlReadOnlyRbacToken =
 const tableRbacToken = urlSearchParams.get("tableRbacToken") || process.env.TABLE_TESTACCOUNT_TOKEN || "";
 const gremlinRbacToken = urlSearchParams.get("gremlinRbacToken") || process.env.GREMLIN_TESTACCOUNT_TOKEN || "";
 
+const cassandraRbacToken = urlSearchParams.get("cassandraRbacToken") || process.env.CASSANDRA_TESTACCOUNT_TOKEN || "";
+
+const mongoRbacToken = urlSearchParams.get("mongoRbacToken") || process.env.MONGO_TESTACCOUNT_TOKEN || "";
+const mongo32RbacToken = urlSearchParams.get("mongo32RbacToken") || process.env.MONGO32_TESTACCOUNT_TOKEN || "";
+const mongoReadOnlyRbacToken =
+  urlSearchParams.get("mongoReadOnlyRbacToken") || process.env.MONGO_READONLY_TESTACCOUNT_TOKEN || "";
+
 const initTestExplorer = async (): Promise<void> => {
   updateUserContext({
     authorizationToken: `bearer ${authToken}`,
@@ -40,6 +47,18 @@ const initTestExplorer = async (): Promise<void> => {
       break;
     case "tables":
       rbacToken = tableRbacToken;
+      break;
+    case "cassandra":
+      rbacToken = cassandraRbacToken;
+      break;
+    case "mongo":
+      rbacToken = mongoRbacToken;
+      break;
+    case "mongo32":
+      rbacToken = mongo32RbacToken;
+      break;
+    case "mongo-readonly":
+      rbacToken = mongoReadOnlyRbacToken;
       break;
   }
 


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2220?feature.someFeatureFlagYouMightNeed=true)

This change adds support for using RBAC in the playwright tests that target MongoDB and Cassandra API accounts.

