### PR TITLE
Updating Cosmos DB JS SDK to 4.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@azure/arm-cosmosdb": "9.1.0",
-        "@azure/cosmos": "4.5.0",
+        "@azure/cosmos": "4.7.0",
         "@azure/cosmos-language-service": "0.0.5",
         "@azure/identity": "4.5.0",
         "@azure/msal-browser": "2.14.2",
@@ -391,9 +391,9 @@
       "license": "0BSD"
     },
     "node_modules/@azure/cosmos": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-4.5.0.tgz",
-      "integrity": "sha512-JsTh4twb6FcwP7rJwxQiNZQ/LGtuF6gmciaxY9Rnp6/A325Lhsw/SH4R2ArpT0yCvozbZpweIwdPfUkXVBtp5w==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-4.7.0.tgz",
+      "integrity": "sha512-a8OV7E41u/ZDaaaDAFdqTTiJ7c82jZc/+ot3XzNCIIilR25NBB+1ixzWQOAgP8SHRUIKfaUl6wAPdTuiG9I66A==",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "@azure/arm-cosmosdb": "9.1.0",
-    "@azure/cosmos": "4.5.0",
+    "@azure/cosmos": "4.7.0",
     "@azure/cosmos-language-service": "0.0.5",
     "@azure/identity": "4.5.0",
     "@azure/msal-browser": "2.14.2",


### PR DESCRIPTION
This should enable PPAF auto-detection. Meaning when a partition in region A is marked as failed, DE (via SDK) should automatically detect that the partition has failed and retries saves on the partition in region B.

[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2243)
