### PR TITLE
Removed broken feature to display PR url in DE console

### DIFF
--- a/preview/index.js
+++ b/preview/index.js
@@ -7,7 +7,6 @@ const backendEndpoint = "https://cdb-ms-mpac-pbe.cosmos.azure.com";
 const previewSiteEndpoint = "https://dataexplorer-preview.azurewebsites.net";
 const previewStorageWebsiteEndpoint = "https://dataexplorerpreview.z5.web.core.windows.net/";
 const githubApiUrl = "https://api.github.com/repos/Azure/cosmos-explorer";
-const githubPullRequestUrl = "https://github.com/Azure/cosmos-explorer/pull";
 const azurePortalMpacEndpoint = "https://ms.portal.azure.com/";
 
 const api = createProxyMiddleware({
@@ -57,11 +56,7 @@ app.get("/pull/:pr(\\d+)", (req, res) => {
 
   fetch(`${githubApiUrl}/pulls/${pr}`)
     .then((response) => response.json())
-    .then(({ head: { ref, sha } }) => {
-      const prUrl = new URL(`${githubPullRequestUrl}/${pr}`);
-      prUrl.hash = ref;
-      search.set("feature.pr", prUrl.href);
-
+    .then(({ head: { sha } }) => {
       const explorer = new URL(`${previewSiteEndpoint}/commit/${sha}/explorer.html`);
       explorer.search = search.toString();
 

--- a/src/Explorer/Menus/NotificationConsole/NotificationConsoleComponent.tsx
+++ b/src/Explorer/Menus/NotificationConsole/NotificationConsoleComponent.tsx
@@ -16,7 +16,6 @@ import InfoIcon from "../../../../images/info_color.svg";
 import LoadingIcon from "../../../../images/loading.svg";
 import WarningIcon from "../../../../images/warning.svg";
 import { ClientDefaults, KeyCodes } from "../../../Common/Constants";
-import { userContext } from "../../../UserContext";
 import { useNotificationConsole } from "../../../hooks/useNotificationConsole";
 import { ConsoleData, ConsoleDataType } from "./ConsoleData";
 
@@ -127,7 +126,6 @@ export class NotificationConsoleComponent extends React.Component<
                 <span className="numWarningItems">{numWarningItems}</span>
               </span>
             </span>
-            {userContext.features.pr && <PrPreview pr={userContext.features.pr} />}
             <span className="consoleSplitter" />
             <span className="headerStatus">
               <span className="headerStatusEllipsis" aria-live="assertive" aria-atomic="true">
@@ -292,21 +290,6 @@ export class NotificationConsoleComponent extends React.Component<
     );
   };
 }
-
-const PrPreview = (props: { pr: string }) => {
-  const url = new URL(props.pr);
-  const [, ref] = url.hash.split("#");
-  url.hash = "";
-
-  return (
-    <>
-      <span className="consoleSplitter" />
-      <a target="_blank" rel="noreferrer" href={url.href} style={{ marginRight: "1em", fontWeight: "bold" }}>
-        {ref}
-      </a>
-    </>
-  );
-};
 
 export const NotificationConsole: React.FC = () => {
   const setIsExpanded = useNotificationConsole((state) => state.setIsExpanded);

--- a/src/Platform/Hosted/extractFeatures.ts
+++ b/src/Platform/Hosted/extractFeatures.ts
@@ -25,7 +25,6 @@ export type Features = {
   readonly notebookServerUrl?: string;
   readonly sandboxNotebookOutputs: boolean;
   readonly selfServeType?: string;
-  readonly pr?: string;
   readonly showMinRUSurvey: boolean;
   readonly ttl90Days: boolean;
   readonly mongoProxyEndpoint?: string;
@@ -96,7 +95,6 @@ export function extractFeatures(given = new URLSearchParams(window.location.sear
     notebookServerUrl: get("notebookserverurl"),
     sandboxNotebookOutputs: "true" === get("sandboxnotebookoutputs", "true"),
     selfServeType: get("selfservetype"),
-    pr: get("pr"),
     showMinRUSurvey: "true" === get("showminrusurvey"),
     ttl90Days: "true" === get("ttl90days"),
     autoscaleDefault: "true" === get("autoscaledefault"),


### PR DESCRIPTION
This removes a control which shows the link back to the PR which is supposed to show when running DE as a result of clicking on the Preview link (like the one in this PR :) ). It would look like this:
<img width="672" height="334" alt="image" src="https://github.com/user-attachments/assets/8cb7a177-f0a6-46e6-8eba-5669db04ce0c" />

However, this probably doesn't look familiar as I don't know when this last work, if ever. Because the URL to github wasn't being validated, it was marked as a security issue so I took the whole feature out. I decided to remove because I don't think this would add any value to anyone.

[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2249)
