### PR TITLE
Fix: better error handling and error message display

### DIFF
--- a/src/Common/ErrorHandlingUtils.ts
+++ b/src/Common/ErrorHandlingUtils.ts
@@ -23,7 +23,10 @@ export const handleError = (error: string | ARMError | Error, area: string, cons
 };
 
 export const getErrorMessage = (error: string | Error = ""): string => {
-  const errorMessage = typeof error === "string" ? error : error.message;
+  let errorMessage = typeof error === "string" ? error : error.message;
+  if (!errorMessage) {
+    errorMessage = JSON.stringify(error);
+  }
   return replaceKnownError(errorMessage);
 };
 


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2253)

The SDK error does not conform to a the typical `error` object emitted which contains the error message in `error.message`. In this case, `error.message` is `''`.

If there is no error message (either `''` or `undefined`), we return the entire JSON stringified string.
This shouldn't break the logic that follows to replace known errors.