### PR TITLE
fix: for fabric, don't display "Querying offer for collection"

### DIFF
--- a/src/Common/dataAccess/readCollectionOffer.ts
+++ b/src/Common/dataAccess/readCollectionOffer.ts
@@ -12,12 +12,12 @@ import { handleError } from "../ErrorHandlingUtils";
 import { readOfferWithSDK } from "./readOfferWithSDK";
 
 export const readCollectionOffer = async (params: ReadCollectionOfferParams): Promise<Offer> => {
-  const clearMessage = logConsoleProgress(`Querying offer for collection ${params.collectionId}`);
-
   if (isFabric()) {
     // Not exposing offers in Fabric
     return undefined;
   }
+
+  const clearMessage = logConsoleProgress(`Querying offer for collection ${params.collectionId}`);
 
   try {
     if (


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Users report "Querying for collection..." that keeps spinning when opening settings.
For Fabric, we bypass this logic, but the bug was that we let the code display the status which would never be cleared.

<img width="600" height="210" alt="image" src="https://github.com/user-attachments/assets/a9f23fd4-8c40-4e11-a511-541e5a097643" />
