### PR TITLE
Add default job name suggestion for container copy operations

### DIFF
--- a/src/Explorer/ContainerCopy/CreateCopyJob/Screens/PreviewCopyJob/PreviewCopyJob.tsx
+++ b/src/Explorer/ContainerCopy/CreateCopyJob/Screens/PreviewCopyJob/PreviewCopyJob.tsx
@@ -1,8 +1,9 @@
 import { DetailsList, DetailsListLayoutMode, Stack, Text, TextField } from "@fluentui/react";
-import FieldRow from "Explorer/ContainerCopy/CreateCopyJob/Screens/Components/FieldRow";
-import React from "react";
+import React, { useEffect } from "react";
 import ContainerCopyMessages from "../../../ContainerCopyMessages";
 import { useCopyJobContext } from "../../../Context/CopyJobContext";
+import { getDefaultJobName } from "../../../CopyJobUtils";
+import FieldRow from "../Components/FieldRow";
 import { getPreviewCopyJobDetailsListColumns } from "./Utils/PreviewCopyJobUtils";
 
 const PreviewCopyJob: React.FC = () => {
@@ -16,6 +17,11 @@ const PreviewCopyJob: React.FC = () => {
       targetContainerName: copyJobState.target?.containerId,
     },
   ];
+
+  useEffect(() => {
+    onJobNameChange(undefined, getDefaultJobName(selectedDatabaseAndContainers));
+  }, []);
+
   const jobName = copyJobState.jobName;
 
   const onJobNameChange = (_ev?: React.FormEvent, newValue?: string) => {

--- a/src/Explorer/ContainerCopy/CreateCopyJob/Utils/useCreateCopyJobScreensList.tsx
+++ b/src/Explorer/ContainerCopy/CreateCopyJob/Utils/useCreateCopyJobScreensList.tsx
@@ -56,7 +56,7 @@ function useCreateCopyJobScreensList() {
         validations: [
           {
             validate: (state: CopyJobContextState) =>
-              !!(typeof state?.jobName === "string" && state?.jobName && /^[a-zA-Z0-9-.]+$/.test(state?.jobName)),
+              !!(typeof state?.jobName === "string" && state?.jobName && /^[a-zA-Z0-9-._]+$/.test(state?.jobName)),
             message: "Please enter a job name to proceed",
           },
         ],

--- a/src/Explorer/ContainerCopy/containerCopyStyles.less
+++ b/src/Explorer/ContainerCopy/containerCopyStyles.less
@@ -118,8 +118,9 @@
 
         .jobNameLink {
           color: @LinkColor;
-          text-decoration: underline;
-          cursor: pointer;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          overflow: hidden;
         }
       }
     }


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2266?feature.someFeatureFlagYouMightNeed=true)

## Summary
Implements auto-generation of default job names in the container copy workflow to improve user experience and reduce manual input errors.

## New Default Job Name Generation
- Added `getDefaultJobName()` function that generates meaningful job names using the pattern: 
    - `{sourceDb}.{sourceContainer}_{targetDb}.{targetContainer}_{timestamp}`
- Database and container names are truncated to **5** characters for brevity
- Timestamp ensures uniqueness for each job

## Utility Functions
- Added `isEqual()` helper function to compare job arrays by name and status
- Added `truncateName()` helper for consistent name truncation

## Screenshot
<img width="2476" height="1442" alt="Screenshot 2025-11-26 130056" src="https://github.com/user-attachments/assets/bcd3fcb9-beb2-416f-85cf-75b01bd9963d" />
