### PR TITLE
Exclude the obj directory when creating the Nuget packages.

### DIFF
--- a/DataExplorer.nuspec
+++ b/DataExplorer.nuspec
@@ -19,6 +19,6 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="**\*" target="content"/>
+    <file src="**\*" exclude="obj\**\*" target="content"/>
   </files>
 </package>


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2277?feature.someFeatureFlagYouMightNeed=true)

This change excludes the obj folder that is created during the build, from the Nuget packages that are produced.
