### PR TITLE
fix: Add SidePanel component back to Container Copy feature

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -125,7 +125,10 @@ const App = (): JSX.Element => {
       <KeyboardShortcutRoot>
         <div className="flexContainer" aria-hidden="false">
           {userContext.features.enableContainerCopy && userContext.apiType === "SQL" ? (
-            <ContainerCopyPanel explorer={explorer} />
+            <>
+              <ContainerCopyPanel explorer={explorer} />
+              <SidePanel />
+            </>
           ) : (
             <DivExplorer explorer={explorer} />
           )}


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2295?feature.someFeatureFlagYouMightNeed=true)

## Description
The Container Copy feature depends on the `SidePanel` component, but during the `Dark Theme PR`, the SidePanel component was moved and only remained in the Explorer component. This caused the Container Copy feature to be missing its required SidePanel dependency when enabled.

### Changes
- Modified `src/Main.tsx` to include `<SidePanel />` alongside `<ContainerCopyPanel />` when Container Copy feature is enabled
