### PR TITLE
Fixed homepage UI for fabric

### DIFF
--- a/less/documentDBFabric.less
+++ b/less/documentDBFabric.less
@@ -44,9 +44,6 @@ a:focus {
 .nav-tabs-margin {
   padding-top: 0px;
   background-color: #ffffff;
-   .nav-tabs {
-    background: none;
-}
 }
 
 .commandBarContainer {


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2234?feature.someFeatureFlagYouMightNeed=true)

Home page layout was not cantered for fabric
<img width="1905" height="938" alt="image" src="https://github.com/user-attachments/assets/8ded6e40-80cf-4cec-a139-df3f90fd68ef" />
