### PR TITLE
updated the feature value to hardcode true

### DIFF
--- a/src/Platform/Hosted/extractFeatures.ts
+++ b/src/Platform/Hosted/extractFeatures.ts
@@ -94,7 +94,7 @@ export function extractFeatures(given = new URLSearchParams(window.location.sear
     notebookBasePath: get("notebookbasepath"),
     notebookServerToken: get("notebookservertoken"),
     notebookServerUrl: get("notebookserverurl"),
-    sandboxNotebookOutputs: "true" === get("sandboxnotebookoutputs", "true"),
+    sandboxNotebookOutputs: true,
     selfServeType: get("selfservetype"),
     showMinRUSurvey: "true" === get("showminrusurvey"),
     ttl90Days: "true" === get("ttl90days"),

--- a/src/Utils/AuthorizationUtils.test.ts
+++ b/src/Utils/AuthorizationUtils.test.ts
@@ -27,7 +27,7 @@ describe("AuthorizationUtils", () => {
         enableKoResourceTree: false,
         enableThroughputBuckets: false,
         hostedDataExplorer: false,
-        sandboxNotebookOutputs: false,
+        sandboxNotebookOutputs: true,
         showMinRUSurvey: false,
         ttl90Days: false,
         enableThroughputCap: false,


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

Updated the feature value to hardcode true reason: Always sandbox notebook outputs, not configurable via URL