### PR TITLE
Added quantizerType support in vector embedding

### DIFF
--- a/src/Contracts/DataModels.ts
+++ b/src/Contracts/DataModels.ts
@@ -255,6 +255,7 @@ export interface VectorIndex {
   vectorIndexShardKey?: string[];
   indexingSearchListSize?: number;
   quantizationByteSize?: number;
+  quantizerType?: "product" | "spherical";
 }
 
 export interface FullTextIndex {

--- a/src/Explorer/Controls/Settings/SettingsComponent.tsx
+++ b/src/Explorer/Controls/Settings/SettingsComponent.tsx
@@ -2,16 +2,16 @@ import { IPivotItemProps, IPivotProps, Pivot, PivotItem, Stack } from "@fluentui
 import { sendMessage } from "Common/MessageHandler";
 import { FabricMessageTypes } from "Contracts/FabricMessageTypes";
 import {
-    ComputedPropertiesComponent,
-    ComputedPropertiesComponentProps,
+  ComputedPropertiesComponent,
+  ComputedPropertiesComponentProps,
 } from "Explorer/Controls/Settings/SettingsSubComponents/ComputedPropertiesComponent";
 import {
-    ContainerPolicyComponent,
-    ContainerPolicyComponentProps,
+  ContainerPolicyComponent,
+  ContainerPolicyComponentProps,
 } from "Explorer/Controls/Settings/SettingsSubComponents/ContainerPolicyComponent";
 import {
-    ThroughputBucketsComponent,
-    ThroughputBucketsComponentProps,
+  ThroughputBucketsComponent,
+  ThroughputBucketsComponentProps,
 } from "Explorer/Controls/Settings/SettingsSubComponents/ThroughputInputComponents/ThroughputBucketsComponent";
 import { useIndexingPolicyStore } from "Explorer/Tabs/QueryTab/ResultsView";
 import { useDatabases } from "Explorer/useDatabases";
@@ -38,43 +38,43 @@ import * as AutoPilotUtils from "../../../Utils/AutoPilotUtils";
 import { MongoDBCollectionResource, MongoIndex } from "../../../Utils/arm/generatedClients/cosmos/types";
 import { CommandButtonComponentProps } from "../../Controls/CommandButton/CommandButtonComponent";
 import {
-    PartitionKeyComponent,
-    PartitionKeyComponentProps,
+  PartitionKeyComponent,
+  PartitionKeyComponentProps,
 } from "../../Controls/Settings/SettingsSubComponents/PartitionKeyComponent";
 import { useCommandBar } from "../../Menus/CommandBar/CommandBarComponentAdapter";
 import { SettingsTabV2 } from "../../Tabs/SettingsTabV2";
 import "./SettingsComponent.less";
 import { mongoIndexingPolicyAADError } from "./SettingsRenderUtils";
 import {
-    ConflictResolutionComponent,
-    ConflictResolutionComponentProps,
+  ConflictResolutionComponent,
+  ConflictResolutionComponentProps,
 } from "./SettingsSubComponents/ConflictResolutionComponent";
 import { DataMaskingComponent, DataMaskingComponentProps } from "./SettingsSubComponents/DataMaskingComponent";
 import {
-    GlobalSecondaryIndexComponent,
-    GlobalSecondaryIndexComponentProps,
+  GlobalSecondaryIndexComponent,
+  GlobalSecondaryIndexComponentProps,
 } from "./SettingsSubComponents/GlobalSecondaryIndexComponent";
 import { IndexingPolicyComponent, IndexingPolicyComponentProps } from "./SettingsSubComponents/IndexingPolicyComponent";
 import {
-    MongoIndexingPolicyComponent,
-    MongoIndexingPolicyComponentProps,
+  MongoIndexingPolicyComponent,
+  MongoIndexingPolicyComponentProps,
 } from "./SettingsSubComponents/MongoIndexingPolicy/MongoIndexingPolicyComponent";
 import { ScaleComponent, ScaleComponentProps } from "./SettingsSubComponents/ScaleComponent";
 import { SubSettingsComponent, SubSettingsComponentProps } from "./SettingsSubComponents/SubSettingsComponent";
 import {
-    AddMongoIndexProps,
-    ChangeFeedPolicyState,
-    GeospatialConfigType,
-    MongoIndexTypes,
-    SettingsV2TabTypes,
-    TtlType,
-    getMongoNotification,
-    getTabTitle,
-    hasDatabaseSharedThroughput,
-    isDataMaskingEnabled,
-    isDirty,
-    parseConflictResolutionMode,
-    parseConflictResolutionProcedure,
+  AddMongoIndexProps,
+  ChangeFeedPolicyState,
+  GeospatialConfigType,
+  MongoIndexTypes,
+  SettingsV2TabTypes,
+  TtlType,
+  getMongoNotification,
+  getTabTitle,
+  hasDatabaseSharedThroughput,
+  isDataMaskingEnabled,
+  isDirty,
+  parseConflictResolutionMode,
+  parseConflictResolutionProcedure,
 } from "./SettingsUtils";
 interface SettingsV2TabInfo {
   tab: SettingsV2TabTypes;
@@ -556,7 +556,8 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
     this.setState({ vectorEmbeddingPolicy: newVectorEmbeddingPolicy });
 
   private onVectorIndexesChange = (newVectorIndexes: DataModels.VectorIndex[]): void => {
-    const currentIndexingPolicy: DataModels.IndexingPolicy = this.state.indexingPolicyContent || ({} as DataModels.IndexingPolicy);
+    const currentIndexingPolicy: DataModels.IndexingPolicy =
+      this.state.indexingPolicyContent || ({} as DataModels.IndexingPolicy);
     const newIndexingPolicy: DataModels.IndexingPolicy = {
       ...currentIndexingPolicy,
       vectorIndexes: newVectorIndexes,

--- a/src/Explorer/Controls/Settings/SettingsComponent.tsx
+++ b/src/Explorer/Controls/Settings/SettingsComponent.tsx
@@ -2,19 +2,20 @@ import { IPivotItemProps, IPivotProps, Pivot, PivotItem, Stack } from "@fluentui
 import { sendMessage } from "Common/MessageHandler";
 import { FabricMessageTypes } from "Contracts/FabricMessageTypes";
 import {
-  ComputedPropertiesComponent,
-  ComputedPropertiesComponentProps,
+    ComputedPropertiesComponent,
+    ComputedPropertiesComponentProps,
 } from "Explorer/Controls/Settings/SettingsSubComponents/ComputedPropertiesComponent";
 import {
-  ContainerPolicyComponent,
-  ContainerPolicyComponentProps,
+    ContainerPolicyComponent,
+    ContainerPolicyComponentProps,
 } from "Explorer/Controls/Settings/SettingsSubComponents/ContainerPolicyComponent";
 import {
-  ThroughputBucketsComponent,
-  ThroughputBucketsComponentProps,
+    ThroughputBucketsComponent,
+    ThroughputBucketsComponentProps,
 } from "Explorer/Controls/Settings/SettingsSubComponents/ThroughputInputComponents/ThroughputBucketsComponent";
 import { useIndexingPolicyStore } from "Explorer/Tabs/QueryTab/ResultsView";
 import { useDatabases } from "Explorer/useDatabases";
+import { Keys, t } from "Localization";
 import { isFabricNative } from "Platform/Fabric/FabricUtil";
 import { isVectorSearchEnabled } from "Utils/CapabilityUtils";
 import { isRunningOnPublicCloud } from "Utils/CloudUtils";
@@ -37,44 +38,43 @@ import * as AutoPilotUtils from "../../../Utils/AutoPilotUtils";
 import { MongoDBCollectionResource, MongoIndex } from "../../../Utils/arm/generatedClients/cosmos/types";
 import { CommandButtonComponentProps } from "../../Controls/CommandButton/CommandButtonComponent";
 import {
-  PartitionKeyComponent,
-  PartitionKeyComponentProps,
+    PartitionKeyComponent,
+    PartitionKeyComponentProps,
 } from "../../Controls/Settings/SettingsSubComponents/PartitionKeyComponent";
 import { useCommandBar } from "../../Menus/CommandBar/CommandBarComponentAdapter";
 import { SettingsTabV2 } from "../../Tabs/SettingsTabV2";
 import "./SettingsComponent.less";
 import { mongoIndexingPolicyAADError } from "./SettingsRenderUtils";
-import { Keys, t } from "Localization";
 import {
-  ConflictResolutionComponent,
-  ConflictResolutionComponentProps,
+    ConflictResolutionComponent,
+    ConflictResolutionComponentProps,
 } from "./SettingsSubComponents/ConflictResolutionComponent";
 import { DataMaskingComponent, DataMaskingComponentProps } from "./SettingsSubComponents/DataMaskingComponent";
 import {
-  GlobalSecondaryIndexComponent,
-  GlobalSecondaryIndexComponentProps,
+    GlobalSecondaryIndexComponent,
+    GlobalSecondaryIndexComponentProps,
 } from "./SettingsSubComponents/GlobalSecondaryIndexComponent";
 import { IndexingPolicyComponent, IndexingPolicyComponentProps } from "./SettingsSubComponents/IndexingPolicyComponent";
 import {
-  MongoIndexingPolicyComponent,
-  MongoIndexingPolicyComponentProps,
+    MongoIndexingPolicyComponent,
+    MongoIndexingPolicyComponentProps,
 } from "./SettingsSubComponents/MongoIndexingPolicy/MongoIndexingPolicyComponent";
 import { ScaleComponent, ScaleComponentProps } from "./SettingsSubComponents/ScaleComponent";
 import { SubSettingsComponent, SubSettingsComponentProps } from "./SettingsSubComponents/SubSettingsComponent";
 import {
-  AddMongoIndexProps,
-  ChangeFeedPolicyState,
-  GeospatialConfigType,
-  MongoIndexTypes,
-  SettingsV2TabTypes,
-  TtlType,
-  getMongoNotification,
-  getTabTitle,
-  hasDatabaseSharedThroughput,
-  isDataMaskingEnabled,
-  isDirty,
-  parseConflictResolutionMode,
-  parseConflictResolutionProcedure,
+    AddMongoIndexProps,
+    ChangeFeedPolicyState,
+    GeospatialConfigType,
+    MongoIndexTypes,
+    SettingsV2TabTypes,
+    TtlType,
+    getMongoNotification,
+    getTabTitle,
+    hasDatabaseSharedThroughput,
+    isDataMaskingEnabled,
+    isDirty,
+    parseConflictResolutionMode,
+    parseConflictResolutionProcedure,
 } from "./SettingsUtils";
 interface SettingsV2TabInfo {
   tab: SettingsV2TabTypes;
@@ -554,6 +554,18 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
 
   private onVectorEmbeddingPolicyChange = (newVectorEmbeddingPolicy: DataModels.VectorEmbeddingPolicy): void =>
     this.setState({ vectorEmbeddingPolicy: newVectorEmbeddingPolicy });
+
+  private onVectorIndexesChange = (newVectorIndexes: DataModels.VectorIndex[]): void => {
+    const currentIndexingPolicy: DataModels.IndexingPolicy = this.state.indexingPolicyContent || ({} as DataModels.IndexingPolicy);
+    const newIndexingPolicy: DataModels.IndexingPolicy = {
+      ...currentIndexingPolicy,
+      vectorIndexes: newVectorIndexes,
+    };
+    this.setState({
+      indexingPolicyContent: newIndexingPolicy,
+      isIndexingPolicyDirty: true,
+    });
+  };
 
   private onFullTextPolicyChange = (newFullTextPolicy: DataModels.FullTextPolicy): void =>
     this.setState({ fullTextPolicy: newFullTextPolicy });
@@ -1332,6 +1344,9 @@ export class SettingsComponent extends React.Component<SettingsComponentProps, S
       onVectorEmbeddingPolicyChange: this.onVectorEmbeddingPolicyChange,
       onVectorEmbeddingPolicyDirtyChange: this.onVectorEmbeddingPolicyDirtyChange,
       onVectorEmbeddingPolicyValidationChange: this.onVectorEmbeddingPolicyValidationChange,
+      vectorIndexes: this.state.indexingPolicyContent?.vectorIndexes ?? [],
+      vectorIndexesBaseline: this.state.indexingPolicyContentBaseline?.vectorIndexes ?? [],
+      onVectorIndexesChange: this.onVectorIndexesChange,
       isVectorSearchEnabled: this.isVectorSearchEnabled,
       fullTextPolicy: this.state.fullTextPolicy,
       fullTextPolicyBaseline: this.state.fullTextPolicyBaseline,

--- a/src/Explorer/Controls/Settings/SettingsSubComponents/ContainerPolicyComponent.tsx
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/ContainerPolicyComponent.tsx
@@ -1,8 +1,8 @@
 import { DefaultButton, Pivot, PivotItem, Stack } from "@fluentui/react";
 import { FullTextPolicy, VectorEmbedding, VectorEmbeddingPolicy, VectorIndex } from "Contracts/DataModels";
 import {
-    FullTextPoliciesComponent,
-    getFullTextLanguageOptions,
+  FullTextPoliciesComponent,
+  getFullTextLanguageOptions,
 } from "Explorer/Controls/FullTextSeach/FullTextPoliciesComponent";
 import { titleAndInputStackProps } from "Explorer/Controls/Settings/SettingsRenderUtils";
 import { ContainerPolicyTabTypes, isDirty } from "Explorer/Controls/Settings/SettingsUtils";

--- a/src/Explorer/Controls/Settings/SettingsSubComponents/ContainerPolicyComponent.tsx
+++ b/src/Explorer/Controls/Settings/SettingsSubComponents/ContainerPolicyComponent.tsx
@@ -1,8 +1,8 @@
 import { DefaultButton, Pivot, PivotItem, Stack } from "@fluentui/react";
-import { FullTextPolicy, VectorEmbedding, VectorEmbeddingPolicy } from "Contracts/DataModels";
+import { FullTextPolicy, VectorEmbedding, VectorEmbeddingPolicy, VectorIndex } from "Contracts/DataModels";
 import {
-  FullTextPoliciesComponent,
-  getFullTextLanguageOptions,
+    FullTextPoliciesComponent,
+    getFullTextLanguageOptions,
 } from "Explorer/Controls/FullTextSeach/FullTextPoliciesComponent";
 import { titleAndInputStackProps } from "Explorer/Controls/Settings/SettingsRenderUtils";
 import { ContainerPolicyTabTypes, isDirty } from "Explorer/Controls/Settings/SettingsUtils";
@@ -16,6 +16,9 @@ export interface ContainerPolicyComponentProps {
   onVectorEmbeddingPolicyChange: (newVectorEmbeddingPolicy: VectorEmbeddingPolicy) => void;
   onVectorEmbeddingPolicyDirtyChange: (isVectorEmbeddingPolicyDirty: boolean) => void;
   onVectorEmbeddingPolicyValidationChange: (isValid: boolean) => void;
+  vectorIndexes: VectorIndex[];
+  vectorIndexesBaseline: VectorIndex[];
+  onVectorIndexesChange: (newVectorIndexes: VectorIndex[]) => void;
   isVectorSearchEnabled: boolean;
   fullTextPolicy: FullTextPolicy;
   fullTextPolicyBaseline: FullTextPolicy;
@@ -33,6 +36,9 @@ export const ContainerPolicyComponent: React.FC<ContainerPolicyComponentProps> =
   onVectorEmbeddingPolicyChange,
   onVectorEmbeddingPolicyDirtyChange,
   onVectorEmbeddingPolicyValidationChange,
+  vectorIndexes,
+  vectorIndexesBaseline,
+  onVectorIndexesChange,
   isVectorSearchEnabled,
   fullTextPolicy,
   fullTextPolicyBaseline,
@@ -78,6 +84,7 @@ export const ContainerPolicyComponent: React.FC<ContainerPolicyComponentProps> =
 
   const checkAndSendVectorEmbeddingPoliciesToSettings = (
     newVectorEmbeddings: VectorEmbedding[],
+    newVectorIndexes: VectorIndex[],
     validationPassed: boolean,
   ): void => {
     onVectorEmbeddingPolicyValidationChange(validationPassed);
@@ -85,6 +92,9 @@ export const ContainerPolicyComponent: React.FC<ContainerPolicyComponentProps> =
     onVectorEmbeddingPolicyDirtyChange(isVectorDirty);
     if (isVectorDirty) {
       onVectorEmbeddingPolicyChange({ vectorEmbeddings: newVectorEmbeddings });
+    }
+    if (isDirty(newVectorIndexes ?? [], vectorIndexesBaseline ?? [])) {
+      onVectorIndexesChange(newVectorIndexes);
     }
   };
 
@@ -169,12 +179,14 @@ export const ContainerPolicyComponent: React.FC<ContainerPolicyComponentProps> =
               <VectorEmbeddingPoliciesComponent
                 vectorEmbeddingsBaseline={vectorEmbeddingsBaseline}
                 vectorEmbeddings={vectorEmbeddings}
-                vectorIndexes={undefined}
+                vectorIndexes={vectorIndexes ?? []}
                 onVectorEmbeddingChange={(
-                  vectorEmbeddings: VectorEmbedding[],
-                  _vectorIndexingPolicies,
+                  newVectorEmbeddings: VectorEmbedding[],
+                  newVectorIndexes: VectorIndex[],
                   validationPassed: boolean,
-                ) => checkAndSendVectorEmbeddingPoliciesToSettings(vectorEmbeddings, validationPassed)}
+                ) =>
+                  checkAndSendVectorEmbeddingPoliciesToSettings(newVectorEmbeddings, newVectorIndexes, validationPassed)
+                }
                 discardChanges={discardVectorChanges}
                 onChangesDiscarded={onVectorChangesDiscarded}
               />

--- a/src/Explorer/Controls/Settings/SettingsUtils.tsx
+++ b/src/Explorer/Controls/Settings/SettingsUtils.tsx
@@ -1,7 +1,7 @@
+import { Keys, t } from "Localization";
 import * as Constants from "../../../Common/Constants";
 import * as DataModels from "../../../Contracts/DataModels";
 import * as ViewModels from "../../../Contracts/ViewModels";
-import { Keys, t } from "Localization";
 import { isFabricNative } from "../../../Platform/Fabric/FabricUtil";
 import { userContext } from "../../../UserContext";
 import { isCapabilityEnabled } from "../../../Utils/CapabilityUtils";

--- a/src/Explorer/Controls/Settings/SettingsUtils.tsx
+++ b/src/Explorer/Controls/Settings/SettingsUtils.tsx
@@ -15,6 +15,7 @@ export type isDirtyTypes =
   | DataModels.IndexingPolicy
   | DataModels.ComputedProperties
   | DataModels.VectorEmbedding[]
+  | DataModels.VectorIndex[]
   | DataModels.FullTextPolicy
   | DataModels.ThroughputBucket[]
   | DataModels.DataMaskingPolicy;

--- a/src/Explorer/Controls/Settings/__snapshots__/SettingsComponent.test.tsx.snap
+++ b/src/Explorer/Controls/Settings/__snapshots__/SettingsComponent.test.tsx.snap
@@ -359,10 +359,13 @@ exports[`SettingsComponent renders 1`] = `
             onVectorEmbeddingPolicyChange={[Function]}
             onVectorEmbeddingPolicyDirtyChange={[Function]}
             onVectorEmbeddingPolicyValidationChange={[Function]}
+            onVectorIndexesChange={[Function]}
             resetShouldDiscardContainerPolicyChange={[Function]}
             shouldDiscardContainerPolicies={false}
             vectorEmbeddingPolicy={{}}
             vectorEmbeddingPolicyBaseline={{}}
+            vectorIndexes={[]}
+            vectorIndexesBaseline={[]}
           />
         </Stack>
       </PivotItem>

--- a/src/Explorer/Controls/VectorSearch/VectorEmbeddingPoliciesComponent.tsx
+++ b/src/Explorer/Controls/VectorSearch/VectorEmbeddingPoliciesComponent.tsx
@@ -17,6 +17,7 @@ import {
   getDistanceFunctionOptions,
   getIndexTypeOptions,
   getQuantizerTypeOptions,
+  supportsQuantization,
 } from "Explorer/Controls/VectorSearch/VectorSearchUtils";
 import { Keys, t } from "Localization";
 import React, { FunctionComponent, useState } from "react";
@@ -159,7 +160,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
     vectorEmbeddings?.forEach((embedding) => {
       const matchingIndex = displayIndexes ? vectorIndexes.find((index) => index.path === embedding.path) : undefined;
       const matchingType = matchingIndex?.type;
-      const supportsQuantizer = matchingType === "quantizedFlat" || matchingType === "diskANN";
+      const supportsQuantizer = supportsQuantization(matchingType);
       mergedData.push({
         ...embedding,
         indexType: matchingType || "none",
@@ -208,7 +209,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
             indexingSearchListSize: policy.indexingSearchListSize,
             quantizationByteSize: policy.quantizationByteSize,
             vectorIndexShardKey: policy.vectorIndexShardKey,
-            ...((policy.indexType === "quantizedFlat" || policy.indexType === "diskANN") && policy.quantizerType
+            ...(supportsQuantization(policy.indexType) && policy.quantizerType
               ? { quantizerType: policy.quantizerType }
               : {}),
           }) as VectorIndex,
@@ -254,7 +255,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
     } else {
       vectorEmbedding.indexingSearchListSize = undefined;
     }
-    if (vectorEmbedding.indexType === "quantizedFlat" || vectorEmbedding.indexType === "diskANN") {
+    if (supportsQuantization(vectorEmbedding.indexType)) {
       vectorEmbedding.quantizerType = vectorEmbedding.quantizerType || "product";
     } else {
       vectorEmbedding.quantizerType = undefined;
@@ -437,8 +438,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
                       <Label
                         disabled={
                           isExistingPolicy(vectorEmbeddingPolicy) ||
-                          (vectorEmbeddingPolicy.indexType !== "quantizedFlat" &&
-                            vectorEmbeddingPolicy.indexType !== "diskANN")
+                          !supportsQuantization(vectorEmbeddingPolicy.indexType)
                         }
                         styles={labelStyles}
                       >
@@ -448,8 +448,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
                       <TextField
                         disabled={
                           isExistingPolicy(vectorEmbeddingPolicy) ||
-                          (vectorEmbeddingPolicy.indexType !== "quantizedFlat" &&
-                            vectorEmbeddingPolicy.indexType !== "diskANN")
+                          !supportsQuantization(vectorEmbeddingPolicy.indexType)
                         }
                         id={`vector-policy-quantizationByteSize-${index + 1}`}
                         styles={textFieldStyles}
@@ -463,8 +462,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
                       <Label
                         disabled={
                           isExistingPolicy(vectorEmbeddingPolicy) ||
-                          (vectorEmbeddingPolicy.indexType !== "quantizedFlat" &&
-                            vectorEmbeddingPolicy.indexType !== "diskANN")
+                          !supportsQuantization(vectorEmbeddingPolicy.indexType)
                         }
                         styles={labelStyles}
                       >
@@ -474,8 +472,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
                       <Dropdown
                         disabled={
                           isExistingPolicy(vectorEmbeddingPolicy) ||
-                          (vectorEmbeddingPolicy.indexType !== "quantizedFlat" &&
-                            vectorEmbeddingPolicy.indexType !== "diskANN")
+                          !supportsQuantization(vectorEmbeddingPolicy.indexType)
                         }
                         id={`vector-policy-quantizerType-${index + 1}`}
                         styles={dropdownStyles}

--- a/src/Explorer/Controls/VectorSearch/VectorEmbeddingPoliciesComponent.tsx
+++ b/src/Explorer/Controls/VectorSearch/VectorEmbeddingPoliciesComponent.tsx
@@ -16,7 +16,9 @@ import {
   getDataTypeOptions,
   getDistanceFunctionOptions,
   getIndexTypeOptions,
+  getQuantizerTypeOptions,
 } from "Explorer/Controls/VectorSearch/VectorSearchUtils";
+import { Keys, t } from "Localization";
 import React, { FunctionComponent, useState } from "react";
 
 export interface IVectorEmbeddingPoliciesComponentProps {
@@ -46,6 +48,7 @@ export interface VectorEmbeddingPolicyData {
   indexingSearchListSizeError?: string;
   quantizationByteSize?: number;
   quantizationByteSizeError?: string;
+  quantizerType?: VectorIndex["quantizerType"];
 }
 
 type VectorEmbeddingPolicyProperty = "dataType" | "distanceFunction" | "indexType";
@@ -110,7 +113,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
   const onVectorEmbeddingPathError = (path: string, index?: number): string => {
     let error = "";
     if (!path) {
-      error = "Path should not be empty";
+      error = t(Keys.controls.vectorEmbeddingPolicies.pathEmptyError);
     }
     if (
       index >= 0 &&
@@ -119,7 +122,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
           dataIndex !== index && vectorEmbedding.path === path,
       )
     ) {
-      error = "Path is already defined";
+      error = t(Keys.controls.vectorEmbeddingPolicies.pathDuplicateError);
     }
     return error;
   };
@@ -127,10 +130,10 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
   const onVectorEmbeddingDimensionError = (dimension: number, indexType: VectorIndex["type"] | "none"): string => {
     let error = "";
     if (dimension <= 0 || dimension > 4096) {
-      error = "Dimension must be greater than 0 and less than or equal 4096";
+      error = t(Keys.controls.vectorEmbeddingPolicies.dimensionRangeError);
     }
     if (indexType === "flat" && dimension > 505) {
-      error = "Maximum allowed dimension for flat index is 505";
+      error = t(Keys.controls.vectorEmbeddingPolicies.dimensionFlatIndexError);
     }
     return error;
   };
@@ -138,7 +141,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
   const onQuantizationByteSizeError = (size: number): string => {
     let error = "";
     if (size < 1 || size > 512) {
-      error = "Quantization byte size must be greater than 0 and less than or equal to 512";
+      error = t(Keys.controls.vectorEmbeddingPolicies.quantizationByteSizeRangeError);
     }
     return error;
   };
@@ -146,7 +149,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
   const onIndexingSearchListSizeError = (size: number): string => {
     let error = "";
     if (size < 25 || size > 500) {
-      error = "Indexing search list size must be greater than or equal to 25 and less than or equal to 500";
+      error = t(Keys.controls.vectorEmbeddingPolicies.indexingSearchListSizeRangeError);
     }
     return error;
   };
@@ -155,11 +158,14 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
     const mergedData: VectorEmbeddingPolicyData[] = [];
     vectorEmbeddings?.forEach((embedding) => {
       const matchingIndex = displayIndexes ? vectorIndexes.find((index) => index.path === embedding.path) : undefined;
+      const matchingType = matchingIndex?.type;
+      const supportsQuantizer = matchingType === "quantizedFlat" || matchingType === "diskANN";
       mergedData.push({
         ...embedding,
-        indexType: matchingIndex?.type || "none",
+        indexType: matchingType || "none",
         indexingSearchListSize: matchingIndex?.indexingSearchListSize || undefined,
         quantizationByteSize: matchingIndex?.quantizationByteSize || undefined,
+        quantizerType: supportsQuantizer ? matchingIndex?.quantizerType || "product" : undefined,
         vectorIndexShardKey: matchingIndex?.vectorIndexShardKey || undefined,
         pathError: onVectorEmbeddingPathError(embedding.path),
         dimensionsError: onVectorEmbeddingDimensionError(embedding.dimensions, matchingIndex?.type || "none"),
@@ -202,6 +208,9 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
             indexingSearchListSize: policy.indexingSearchListSize,
             quantizationByteSize: policy.quantizationByteSize,
             vectorIndexShardKey: policy.vectorIndexShardKey,
+            ...((policy.indexType === "quantizedFlat" || policy.indexType === "diskANN") && policy.quantizerType
+              ? { quantizerType: policy.quantizerType }
+              : {}),
           }) as VectorIndex,
       );
     const validationPassed = vectorEmbeddingPolicyData.every(
@@ -245,6 +254,17 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
     } else {
       vectorEmbedding.indexingSearchListSize = undefined;
     }
+    if (vectorEmbedding.indexType === "quantizedFlat" || vectorEmbedding.indexType === "diskANN") {
+      vectorEmbedding.quantizerType = vectorEmbedding.quantizerType || "product";
+    } else {
+      vectorEmbedding.quantizerType = undefined;
+    }
+    setVectorEmbeddingPolicyData(vectorEmbeddings);
+  };
+
+  const onQuantizerTypeChange = (index: number, option: IDropdownOption): void => {
+    const vectorEmbeddings = [...vectorEmbeddingPolicyData];
+    vectorEmbeddings[index].quantizerType = option.key as VectorIndex["quantizerType"];
     setVectorEmbeddingPolicyData(vectorEmbeddings);
   };
 
@@ -306,8 +326,10 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
   };
 
   const getQuantizationByteSizeTooltipContent = (): string => {
-    const containerName: string = isGlobalSecondaryIndex ? "global secondary index" : "container";
-    return `This is dynamically set by the ${containerName} if left blank, or it can be set to a fixed number`;
+    const containerName = isGlobalSecondaryIndex
+      ? t(Keys.controls.vectorEmbeddingPolicies.quantizationByteSizeTooltipGlobalSecondaryIndexName)
+      : t(Keys.controls.vectorEmbeddingPolicies.quantizationByteSizeTooltipContainerName);
+    return t(Keys.controls.vectorEmbeddingPolicies.quantizationByteSizeTooltip, { containerName });
   };
 
   return (
@@ -319,7 +341,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
             disabled={isExistingPolicy(vectorEmbeddingPolicy)}
             key={index}
             isExpandedByDefault={true}
-            title={`Vector embedding ${index + 1}`}
+            title={t(Keys.controls.vectorEmbeddingPolicies.vectorEmbeddingTitle, { index: index + 1 })}
             showDelete={true}
             onDelete={() => onDelete(index)}
             disableDelete={false}
@@ -337,7 +359,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
               >
                 <Stack>
                   <Label disabled={isExistingPolicy(vectorEmbeddingPolicy)} styles={labelStyles}>
-                    Path
+                    {t(Keys.controls.vectorEmbeddingPolicies.path)}
                   </Label>
                   <TextField
                     disabled={isExistingPolicy(vectorEmbeddingPolicy)}
@@ -352,7 +374,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
                 </Stack>
                 <Stack>
                   <Label disabled={isExistingPolicy(vectorEmbeddingPolicy)} styles={labelStyles}>
-                    Data type
+                    {t(Keys.controls.vectorEmbeddingPolicies.dataType)}
                   </Label>
                   <Dropdown
                     disabled={isExistingPolicy(vectorEmbeddingPolicy)}
@@ -367,7 +389,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
                 </Stack>
                 <Stack>
                   <Label disabled={isExistingPolicy(vectorEmbeddingPolicy)} styles={labelStyles}>
-                    Distance function
+                    {t(Keys.controls.vectorEmbeddingPolicies.distanceFunction)}
                   </Label>
                   <Dropdown
                     disabled={isExistingPolicy(vectorEmbeddingPolicy)}
@@ -382,7 +404,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
                 </Stack>
                 <Stack>
                   <Label disabled={isExistingPolicy(vectorEmbeddingPolicy)} styles={labelStyles}>
-                    Dimensions
+                    {t(Keys.controls.vectorEmbeddingPolicies.dimensions)}
                   </Label>
                   <TextField
                     disabled={isExistingPolicy(vectorEmbeddingPolicy)}
@@ -399,7 +421,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
                 {displayIndexes && (
                   <Stack>
                     <Label disabled={isExistingPolicy(vectorEmbeddingPolicy)} styles={labelStyles}>
-                      Index type
+                      {t(Keys.controls.vectorEmbeddingPolicies.indexType)}
                     </Label>
                     <Dropdown
                       disabled={isExistingPolicy(vectorEmbeddingPolicy)}
@@ -420,7 +442,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
                         }
                         styles={labelStyles}
                       >
-                        Quantization byte size
+                        {t(Keys.controls.vectorEmbeddingPolicies.quantizationByteSize)}
                         <InfoTooltip>{getQuantizationByteSizeTooltipContent()}</InfoTooltip>
                       </Label>
                       <TextField
@@ -440,11 +462,38 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
                     <Stack style={{ marginLeft: "10px" }}>
                       <Label
                         disabled={
+                          isExistingPolicy(vectorEmbeddingPolicy) ||
+                          (vectorEmbeddingPolicy.indexType !== "quantizedFlat" &&
+                            vectorEmbeddingPolicy.indexType !== "diskANN")
+                        }
+                        styles={labelStyles}
+                      >
+                        {t(Keys.controls.vectorEmbeddingPolicies.quantizerType)}
+                        <InfoTooltip>{t(Keys.controls.vectorEmbeddingPolicies.quantizerTypeTooltip)}</InfoTooltip>
+                      </Label>
+                      <Dropdown
+                        disabled={
+                          isExistingPolicy(vectorEmbeddingPolicy) ||
+                          (vectorEmbeddingPolicy.indexType !== "quantizedFlat" &&
+                            vectorEmbeddingPolicy.indexType !== "diskANN")
+                        }
+                        id={`vector-policy-quantizerType-${index + 1}`}
+                        styles={dropdownStyles}
+                        options={getQuantizerTypeOptions()}
+                        selectedKey={vectorEmbeddingPolicy.quantizerType ?? null}
+                        onChange={(_event: React.FormEvent<HTMLDivElement>, option: IDropdownOption) =>
+                          onQuantizerTypeChange(index, option)
+                        }
+                      />
+                    </Stack>
+                    <Stack style={{ marginLeft: "10px" }}>
+                      <Label
+                        disabled={
                           isExistingPolicy(vectorEmbeddingPolicy) || vectorEmbeddingPolicy.indexType !== "diskANN"
                         }
                         styles={labelStyles}
                       >
-                        Indexing search list size
+                        {t(Keys.controls.vectorEmbeddingPolicies.indexingSearchListSize)}
                       </Label>
                       <TextField
                         disabled={
@@ -465,7 +514,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
                         }
                         styles={labelStyles}
                       >
-                        Vector index shard key
+                        {t(Keys.controls.vectorEmbeddingPolicies.vectorIndexShardKey)}
                       </Label>
                       <TextField
                         disabled={
@@ -484,7 +533,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
           </CollapsibleSectionComponent>
         ))}
       <DefaultButton id={`add-vector-policy`} styles={{ root: { maxWidth: 170, fontSize: 12 } }} onClick={onAdd}>
-        Add vector embedding
+        {t(Keys.controls.vectorEmbeddingPolicies.addVectorEmbedding)}
       </DefaultButton>
     </Stack>
   );

--- a/src/Explorer/Controls/VectorSearch/VectorSearchUtils.ts
+++ b/src/Explorer/Controls/VectorSearch/VectorSearchUtils.ts
@@ -7,6 +7,10 @@ const indexTypes = ["none", "flat", "diskANN", "quantizedFlat"];
 export const getDataTypeOptions = (): IDropdownOption[] => createDropdownOptionsFromLiterals(dataTypes);
 export const getDistanceFunctionOptions = (): IDropdownOption[] => createDropdownOptionsFromLiterals(distanceFunctions);
 export const getIndexTypeOptions = (): IDropdownOption[] => createDropdownOptionsFromLiterals(indexTypes);
+export const getQuantizerTypeOptions = (): IDropdownOption[] => [
+  { key: "product", text: "Product" },
+  { key: "spherical", text: "Spherical (Preview)" },
+];
 
 function createDropdownOptionsFromLiterals<T extends string>(literals: T[]): IDropdownOption[] {
   return literals.map((value) => ({

--- a/src/Explorer/Controls/VectorSearch/VectorSearchUtils.ts
+++ b/src/Explorer/Controls/VectorSearch/VectorSearchUtils.ts
@@ -1,4 +1,6 @@
 import { IDropdownOption } from "@fluentui/react";
+import { VectorIndex } from "Contracts/DataModels";
+import { Keys, t } from "Localization";
 
 const dataTypes = ["float32", "uint8", "int8", "float16"];
 const distanceFunctions = ["euclidean", "cosine", "dotproduct"];
@@ -8,9 +10,15 @@ export const getDataTypeOptions = (): IDropdownOption[] => createDropdownOptions
 export const getDistanceFunctionOptions = (): IDropdownOption[] => createDropdownOptionsFromLiterals(distanceFunctions);
 export const getIndexTypeOptions = (): IDropdownOption[] => createDropdownOptionsFromLiterals(indexTypes);
 export const getQuantizerTypeOptions = (): IDropdownOption[] => [
-  { key: "product", text: "Product" },
-  { key: "spherical", text: "Spherical (Preview)" },
+  { key: "product", text: t(Keys.controls.vectorEmbeddingPolicies.quantizerTypeProduct) },
+  {
+    key: "spherical",
+    text: `${t(Keys.controls.vectorEmbeddingPolicies.quantizerTypeSpherical)} (${t(Keys.common.preview)})`,
+  },
 ];
+
+export const supportsQuantization = (indexType: VectorIndex["type"] | "none" | undefined): boolean =>
+  indexType === "quantizedFlat" || indexType === "diskANN";
 
 function createDropdownOptionsFromLiterals<T extends string>(literals: T[]): IDropdownOption[] {
   return literals.map((value) => ({

--- a/src/Explorer/Controls/VectorSearch/VectorSearchUtils.ts
+++ b/src/Explorer/Controls/VectorSearch/VectorSearchUtils.ts
@@ -10,11 +10,8 @@ export const getDataTypeOptions = (): IDropdownOption[] => createDropdownOptions
 export const getDistanceFunctionOptions = (): IDropdownOption[] => createDropdownOptionsFromLiterals(distanceFunctions);
 export const getIndexTypeOptions = (): IDropdownOption[] => createDropdownOptionsFromLiterals(indexTypes);
 export const getQuantizerTypeOptions = (): IDropdownOption[] => [
-  { key: "product", text: t(Keys.controls.vectorEmbeddingPolicies.quantizerTypeProduct) },
-  {
-    key: "spherical",
-    text: `${t(Keys.controls.vectorEmbeddingPolicies.quantizerTypeSpherical)} (${t(Keys.common.preview)})`,
-  },
+  { key: "product", text: "Product" },
+  { key: "spherical", text: `Spherical (${t(Keys.common.preview)})` },
 ];
 
 export const supportsQuantization = (indexType: VectorIndex["type"] | "none" | undefined): boolean =>

--- a/src/Localization/en/Resources.json
+++ b/src/Localization/en/Resources.json
@@ -33,7 +33,8 @@
     "publish": "Publish",
     "browse": "Browse",
     "increaseValueBy1": "Increase value by 1",
-    "decreaseValueBy1": "Decrease value by 1"
+    "decreaseValueBy1": "Decrease value by 1",
+    "preview": "Preview"
   },
   "splashScreen": {
     "title": {
@@ -981,6 +982,8 @@
       "quantizationByteSizeTooltipGlobalSecondaryIndexName": "global secondary index",
       "quantizerType": "Quantizer type",
       "quantizerTypeTooltip": "The quantization method used by the vector index.",
+      "quantizerTypeProduct": "Product",
+      "quantizerTypeSpherical": "Spherical",
       "indexingSearchListSize": "Indexing search list size",
       "vectorIndexShardKey": "Vector index shard key",
       "addVectorEmbedding": "Add vector embedding",

--- a/src/Localization/en/Resources.json
+++ b/src/Localization/en/Resources.json
@@ -982,8 +982,6 @@
       "quantizationByteSizeTooltipGlobalSecondaryIndexName": "global secondary index",
       "quantizerType": "Quantizer type",
       "quantizerTypeTooltip": "The quantization method used by the vector index.",
-      "quantizerTypeProduct": "Product",
-      "quantizerTypeSpherical": "Spherical",
       "indexingSearchListSize": "Indexing search list size",
       "vectorIndexShardKey": "Vector index shard key",
       "addVectorEmbedding": "Add vector embedding",

--- a/src/Localization/en/Resources.json
+++ b/src/Localization/en/Resources.json
@@ -967,6 +967,29 @@
         "bucketOptionLabel": "Bucket {{id}} - {{percentage}}%",
         "bucketNotActive": "Bucket {{id}} is not active."
       }
+    },
+    "vectorEmbeddingPolicies": {
+      "vectorEmbeddingTitle": "Vector embedding {{index}}",
+      "path": "Path",
+      "dataType": "Data type",
+      "distanceFunction": "Distance function",
+      "dimensions": "Dimensions",
+      "indexType": "Index type",
+      "quantizationByteSize": "Quantization byte size",
+      "quantizationByteSizeTooltip": "This is dynamically set by the {{containerName}} if left blank, or it can be set to a fixed number",
+      "quantizationByteSizeTooltipContainerName": "container",
+      "quantizationByteSizeTooltipGlobalSecondaryIndexName": "global secondary index",
+      "quantizerType": "Quantizer type",
+      "quantizerTypeTooltip": "The quantization method used by the vector index.",
+      "indexingSearchListSize": "Indexing search list size",
+      "vectorIndexShardKey": "Vector index shard key",
+      "addVectorEmbedding": "Add vector embedding",
+      "pathEmptyError": "Path should not be empty",
+      "pathDuplicateError": "Path is already defined",
+      "dimensionRangeError": "Dimension must be greater than 0 and less than or equal 4096",
+      "dimensionFlatIndexError": "Maximum allowed dimension for flat index is 505",
+      "quantizationByteSizeRangeError": "Quantization byte size must be greater than 0 and less than or equal to 512",
+      "indexingSearchListSizeRangeError": "Indexing search list size must be greater than or equal to 25 and less than or equal to 500"
     }
   }
 }


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2471?feature.someFeatureFlagYouMightNeed=true)

Adds the ability to configure a quantizer type when creating or editing vector indexes that use quantization (quantizedFlat and diskANN). Users can now choose between Product and Spherical (Preview) quantization.

<img width="1431" height="917" alt="image" src="https://github.com/user-attachments/assets/24e91e91-6509-40d7-aa94-e9497a11b68f" />


Changes
1. New Quantizer type dropdown in the vector embedding policy editor, available wherever vector indexes are configured (New Container panel and the container's Scale & Settings tab).
2. The dropdown is enabled only for index types that support quantization, and is hidden/disabled for flat indexes.
3. The selected value is included in create and update payloads, and the existing value is read back and displayed when viewing an existing container's policy.
4. Settings tab tracks edits to vector indexes as part of dirty-state detection so saves and discards behave correctly.
Added a tooltip explaining the difference between the two quantizer options.
5. Updated localized strings for the new field and its tooltip.
