### PR TITLE
Remove preview tag from GSI label.

### DIFF
--- a/src/Explorer/Controls/Settings/__snapshots__/SettingsComponent.test.tsx.snap
+++ b/src/Explorer/Controls/Settings/__snapshots__/SettingsComponent.test.tsx.snap
@@ -670,7 +670,7 @@ exports[`SettingsComponent renders 1`] = `
             "data-test": "settings-tab-header/GlobalSecondaryIndexTab",
           }
         }
-        headerText="Global Secondary Index (Preview)"
+        headerText="Global Secondary Index"
         itemKey="GlobalSecondaryIndexTab"
         key="GlobalSecondaryIndexTab"
         style={

--- a/src/Localization/en/Resources.json
+++ b/src/Localization/en/Resources.json
@@ -764,7 +764,7 @@
         "computedProperties": "Computed Properties",
         "containerPolicies": "Container Policies",
         "throughputBuckets": "Throughput Buckets",
-        "globalSecondaryIndexPreview": "Global Secondary Index (Preview)",
+        "globalSecondaryIndexPreview": "Global Secondary Index",
         "maskingPolicyPreview": "Masking Policy"
       },
       "mongoNotifications": {


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2484?feature.someFeatureFlagYouMightNeed=true)

Remove the preview tag from the Global Secondary Index label.

