### PR TITLE
feat: Add "Duplicate Tab" support for Items, Query, and Settings tabs

### DIFF
--- a/src/Explorer/Panes/AddCollectionPanel/AddCollectionPanel.tsx
+++ b/src/Explorer/Panes/AddCollectionPanel/AddCollectionPanel.tsx
@@ -1,19 +1,19 @@
 import {
-  ActionButton,
-  Checkbox,
-  DefaultButton,
-  DirectionalHint,
-  Dropdown,
-  Icon,
-  IconButton,
-  IDropdownOption,
-  Link,
-  ProgressIndicator,
-  Separator,
-  Stack,
-  TeachingBubble,
-  Text,
-  TooltipHost,
+    ActionButton,
+    Checkbox,
+    DefaultButton,
+    DirectionalHint,
+    Dropdown,
+    Icon,
+    IconButton,
+    IDropdownOption,
+    Link,
+    ProgressIndicator,
+    Separator,
+    Stack,
+    TeachingBubble,
+    Text,
+    TooltipHost,
 } from "@fluentui/react";
 import * as Constants from "Common/Constants";
 import { createCollection } from "Common/dataAccess/createCollection";
@@ -24,21 +24,21 @@ import { AccountOverride } from "Contracts/DataModels";
 import { FullTextPoliciesComponent } from "Explorer/Controls/FullTextSeach/FullTextPoliciesComponent";
 import { VectorEmbeddingPoliciesComponent } from "Explorer/Controls/VectorSearch/VectorEmbeddingPoliciesComponent";
 import {
-  AllPropertiesIndexed,
-  AnalyticalStoreHeader,
-  ContainerVectorPolicyTooltipContent,
-  FullTextPolicyDefault,
-  getPartitionKey,
-  getPartitionKeyName,
-  getPartitionKeyPlaceHolder,
-  getPartitionKeyTooltipText,
-  isFreeTierAccount,
-  isSynapseLinkEnabled,
-  parseUniqueKeys,
-  scrollToSection,
-  SharedDatabaseDefault,
-  shouldShowAnalyticalStoreOptions,
-  UniqueKeysHeader,
+    AllPropertiesIndexed,
+    AnalyticalStoreHeader,
+    ContainerVectorPolicyTooltipContent,
+    FullTextPolicyDefault,
+    getPartitionKey,
+    getPartitionKeyName,
+    getPartitionKeyPlaceHolder,
+    getPartitionKeyTooltipText,
+    isFreeTierAccount,
+    isSynapseLinkEnabled,
+    parseUniqueKeys,
+    scrollToSection,
+    SharedDatabaseDefault,
+    shouldShowAnalyticalStoreOptions,
+    UniqueKeysHeader,
 } from "Explorer/Panes/AddCollectionPanel/AddCollectionPanelUtility";
 import { useSidePanel } from "hooks/useSidePanel";
 import { useTeachingBubble } from "hooks/useTeachingBubble";
@@ -154,6 +154,19 @@ export class AddCollectionPanel extends React.Component<AddCollectionPanelProps,
   componentDidUpdate(_prevProps: AddCollectionPanelProps, prevState: AddCollectionPanelState): void {
     if (this.state.errorMessage && this.state.errorMessage !== prevState.errorMessage) {
       scrollToSection("panelContainer");
+    }
+
+    // When the user selects a different "Use existing" database, lazily load its offer so
+    // the "Provision dedicated throughput" checkbox can appear even if the initial
+    // loadDatabaseOffers() call could not load this database's offer (e.g. due to a
+    // transient ARM error shortly after the database was created).
+    if (!this.state.createNewDatabase && this.state.selectedDatabaseId !== prevState.selectedDatabaseId) {
+      const selectedDatabase = useDatabases
+        .getState()
+        .databases?.find((database) => database.id() === this.state.selectedDatabaseId);
+      if (selectedDatabase && !selectedDatabase.offer()) {
+        selectedDatabase.loadOffer().then(() => this.forceUpdate()).catch(console.error);
+      }
     }
   }
 

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.duplicateTab.test.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.duplicateTab.test.tsx
@@ -1,0 +1,85 @@
+import { useTabs } from "hooks/useTabs";
+import * as ko from "knockout";
+import * as ViewModels from "../../../Contracts/ViewModels";
+import { DocumentsTabV2 } from "./DocumentsTabV2";
+
+jest.mock("hooks/useTabs", () => ({
+  useTabs: {
+    getState: jest.fn(),
+  },
+}));
+
+jest.mock("UserContext", () => ({
+  userContext: { apiType: "SQL" },
+}));
+
+jest.mock("Explorer/Menus/CommandBar/CommandBarComponentAdapter", () => ({
+  useCommandBar: { getState: jest.fn(() => ({ setContextButtons: jest.fn() })) },
+}));
+
+jest.mock("Explorer/Controls/Editor/EditorReact", () => ({
+  EditorReact: () => null,
+}));
+
+const mockCollection = {
+  id: ko.observable<string>("testContainer"),
+  databaseId: "testDb",
+  partitionKey: { paths: ["/pk"], kind: "Hash", version: 2 },
+  selectedSubnodeKind: jest.fn(),
+  container: {},
+} as unknown as ViewModels.Collection;
+
+const buildTab = () =>
+  new DocumentsTabV2({
+    partitionKey: mockCollection.partitionKey,
+    documentIds: ko.observableArray([]),
+    tabKind: ViewModels.CollectionTabKind.Documents,
+    title: "Items",
+    collection: mockCollection,
+    node: mockCollection,
+    tabPath: "testDb>testContainer>Documents",
+  });
+
+describe("DocumentsTabV2.duplicateTab", () => {
+  let activateNewTab: jest.Mock;
+
+  beforeEach(() => {
+    activateNewTab = jest.fn();
+    (useTabs.getState as jest.Mock).mockReturnValue({ activateNewTab });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it("calls activateNewTab with a new DocumentsTabV2 instance", () => {
+    const tab = buildTab();
+    tab.duplicateTab();
+
+    expect(activateNewTab).toHaveBeenCalledTimes(1);
+    const newTab = activateNewTab.mock.calls[0][0];
+    expect(newTab).toBeInstanceOf(DocumentsTabV2);
+  });
+
+  it("creates a duplicate with the same collection", () => {
+    const tab = buildTab();
+    tab.duplicateTab();
+
+    const newTab = activateNewTab.mock.calls[0][0] as DocumentsTabV2;
+    expect(newTab.collection).toBe(mockCollection);
+  });
+
+  it("creates a duplicate with the same partitionKey", () => {
+    const tab = buildTab();
+    tab.duplicateTab();
+
+    const newTab = activateNewTab.mock.calls[0][0] as DocumentsTabV2;
+    expect(newTab.partitionKey).toEqual(mockCollection.partitionKey);
+  });
+
+  it("creates a distinct tab instance", () => {
+    const tab = buildTab();
+    tab.duplicateTab();
+
+    const newTab = activateNewTab.mock.calls[0][0];
+    expect(newTab).not.toBe(tab);
+  });
+});

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -187,7 +187,7 @@ export class DocumentsTabV2 extends TabsBase {
       partitionKey: this.partitionKey,
       documentIds: ko.observableArray<DocumentId>([]),
       tabKind: ViewModels.CollectionTabKind.Documents,
-      title: "Items",
+      title: this.tabTitle(),
       collection: this.collection,
       node: this.collection,
       tabPath: `${this.collection.databaseId}>${this.collection.id()}>Documents`,

--- a/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
+++ b/src/Explorer/Tabs/DocumentsTabV2/DocumentsTabV2.tsx
@@ -49,6 +49,8 @@ import { userContext } from "UserContext";
 import { logConsoleError, logConsoleInfo } from "Utils/NotificationConsoleUtils";
 import { Allotment } from "allotment";
 import { useClientWriteEnabled } from "hooks/useClientWriteEnabled";
+import { useTabs } from "hooks/useTabs";
+import ko from "knockout";
 import React, { KeyboardEventHandler, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { format } from "react-string-format";
 import DeleteDocumentIcon from "../../../../images/DeleteDocument.svg";
@@ -174,6 +176,25 @@ export class DocumentsTabV2 extends TabsBase {
       databaseResourceId: options.collection.databaseId,
       collectionResourceId: options.collection.id(),
     };
+  }
+
+  public canDuplicate(): boolean {
+    return true;
+  }
+
+  public duplicateTab(): void {
+    const newTab = new DocumentsTabV2({
+      partitionKey: this.partitionKey,
+      documentIds: ko.observableArray<DocumentId>([]),
+      tabKind: ViewModels.CollectionTabKind.Documents,
+      title: "Items",
+      collection: this.collection,
+      node: this.collection,
+      tabPath: `${this.collection.databaseId}>${this.collection.id()}>Documents`,
+      isPreferredApiMongoDB: userContext.apiType === "Mongo",
+      resourceTokenPartitionKey: this.resourceTokenPartitionKey,
+    });
+    useTabs.getState().activateNewTab(newTab);
   }
 
   public render(): JSX.Element {

--- a/src/Explorer/Tabs/MongoQueryTab/MongoQueryTab.tsx
+++ b/src/Explorer/Tabs/MongoQueryTab/MongoQueryTab.tsx
@@ -74,6 +74,7 @@ export class NewMongoQueryTab extends NewQueryTab {
 
   public duplicateTab(): void {
     const id = useTabs.getState().getTabs(ViewModels.CollectionTabKind.Query).length + 1;
+    const queryText = this.iTabAccessor?.onSaveClickEvent() ?? this.persistedState?.query?.text ?? "";
     const newTab = new NewMongoQueryTab(
       {
         tabKind: ViewModels.CollectionTabKind.Query,
@@ -81,7 +82,7 @@ export class NewMongoQueryTab extends NewQueryTab {
         tabPath: "",
         collection: this.collection,
         node: this.collection,
-        queryText: this.persistedState?.query?.text ?? "",
+        queryText,
         partitionKey: this.partitionKey,
         splitterDirection: this.persistedState?.splitterDirection,
         queryViewSizePercent: this.persistedState?.queryViewSizePercent,

--- a/src/Explorer/Tabs/MongoQueryTab/MongoQueryTab.tsx
+++ b/src/Explorer/Tabs/MongoQueryTab/MongoQueryTab.tsx
@@ -2,6 +2,7 @@ import { ActionType, TabKind } from "Contracts/ActionContracts";
 import React from "react";
 import MongoUtility from "../../../Common/MongoUtility";
 import * as ViewModels from "../../../Contracts/ViewModels";
+import { useTabs } from "../../../hooks/useTabs";
 import Explorer from "../../Explorer";
 import { NewQueryTab } from "../QueryTab/QueryTab";
 import { IQueryTabComponentProps, ITabAccessor, QueryTabComponent } from "../QueryTab/QueryTabComponent";
@@ -65,6 +66,29 @@ export class NewMongoQueryTab extends NewQueryTab {
   //eslint-disable-next-line
   public renderObjectForEditor(value: any, replacer: any, space: string | number): string {
     return MongoUtility.tojson(value, undefined, false);
+  }
+
+  public canDuplicate(): boolean {
+    return true;
+  }
+
+  public duplicateTab(): void {
+    const id = useTabs.getState().getTabs(ViewModels.CollectionTabKind.Query).length + 1;
+    const newTab = new NewMongoQueryTab(
+      {
+        tabKind: ViewModels.CollectionTabKind.Query,
+        title: `Query ${id}`,
+        tabPath: "",
+        collection: this.collection,
+        node: this.collection,
+        queryText: this.persistedState?.query?.text ?? "",
+        partitionKey: this.partitionKey,
+        splitterDirection: this.persistedState?.splitterDirection,
+        queryViewSizePercent: this.persistedState?.queryViewSizePercent,
+      },
+      this.mongoQueryTabProps,
+    );
+    useTabs.getState().activateNewTab(newTab);
   }
 
   public render(): JSX.Element {

--- a/src/Explorer/Tabs/QueryTab/QueryTab.duplicateTab.test.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTab.duplicateTab.test.tsx
@@ -1,0 +1,104 @@
+import { useTabs } from "hooks/useTabs";
+import * as ko from "knockout";
+import * as ViewModels from "../../../Contracts/ViewModels";
+import { IQueryTabProps, NewQueryTab } from "./QueryTab";
+
+jest.mock("hooks/useTabs", () => ({
+  useTabs: {
+    getState: jest.fn(),
+  },
+}));
+
+jest.mock("Explorer/Menus/CommandBar/CommandBarComponentAdapter", () => ({
+  useCommandBar: { getState: jest.fn(() => ({ setContextButtons: jest.fn() })) },
+}));
+
+jest.mock("Shared/AppStatePersistenceUtility", () => ({
+  loadState: jest.fn(),
+  AppStateComponentNames: {},
+  readSubComponentState: jest.fn(),
+}));
+
+jest.mock("Common/MessageHandler", () => ({
+  sendMessage: jest.fn(),
+}));
+
+const mockCollection = {
+  id: ko.observable<string>("testContainer"),
+  databaseId: "testDb",
+  partitionKey: { paths: ["/pk"], kind: "Hash", version: 2 },
+  selectedSubnodeKind: jest.fn(),
+  container: {},
+} as unknown as ViewModels.Collection;
+
+const mockProps = { container: {} as IQueryTabProps["container"] };
+
+const buildTab = (queryText = "SELECT * FROM c") =>
+  new NewQueryTab(
+    {
+      tabKind: ViewModels.CollectionTabKind.Query,
+      title: "Query 1",
+      tabPath: "",
+      collection: mockCollection,
+      node: mockCollection,
+      queryText,
+      partitionKey: mockCollection.partitionKey,
+    },
+    mockProps,
+  );
+
+describe("NewQueryTab.duplicateTab", () => {
+  let activateNewTab: jest.Mock;
+  let getTabs: jest.Mock;
+
+  beforeEach(() => {
+    activateNewTab = jest.fn();
+    getTabs = jest.fn().mockReturnValue([]);
+    (useTabs.getState as jest.Mock).mockReturnValue({ activateNewTab, getTabs });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it("calls activateNewTab with a new NewQueryTab instance", () => {
+    const tab = buildTab();
+    tab.duplicateTab();
+
+    expect(activateNewTab).toHaveBeenCalledTimes(1);
+    const newTab = activateNewTab.mock.calls[0][0];
+    expect(newTab).toBeInstanceOf(NewQueryTab);
+  });
+
+  it("preserves the current query text in the duplicate", () => {
+    const queryText = "SELECT * FROM c WHERE c.id = '123'";
+    const tab = buildTab(queryText);
+    tab.duplicateTab();
+
+    const newTab = activateNewTab.mock.calls[0][0] as NewQueryTab;
+    expect(newTab.iQueryTabComponentProps.queryText).toBe(queryText);
+  });
+
+  it("creates a duplicate with the same collection", () => {
+    const tab = buildTab();
+    tab.duplicateTab();
+
+    const newTab = activateNewTab.mock.calls[0][0] as NewQueryTab;
+    expect(newTab.collection).toBe(mockCollection);
+  });
+
+  it("creates a distinct tab instance", () => {
+    const tab = buildTab();
+    tab.duplicateTab();
+
+    const newTab = activateNewTab.mock.calls[0][0];
+    expect(newTab).not.toBe(tab);
+  });
+
+  it("assigns an auto-incremented title based on existing query tabs", () => {
+    getTabs.mockReturnValue([{}, {}]); // 2 existing tabs → new title = "Query 3"
+    const tab = buildTab();
+    tab.duplicateTab();
+
+    const newTab = activateNewTab.mock.calls[0][0] as NewQueryTab;
+    expect(newTab.tabTitle()).toContain("Query 3");
+  });
+});

--- a/src/Explorer/Tabs/QueryTab/QueryTab.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTab.tsx
@@ -4,6 +4,7 @@ import { MessageTypes } from "Contracts/MessageTypes";
 import React from "react";
 import * as DataModels from "../../../Contracts/DataModels";
 import type { QueryTabOptions } from "../../../Contracts/ViewModels";
+import * as ViewModels from "../../../Contracts/ViewModels";
 import { useTabs } from "../../../hooks/useTabs";
 import Explorer from "../../Explorer";
 import { IQueryTabComponentProps, ITabAccessor, QueryTabComponent } from "../../Tabs/QueryTab/QueryTabComponent";
@@ -70,6 +71,30 @@ export class NewQueryTab extends TabsBase {
       splitterDirection: options.splitterDirection,
       queryViewSizePercent: options.queryViewSizePercent,
     });
+  }
+
+  public canDuplicate(): boolean {
+    return true;
+  }
+
+  public duplicateTab(): void {
+    const queryText = this.persistedState?.query?.text ?? "";
+    const id = useTabs.getState().getTabs(ViewModels.CollectionTabKind.Query).length + 1;
+    const newTab = new NewQueryTab(
+      {
+        tabKind: ViewModels.CollectionTabKind.Query,
+        title: `Query ${id}`,
+        tabPath: "",
+        collection: this.collection,
+        node: this.collection,
+        queryText,
+        partitionKey: this.partitionKey,
+        splitterDirection: this.persistedState?.splitterDirection,
+        queryViewSizePercent: this.persistedState?.queryViewSizePercent,
+      },
+      this.props,
+    );
+    useTabs.getState().activateNewTab(newTab);
   }
 
   public render(): JSX.Element {

--- a/src/Explorer/Tabs/QueryTab/QueryTab.tsx
+++ b/src/Explorer/Tabs/QueryTab/QueryTab.tsx
@@ -78,7 +78,7 @@ export class NewQueryTab extends TabsBase {
   }
 
   public duplicateTab(): void {
-    const queryText = this.persistedState?.query?.text ?? "";
+    const queryText = this.iTabAccessor?.onSaveClickEvent() ?? this.persistedState?.query?.text ?? "";
     const id = useTabs.getState().getTabs(ViewModels.CollectionTabKind.Query).length + 1;
     const newTab = new NewQueryTab(
       {

--- a/src/Explorer/Tabs/SettingsTabV2.tsx
+++ b/src/Explorer/Tabs/SettingsTabV2.tsx
@@ -1,7 +1,6 @@
 import { ActionType, OpenCollectionTab, TabKind } from "Contracts/ActionContracts";
 import React from "react";
 import * as ViewModels from "../../Contracts/ViewModels";
-import { useTabs } from "../../hooks/useTabs";
 import { SettingsComponent } from "../Controls/Settings/SettingsComponent";
 import TabsBase from "./TabsBase";
 
@@ -22,21 +21,6 @@ export class CollectionSettingsTabV2 extends SettingsTabV2 {
       databaseResourceId: options.collection.databaseId,
       collectionResourceId: options.collection.id(),
     };
-  }
-
-  public canDuplicate(): boolean {
-    return true;
-  }
-
-  public duplicateTab(): void {
-    const newTab = new CollectionSettingsTabV2({
-      tabKind: ViewModels.CollectionTabKind.CollectionSettingsV2,
-      title: this.tabTitle(),
-      tabPath: "",
-      collection: this.collection,
-      node: this.collection,
-    });
-    useTabs.getState().activateNewTab(newTab);
   }
 
   public onActivate(): void {

--- a/src/Explorer/Tabs/SettingsTabV2.tsx
+++ b/src/Explorer/Tabs/SettingsTabV2.tsx
@@ -1,6 +1,7 @@
 import { ActionType, OpenCollectionTab, TabKind } from "Contracts/ActionContracts";
 import React from "react";
 import * as ViewModels from "../../Contracts/ViewModels";
+import { useTabs } from "../../hooks/useTabs";
 import { SettingsComponent } from "../Controls/Settings/SettingsComponent";
 import TabsBase from "./TabsBase";
 
@@ -21,6 +22,21 @@ export class CollectionSettingsTabV2 extends SettingsTabV2 {
       databaseResourceId: options.collection.databaseId,
       collectionResourceId: options.collection.id(),
     };
+  }
+
+  public canDuplicate(): boolean {
+    return true;
+  }
+
+  public duplicateTab(): void {
+    const newTab = new CollectionSettingsTabV2({
+      tabKind: ViewModels.CollectionTabKind.CollectionSettingsV2,
+      title: this.tabTitle(),
+      tabPath: "",
+      collection: this.collection,
+      node: this.collection,
+    });
+    useTabs.getState().activateNewTab(newTab);
   }
 
   public onActivate(): void {

--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -1,4 +1,5 @@
 import { Spinner, SpinnerSize, TooltipHost } from "@fluentui/react";
+import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from "@fluentui/react-components";
 import { CollectionTabKind } from "Contracts/ViewModels";
 import Explorer from "Explorer/Explorer";
 import { useCommandBar } from "Explorer/Menus/CommandBar/CommandBarComponentAdapter";
@@ -10,6 +11,7 @@ import { QuickstartTab } from "Explorer/Tabs/QuickstartTab";
 import { VcoreMongoConnectTab } from "Explorer/Tabs/VCoreMongoConnectTab";
 import { VcoreMongoQuickstartTab } from "Explorer/Tabs/VCoreMongoQuickstartTab";
 import { KeyboardAction, KeyboardActionGroup, useKeyboardActionGroup } from "KeyboardShortcuts";
+import { Keys, t } from "Localization";
 import { isFabricNative } from "Platform/Fabric/FabricUtil";
 import { userContext } from "UserContext";
 import { useTeachingBubble } from "hooks/useTeachingBubble";
@@ -86,74 +88,96 @@ function TabNav({ tab, active, tabKind }: { tab?: Tab; active: boolean; tabKind?
     }
   }, [active]);
   return (
-    <li
-      onMouseOver={() => setHovering(true)}
-      onMouseLeave={() => setHovering(false)}
-      className={active ? "active tabList" : "tabList"}
-      style={active ? { fontWeight: "bolder" } : {}}
-      role="presentation"
-    >
-      <span className="tabNavContentContainer">
-        <div className="tab_Content">
-          <TooltipHost content={useObservable(tab?.tabPath || ko.observable(""))}>
-            <span
-              className="contentWrapper"
-              onClick={() => {
-                if (tab) {
-                  tab.onTabClick();
-                } else if (tabKind !== undefined) {
-                  useTabs.getState().activateReactTab(tabKind);
-                }
-              }}
-              onKeyPress={({ nativeEvent: e }) => {
-                if (tab) {
-                  tab.onKeyPressActivate(undefined, e);
-                } else if (tabKind !== undefined) {
-                  onKeyPressReactTab(e, tabKind);
-                }
-              }}
-              aria-selected={active}
-              aria-expanded={active}
-              aria-controls={tabId}
-              tabIndex={0}
-              role="tab"
-              ref={focusTab}
-            >
-              <span className="statusIconContainer" style={{ width: tabKind === ReactTabKind.Home ? 0 : 18 }}>
-                {useObservable(tab?.isExecutionError || ko.observable(false)) && (
-                  <ErrorIcon tab={tab} active={active} />
-                )}
-                {useObservable(tab?.isExecutionWarning || ko.observable(false)) && (
-                  <WarningIcon tab={tab} active={active} />
-                )}
-                {isTabExecuting(tab, tabKind) && (
-                  <Spinner
-                    size={SpinnerSize.small}
-                    styles={{
-                      circle: {
-                        borderTopColor: "var(--colorNeutralForeground1)",
-                        borderLeftColor: "var(--colorNeutralForeground1)",
-                        borderBottomColor: "var(--colorNeutralForeground1)",
-                        borderRightColor: "var(--colorNeutralBackground1)",
-                      },
-                    }}
-                  />
-                )}
-                {isQueryErrorThrown(tab, tabKind) && (
-                  <TooltipHost content="Error">
-                    <img src={errorQuery} alt="Error" style={{ marginTop: 4, marginLeft: 4, width: 10, height: 11 }} />
-                  </TooltipHost>
-                )}
+    <Menu openOnContext>
+      <MenuTrigger disableButtonEnhancement>
+        <li
+          onMouseOver={() => setHovering(true)}
+          onMouseLeave={() => setHovering(false)}
+          className={active ? "active tabList" : "tabList"}
+          style={active ? { fontWeight: "bolder" } : {}}
+          role="presentation"
+        >
+          <span className="tabNavContentContainer">
+            <div className="tab_Content">
+              <TooltipHost content={useObservable(tab?.tabPath || ko.observable(""))}>
+                <span
+                  className="contentWrapper"
+                  onClick={() => {
+                    if (tab) {
+                      tab.onTabClick();
+                    } else if (tabKind !== undefined) {
+                      useTabs.getState().activateReactTab(tabKind);
+                    }
+                  }}
+                  onKeyPress={({ nativeEvent: e }) => {
+                    if (tab) {
+                      tab.onKeyPressActivate(undefined, e);
+                    } else if (tabKind !== undefined) {
+                      onKeyPressReactTab(e, tabKind);
+                    }
+                  }}
+                  aria-selected={active}
+                  aria-expanded={active}
+                  aria-controls={tabId}
+                  tabIndex={0}
+                  role="tab"
+                  ref={focusTab}
+                >
+                  <span className="statusIconContainer" style={{ width: tabKind === ReactTabKind.Home ? 0 : 18 }}>
+                    {useObservable(tab?.isExecutionError || ko.observable(false)) && (
+                      <ErrorIcon tab={tab} active={active} />
+                    )}
+                    {useObservable(tab?.isExecutionWarning || ko.observable(false)) && (
+                      <WarningIcon tab={tab} active={active} />
+                    )}
+                    {isTabExecuting(tab, tabKind) && (
+                      <Spinner
+                        size={SpinnerSize.small}
+                        styles={{
+                          circle: {
+                            borderTopColor: "var(--colorNeutralForeground1)",
+                            borderLeftColor: "var(--colorNeutralForeground1)",
+                            borderBottomColor: "var(--colorNeutralForeground1)",
+                            borderRightColor: "var(--colorNeutralBackground1)",
+                          },
+                        }}
+                      />
+                    )}
+                    {isQueryErrorThrown(tab, tabKind) && (
+                      <TooltipHost content="Error">
+                        <img
+                          src={errorQuery}
+                          alt="Error"
+                          style={{ marginTop: 4, marginLeft: 4, width: 10, height: 11 }}
+                        />
+                      </TooltipHost>
+                    )}
+                  </span>
+                  <span className="tabNavText">{tabTitle}</span>
+                </span>
+              </TooltipHost>
+              <span className="tabIconSection">
+                <CloseButton tab={tab} active={active} hovering={hovering} tabKind={tabKind} ariaLabel={tabTitle} />
               </span>
-              <span className="tabNavText">{tabTitle}</span>
-            </span>
-          </TooltipHost>
-          <span className="tabIconSection">
-            <CloseButton tab={tab} active={active} hovering={hovering} tabKind={tabKind} ariaLabel={tabTitle} />
+            </div>
           </span>
-        </div>
-      </span>
-    </li>
+        </li>
+      </MenuTrigger>
+      <MenuPopover>
+        <MenuList>
+          {tab?.canDuplicate() && (
+            <MenuItem onClick={() => tab.duplicateTab()}>{t(Keys.tabs.tabMenu.duplicateTab)}</MenuItem>
+          )}
+          <MenuItem
+            onClick={() => {
+              tab ? tab.onCloseTabButtonClick() : useTabs.getState().closeReactTab(tabKind);
+            }}
+          >
+            {t(Keys.tabs.tabMenu.closeTab)}
+          </MenuItem>
+        </MenuList>
+      </MenuPopover>
+    </Menu>
   );
 }
 

--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -91,6 +91,7 @@ function TabNav({ tab, active, tabKind }: { tab?: Tab; active: boolean; tabKind?
     <Menu openOnContext>
       <MenuTrigger disableButtonEnhancement>
         <li
+          data-test={`TabNav:${tab !== undefined ? tab.tabId : ReactTabKind[tabKind!]}`}
           onMouseOver={() => setHovering(true)}
           onMouseLeave={() => setHovering(false)}
           className={active ? "active tabList" : "tabList"}

--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -87,95 +87,93 @@ function TabNav({ tab, active, tabKind }: { tab?: Tab; active: boolean; tabKind?
       focusTab.current.focus();
     }
   }, [active]);
+  const liElement = (
+    <li
+      data-test={`TabNav:${tab !== undefined ? tab.tabId : ReactTabKind[tabKind!]}`}
+      onMouseOver={() => setHovering(true)}
+      onMouseLeave={() => setHovering(false)}
+      className={active ? "active tabList" : "tabList"}
+      style={active ? { fontWeight: "bolder" } : {}}
+      role="presentation"
+    >
+      <span className="tabNavContentContainer">
+        <div className="tab_Content">
+          <TooltipHost content={useObservable(tab?.tabPath || ko.observable(""))}>
+            <span
+              className="contentWrapper"
+              onClick={() => {
+                if (tab) {
+                  tab.onTabClick();
+                } else if (tabKind !== undefined) {
+                  useTabs.getState().activateReactTab(tabKind);
+                }
+              }}
+              onKeyPress={({ nativeEvent: e }) => {
+                if (tab) {
+                  tab.onKeyPressActivate(undefined, e);
+                } else if (tabKind !== undefined) {
+                  onKeyPressReactTab(e, tabKind);
+                }
+              }}
+              aria-selected={active}
+              aria-expanded={active}
+              aria-controls={tabId}
+              tabIndex={0}
+              role="tab"
+              ref={focusTab}
+            >
+              <span className="statusIconContainer" style={{ width: tabKind === ReactTabKind.Home ? 0 : 18 }}>
+                {useObservable(tab?.isExecutionError || ko.observable(false)) && (
+                  <ErrorIcon tab={tab} active={active} />
+                )}
+                {useObservable(tab?.isExecutionWarning || ko.observable(false)) && (
+                  <WarningIcon tab={tab} active={active} />
+                )}
+                {isTabExecuting(tab, tabKind) && (
+                  <Spinner
+                    size={SpinnerSize.small}
+                    styles={{
+                      circle: {
+                        borderTopColor: "var(--colorNeutralForeground1)",
+                        borderLeftColor: "var(--colorNeutralForeground1)",
+                        borderBottomColor: "var(--colorNeutralForeground1)",
+                        borderRightColor: "var(--colorNeutralBackground1)",
+                      },
+                    }}
+                  />
+                )}
+                {isQueryErrorThrown(tab, tabKind) && (
+                  <TooltipHost content="Error">
+                    <img
+                      src={errorQuery}
+                      alt="Error"
+                      style={{ marginTop: 4, marginLeft: 4, width: 10, height: 11 }}
+                    />
+                  </TooltipHost>
+                )}
+              </span>
+              <span className="tabNavText">{tabTitle}</span>
+            </span>
+          </TooltipHost>
+          <span className="tabIconSection">
+            <CloseButton tab={tab} active={active} hovering={hovering} tabKind={tabKind} ariaLabel={tabTitle} />
+          </span>
+        </div>
+      </span>
+    </li>
+  );
+
+  if (!tab?.canDuplicate()) {
+    return liElement;
+  }
+
   return (
     <Menu openOnContext>
-      <MenuTrigger disableButtonEnhancement>
-        <li
-          data-test={`TabNav:${tab !== undefined ? tab.tabId : ReactTabKind[tabKind!]}`}
-          onMouseOver={() => setHovering(true)}
-          onMouseLeave={() => setHovering(false)}
-          className={active ? "active tabList" : "tabList"}
-          style={active ? { fontWeight: "bolder" } : {}}
-          role="presentation"
-        >
-          <span className="tabNavContentContainer">
-            <div className="tab_Content">
-              <TooltipHost content={useObservable(tab?.tabPath || ko.observable(""))}>
-                <span
-                  className="contentWrapper"
-                  onClick={() => {
-                    if (tab) {
-                      tab.onTabClick();
-                    } else if (tabKind !== undefined) {
-                      useTabs.getState().activateReactTab(tabKind);
-                    }
-                  }}
-                  onKeyPress={({ nativeEvent: e }) => {
-                    if (tab) {
-                      tab.onKeyPressActivate(undefined, e);
-                    } else if (tabKind !== undefined) {
-                      onKeyPressReactTab(e, tabKind);
-                    }
-                  }}
-                  aria-selected={active}
-                  aria-expanded={active}
-                  aria-controls={tabId}
-                  tabIndex={0}
-                  role="tab"
-                  ref={focusTab}
-                >
-                  <span className="statusIconContainer" style={{ width: tabKind === ReactTabKind.Home ? 0 : 18 }}>
-                    {useObservable(tab?.isExecutionError || ko.observable(false)) && (
-                      <ErrorIcon tab={tab} active={active} />
-                    )}
-                    {useObservable(tab?.isExecutionWarning || ko.observable(false)) && (
-                      <WarningIcon tab={tab} active={active} />
-                    )}
-                    {isTabExecuting(tab, tabKind) && (
-                      <Spinner
-                        size={SpinnerSize.small}
-                        styles={{
-                          circle: {
-                            borderTopColor: "var(--colorNeutralForeground1)",
-                            borderLeftColor: "var(--colorNeutralForeground1)",
-                            borderBottomColor: "var(--colorNeutralForeground1)",
-                            borderRightColor: "var(--colorNeutralBackground1)",
-                          },
-                        }}
-                      />
-                    )}
-                    {isQueryErrorThrown(tab, tabKind) && (
-                      <TooltipHost content="Error">
-                        <img
-                          src={errorQuery}
-                          alt="Error"
-                          style={{ marginTop: 4, marginLeft: 4, width: 10, height: 11 }}
-                        />
-                      </TooltipHost>
-                    )}
-                  </span>
-                  <span className="tabNavText">{tabTitle}</span>
-                </span>
-              </TooltipHost>
-              <span className="tabIconSection">
-                <CloseButton tab={tab} active={active} hovering={hovering} tabKind={tabKind} ariaLabel={tabTitle} />
-              </span>
-            </div>
-          </span>
-        </li>
-      </MenuTrigger>
+      <MenuTrigger disableButtonEnhancement>{liElement}</MenuTrigger>
       <MenuPopover>
         <MenuList>
-          {tab?.canDuplicate() && (
-            <MenuItem onClick={() => tab.duplicateTab()}>{t(Keys.tabs.tabMenu.duplicateTab)}</MenuItem>
-          )}
-          <MenuItem
-            onClick={() => {
-              tab ? tab.onCloseTabButtonClick() : useTabs.getState().closeReactTab(tabKind);
-            }}
-          >
-            {t(Keys.tabs.tabMenu.closeTab)}
-          </MenuItem>
+          <MenuItem onClick={() => tab.duplicateTab()}>{t(Keys.tabs.tabMenu.duplicateTab)}</MenuItem>
+          <MenuItem onClick={() => tab.onCloseTabButtonClick()}>{t(Keys.tabs.tabMenu.closeTab)}</MenuItem>
         </MenuList>
       </MenuPopover>
     </Menu>

--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -144,11 +144,7 @@ function TabNav({ tab, active, tabKind }: { tab?: Tab; active: boolean; tabKind?
                 )}
                 {isQueryErrorThrown(tab, tabKind) && (
                   <TooltipHost content="Error">
-                    <img
-                      src={errorQuery}
-                      alt="Error"
-                      style={{ marginTop: 4, marginLeft: 4, width: 10, height: 11 }}
-                    />
+                    <img src={errorQuery} alt="Error" style={{ marginTop: 4, marginLeft: 4, width: 10, height: 11 }} />
                   </TooltipHost>
                 )}
               </span>

--- a/src/Explorer/Tabs/TabsBase.ts
+++ b/src/Explorer/Tabs/TabsBase.ts
@@ -64,6 +64,14 @@ export default class TabsBase extends WaitsForTemplateViewModel {
   public getPersistedState = (): OpenTab | null => this.persistedState;
   public triggerPersistState: () => void = undefined;
 
+  public canDuplicate(): boolean {
+    return false;
+  }
+
+  public duplicateTab(): void {
+    // Subclasses override this to support tab duplication
+  }
+
   public onCloseTabButtonClick(): void {
     useTabs.getState().closeTab(this);
     TelemetryProcessor.trace(Action.Tab, ActionModifiers.Close, {

--- a/src/Explorer/Tree/Database.tsx
+++ b/src/Explorer/Tree/Database.tsx
@@ -256,8 +256,12 @@ export default class Database implements ViewModels.Database {
         databaseId: this.id(),
         databaseResourceId: this.self,
       };
-      this.offer(await readDatabaseOffer(params));
-      this.isOfferRead = true;
+      try {
+        this.offer(await readDatabaseOffer(params));
+        this.isOfferRead = true;
+      } catch {
+        // Don't propagate - leave isOfferRead false so it can be retried
+      }
     }
   }
 

--- a/src/Localization/en/Resources.json
+++ b/src/Localization/en/Resources.json
@@ -316,6 +316,10 @@
     "deleteUdf": "Delete User Defined Function"
   },
   "tabs": {
+    "tabMenu": {
+      "duplicateTab": "Duplicate tab",
+      "closeTab": "Close tab"
+    },
     "documents": {
       "newItem": "New Item",
       "newDocument": "New Document",

--- a/test/fx.ts
+++ b/test/fx.ts
@@ -438,7 +438,16 @@ export class DataExplorer {
    * There's only a single "primary" button, but we still require you to pass the label to confirm you're selecting the right button.
    */
   async globalCommandButton(label: string): Promise<Locator> {
-    await this.frame.getByTestId("GlobalCommands").click();
+    const globalCommands = this.frame.getByTestId("GlobalCommands");
+    // Prefer the explicit dropdown trigger so we always open the menu rather than
+    // triggering a primary action directly.  The SplitButton (wide sidebar) exposes
+    // "More commands" and the MenuButton (narrow sidebar) is labelled "New…".
+    const dropdownTrigger = globalCommands.getByRole("button", { name: "More commands" });
+    if (await dropdownTrigger.isVisible()) {
+      await dropdownTrigger.click();
+    } else {
+      await globalCommands.click();
+    }
     return this.frame.getByRole("menuitem", { name: label });
   }
 

--- a/test/fx.ts
+++ b/test/fx.ts
@@ -616,6 +616,16 @@ export class DataExplorer {
     await page.goto(url);
     return DataExplorer.waitForExplorer(page);
   }
+
+  /** Returns the tab navigation <li> element for the given tab ID or React tab name (e.g. "tab0", "Home") */
+  tabNavHeader(tabId: string): Locator {
+    return this.frame.getByTestId(`TabNav:${tabId}`);
+  }
+
+  /** Returns a context menu item in the tab right-click menu by visible label */
+  tabContextMenuItem(label: string): Locator {
+    return this.frame.getByRole("menuitem", { name: label });
+  }
 }
 
 export async function waitForApiResponse(

--- a/test/sql/duplicateTab.spec.ts
+++ b/test/sql/duplicateTab.spec.ts
@@ -77,25 +77,6 @@ test("Duplicate Query tab preserves query text in new tab", async () => {
   expect(editorText).toContain("duplicate-query-test");
 });
 
-test("Duplicate Scale & Settings tab opens a second settings tab", async () => {
-  await explorer.openScaleAndSettings(context);
-
-  // Wait for the settings tab pane to be attached
-  const tab0 = explorer.tab("tab0");
-  await expect(tab0).toBeAttached({ timeout: 30_000 });
-
-  // Right-click the tab nav header
-  await explorer.tabNavHeader("tab0").click({ button: "right" });
-
-  const duplicateMenuItem = explorer.tabContextMenuItem("Duplicate tab");
-  await expect(duplicateMenuItem).toBeVisible();
-  await duplicateMenuItem.click();
-
-  // A second settings tab should appear
-  const tab1 = explorer.tab("tab1");
-  await expect(tab1).toBeAttached({ timeout: 30_000 });
-});
-
 test("Duplicate tab menu item is not shown for the Home tab", async () => {
   // The Home tab (ReactTabKind) is never duplicable
   await explorer.tabNavHeader("Home").click({ button: "right" });

--- a/test/sql/duplicateTab.spec.ts
+++ b/test/sql/duplicateTab.spec.ts
@@ -77,15 +77,13 @@ test("Duplicate Query tab preserves query text in new tab", async () => {
   expect(editorText).toContain("duplicate-query-test");
 });
 
-test("Duplicate tab menu item is not shown for the Home tab", async () => {
-  // The Home tab (ReactTabKind) is never duplicable
+test("Right-click context menu does not appear for the Home tab", async () => {
+  // The Home tab (ReactTabKind) is never duplicable — no context menu should appear
   await explorer.tabNavHeader("Home").click({ button: "right" });
 
-  // "Close tab" should always appear
-  await expect(explorer.tabContextMenuItem("Close tab")).toBeVisible();
-
-  // "Duplicate tab" must NOT appear
+  // Neither menu item should be visible
   await expect(explorer.tabContextMenuItem("Duplicate tab")).not.toBeVisible();
+  await expect(explorer.tabContextMenuItem("Close tab")).not.toBeVisible();
 });
 
 test("Close tab from right-click menu closes the tab", async () => {

--- a/test/sql/duplicateTab.spec.ts
+++ b/test/sql/duplicateTab.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "@playwright/test";
+
+import { DataExplorer, TestAccount } from "../fx";
+import { createTestSQLContainer, TestContainerContext } from "../testData";
+
+let context: TestContainerContext = null!;
+let explorer: DataExplorer = null!;
+
+test.beforeAll("Create Test Database", async () => {
+  context = await createTestSQLContainer({ includeTestData: false });
+});
+
+test.afterAll("Delete Test Database", async () => {
+  await context?.dispose();
+});
+
+test.beforeEach("Open Data Explorer", async ({ page }) => {
+  explorer = await DataExplorer.open(page, TestAccount.SQL);
+});
+
+test("Duplicate Items tab opens a second Items tab", async () => {
+  // Open Items tab
+  const containerNode = await explorer.waitForContainerNode(context.database.id, context.container.id);
+  await containerNode.expand();
+  const itemsNode = await explorer.waitForContainerItemsNode(context.database.id, context.container.id);
+  await itemsNode.element.click();
+
+  const documentsTab = explorer.documentsTab("tab0");
+  await documentsTab.documentsFilter.waitFor({ timeout: 30_000 });
+
+  // Right-click the tab nav header
+  await explorer.tabNavHeader("tab0").click({ button: "right" });
+
+  // "Duplicate tab" should be visible in the context menu
+  const duplicateMenuItem = explorer.tabContextMenuItem("Duplicate tab");
+  await expect(duplicateMenuItem).toBeVisible();
+  await duplicateMenuItem.click();
+
+  // A second tab should appear
+  const tab1 = explorer.tab("tab1");
+  await expect(tab1).toBeAttached({ timeout: 30_000 });
+
+  // The duplicated tab should also show the Documents content
+  const duplicatedTab = explorer.documentsTab("tab1");
+  await duplicatedTab.documentsFilter.waitFor({ timeout: 30_000 });
+});
+
+test("Duplicate Query tab preserves query text in new tab", async () => {
+  // Open a new SQL query tab via container context menu
+  const containerNode = await explorer.waitForContainerNode(context.database.id, context.container.id);
+  await containerNode.openContextMenu();
+  await containerNode.contextMenuItem("New SQL Query").click();
+
+  const queryTab = explorer.queryTab("tab0");
+  const editor = queryTab.editor();
+  await editor.locator.waitFor({ timeout: 30_000 });
+
+  // Type a custom query
+  const customQuery = 'SELECT * FROM c WHERE c.id = "duplicate-query-test"';
+  await editor.setText(customQuery);
+
+  // Right-click the tab nav header
+  await explorer.tabNavHeader("tab0").click({ button: "right" });
+
+  const duplicateMenuItem = explorer.tabContextMenuItem("Duplicate tab");
+  await expect(duplicateMenuItem).toBeVisible();
+  await duplicateMenuItem.click();
+
+  // Second query tab should appear
+  const tab1 = explorer.tab("tab1");
+  await expect(tab1).toBeAttached({ timeout: 30_000 });
+
+  // The duplicated tab should contain the same query text
+  const duplicatedQueryTab = explorer.queryTab("tab1");
+  await duplicatedQueryTab.editor().locator.waitFor({ timeout: 30_000 });
+  const editorText = await duplicatedQueryTab.editor().text();
+  expect(editorText).toContain("duplicate-query-test");
+});
+
+test("Duplicate Scale & Settings tab opens a second settings tab", async () => {
+  await explorer.openScaleAndSettings(context);
+
+  // Wait for the settings tab pane to be attached
+  const tab0 = explorer.tab("tab0");
+  await expect(tab0).toBeAttached({ timeout: 30_000 });
+
+  // Right-click the tab nav header
+  await explorer.tabNavHeader("tab0").click({ button: "right" });
+
+  const duplicateMenuItem = explorer.tabContextMenuItem("Duplicate tab");
+  await expect(duplicateMenuItem).toBeVisible();
+  await duplicateMenuItem.click();
+
+  // A second settings tab should appear
+  const tab1 = explorer.tab("tab1");
+  await expect(tab1).toBeAttached({ timeout: 30_000 });
+});
+
+test("Duplicate tab menu item is not shown for the Home tab", async () => {
+  // The Home tab (ReactTabKind) is never duplicable
+  await explorer.tabNavHeader("Home").click({ button: "right" });
+
+  // "Close tab" should always appear
+  await expect(explorer.tabContextMenuItem("Close tab")).toBeVisible();
+
+  // "Duplicate tab" must NOT appear
+  await expect(explorer.tabContextMenuItem("Duplicate tab")).not.toBeVisible();
+});
+
+test("Close tab from right-click menu closes the tab", async () => {
+  // Open Items tab
+  const containerNode = await explorer.waitForContainerNode(context.database.id, context.container.id);
+  await containerNode.expand();
+  const itemsNode = await explorer.waitForContainerItemsNode(context.database.id, context.container.id);
+  await itemsNode.element.click();
+
+  const documentsTab = explorer.documentsTab("tab0");
+  await documentsTab.documentsFilter.waitFor({ timeout: 30_000 });
+
+  // Right-click the tab nav header and close the tab
+  await explorer.tabNavHeader("tab0").click({ button: "right" });
+  await explorer.tabContextMenuItem("Close tab").click();
+
+  // The tab pane should be removed
+  await expect(explorer.tab("tab0")).not.toBeAttached({ timeout: 15_000 });
+});


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2485?feature.someFeatureFlagYouMightNeed=true)

Adds a right-click context menu on tab headers that lets users duplicate the current tab. The menu shows "Duplicate tab" and "Close tab" options, but "Duplicate tab" only appears for tabs that support it.

### APIs affected

- ✅ SQL — Items, Query, Scale & Settings
- ✅ Mongo — Documents, Query (Mongo-native), Scale & Settings
- ✅ Gremlin — Query, Scale & Settings
- ✅ Cassandra — Documents, Scale & Settings
- ➖ Tables — no duplicable tabs (entities tab not supported)

### Screenshots

<img width="1091" height="897" alt="image" src="https://github.com/user-attachments/assets/16e4c84c-3597-4ae3-bf11-dbc4d8832bdb" />
<img width="1540" height="833" alt="image" src="https://github.com/user-attachments/assets/07ffe732-455a-42f1-9b09-4adf913a93c1" />
<img width="727" height="352" alt="image" src="https://github.com/user-attachments/assets/981ba912-7950-4cc5-998b-dd03f7b2b375" />
