### PR TITLE
Fix stored XSS via Cassandra column names in DataTable headers

### DIFF
--- a/src/Explorer/Tables/DataTable/DataTableBindingManager.ts
+++ b/src/Explorer/Tables/DataTable/DataTableBindingManager.ts
@@ -93,7 +93,7 @@ function createDataTable(
 
   for (var i = 0; i < tableEntityListViewModel.headers.length; i++) {
     jsonColTable.push({
-      sTitle: tableEntityListViewModel.headers[i],
+      sTitle: Utilities.htmlEncode(tableEntityListViewModel.headers[i]),
       data: tableEntityListViewModel.headers[i],
       aTargets: [i],
       mRender: bindColumn,


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2499)

### Problem
Cassandra column names are passed directly to DataTables `sTitle`, which renders them as HTML. An attacker can create a column named `<img src=x onerror=alert(1)>` to execute JavaScript in any victim's browser session when they view the table.

### Fix
HTML-encode column names with `Utilities.htmlEncode()` before passing to `sTitle`, same as cell values are already encoded in `bindColumn`.