### PR TITLE
Fixing a github alert

### DIFF
--- a/src/Explorer/ContainerCopy/Actions/CopyJobActions.tsx
+++ b/src/Explorer/ContainerCopy/Actions/CopyJobActions.tsx
@@ -115,7 +115,7 @@ export const getCopyJobs = async (): Promise<CopyJobType[]> => {
       });
     return formattedJobs;
   } catch (error) {
-    const errorContent = JSON.stringify(error.content || error.message || error);
+    const errorContent = String(error.content || error.message || error);
     if (errorContent.includes("signal is aborted without reason")) {
       throw {
         message: "Previous copy job request was cancelled.",

--- a/src/Explorer/Graph/GraphExplorerComponent/GraphExplorer.tsx
+++ b/src/Explorer/Graph/GraphExplorerComponent/GraphExplorer.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { FeedOptions, ItemDefinition, QueryIterator, Resource } from "@azure/cosmos";
+import { stringifyError } from "Common/stringifyError";
 import * as Q from "q";
 import * as React from "react";
 import LoadGraphIcon from "../../../../images/LoadGraph.png";
@@ -1092,8 +1093,8 @@ export class GraphExplorer extends React.Component<GraphExplorerProps, GraphExpl
   public static reportToConsole(type: ConsoleDataType, msg: string, ...errorData: any[]): void | (() => void) {
     let errorDataStr = "";
     if (errorData && errorData.length > 0) {
-      console.error(msg, errorData);
-      errorDataStr = ": " + JSON.stringify(errorData);
+      console.error(msg, String(errorData));
+      errorDataStr = ": " + stringifyError(errorData);
     }
 
     const consoleMessage = `${msg}${errorDataStr}`;

--- a/src/Explorer/Graph/GraphExplorerComponent/GraphExplorer.tsx
+++ b/src/Explorer/Graph/GraphExplorerComponent/GraphExplorer.tsx
@@ -1093,7 +1093,7 @@ export class GraphExplorer extends React.Component<GraphExplorerProps, GraphExpl
   public static reportToConsole(type: ConsoleDataType, msg: string, ...errorData: any[]): void | (() => void) {
     let errorDataStr = "";
     if (errorData && errorData.length > 0) {
-      console.error(msg, String(errorData));
+      console.error(msg + String(errorData));
       errorDataStr = ": " + stringifyError(errorData);
     }
 

--- a/src/Explorer/Notebook/NotebookComponent/store.ts
+++ b/src/Explorer/Notebook/NotebookComponent/store.ts
@@ -1,6 +1,7 @@
 import { AppState, epics as coreEpics, IContentProvider, reducers } from "@nteract/core";
 import { configuration } from "@nteract/mythic-configuration";
 import { makeConfigureStore } from "@nteract/myths";
+import { stringifyError } from "Common/stringifyError";
 import { AnyAction, compose, Dispatch, Middleware, MiddlewareAPI, Store } from "redux";
 import { Epic } from "redux-observable";
 import { Observable } from "rxjs";
@@ -44,7 +45,7 @@ export default function configureStore(
 
   const traceFailure = (title: string, error: any) => {
     if (error instanceof Error) {
-      onTraceFailure(title, `${error.message} ${JSON.stringify(error.stack)}`);
+      onTraceFailure(title, `${error.message} ${stringifyError(error.stack)}`);
       console.error(error);
     } else {
       onTraceFailure(title, error.message);

--- a/src/Explorer/Tables/DataTable/TableEntityListViewModel.ts
+++ b/src/Explorer/Tables/DataTable/TableEntityListViewModel.ts
@@ -1,3 +1,4 @@
+import { stringifyError } from "Common/stringifyError";
 import * as DataTables from "datatables.net";
 import * as ko from "knockout";
 import Q from "q";
@@ -37,7 +38,7 @@ function parseError(err: any): ErrorDataModel[] {
   try {
     return _parse(err);
   } catch (e) {
-    return [<ErrorDataModel>{ message: JSON.stringify(err) }];
+    return [<ErrorDataModel>{ message: stringifyError(err) }];
   }
 }
 


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2506)

We got an alert on this concatenation:
console.error(msg, errorData) (src\Explorer\Graph\GraphExplorerComponent\GraphExplorer.tsx, line 1096)

If msg had a format converter of, say %d and errorData was a string then the the console.log would show "foo bar NaN". I don't think this is too likely, but this fixes that issue by manually concatenating msg and errorData which seems to have been the intent but doing it the old way is causing an alert.