### PR TITLE
Fix playwright token leak 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,6 +353,13 @@ jobs:
             -s playwright-reports \
             --pattern "${KEY}/shards/*" \
             -d ./all-blob-reports
+          # az storage blob download-batch preserves the full blob path, so files
+          # land nested under all-blob-reports/{KEY}/shards/shard-N/report-*.zip.
+          # playwright merge-reports expects the .zip files directly in the target
+          # directory, so flatten the structure.
+          find ./all-blob-reports -type f -name "*.zip" -exec mv -t ./all-blob-reports {} +
+          find ./all-blob-reports -type d -empty -delete
+          ls -la ./all-blob-reports
 
       - name: Merge into HTML Report
         run: npx playwright merge-reports --reporter html ./all-blob-reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,8 +408,7 @@ jobs:
             --jq '[.jobs[] | select(.name | startswith("Run Playwright Tests")) | select(.conclusion == "failure")] | length')
           if [ "$FAILED" -gt 0 ] || [ "$BROKEN" -gt 0 ]; then ICON="❌ failed"; else ICON="✅ passed"; fi
           SA_ENC=$(printf '%s' "$SA_ID" | jq -sRr @uri)
-          BLOB_PATH_ENC=$(printf 'playwright-reports/%s/report.zip' "$KEY" | jq -sRr @uri)
-          REPORT_URL="https://portal.azure.com/#view/Microsoft_Azure_Storage/BlobPropertiesBladeV2/storageAccountId/${SA_ENC}/path/${BLOB_PATH_ENC}"
+          CONTAINER_URL="https://portal.azure.com/#view/Microsoft_Azure_Storage/ContainerMenuBlade/~/overview/storageAccountId/${SA_ENC}/path/playwright-reports"
           NOTE=""
           [ "$BROKEN" -gt 0 ] && NOTE="
 
@@ -420,6 +419,6 @@ jobs:
           | :---: | :---: | :---: | :---: |
           | $PASSED | $FAILED | $FLAKY | ${DURATION}s |
 
-          📁 [Download report.zip]($REPORT_URL) (Azure sign-in required → click **Download** → unzip → open \`index.html\`) · [Workflow run]($RUN_URL)$NOTE"
+          📁 [Open report container]($CONTAINER_URL) (Azure sign-in required) → navigate to \`${KEY}/report.zip\` → click **Download** → unzip → open \`index.html\` · [Workflow run]($RUN_URL)$NOTE"
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,6 +419,7 @@ jobs:
           | :---: | :---: | :---: | :---: |
           | $PASSED | $FAILED | $FLAKY | ${DURATION}s |
 
-          📁 [Open report container]($CONTAINER_URL) (Azure sign-in required) → navigate to \`${KEY}/report.zip\` → click **Download** → unzip → open \`index.html\` · [Workflow run]($RUN_URL)$NOTE"
+          📁 **Report:** \`${KEY}/report.zip\`
+          [Open container]($CONTAINER_URL) (Azure sign-in required) → click into \`${KEY}\` folder → click \`report.zip\` → **Download** → unzip → open \`index.html\` · [Workflow run]($RUN_URL)$NOTE"
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,9 +166,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMP: smoke-testing MSRC ci.yml changes. Revert to [1..20] / [20] before merging.
-        shardIndex: [1]
-        shardTotal: [1]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        shardTotal: [20]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 18.x
@@ -297,11 +296,9 @@ jobs:
             echo "::add-mask::$MONGO_READONLY_TESTACCOUNT_TOKEN"
             echo MONGO_READONLY_TESTACCOUNT_TOKEN=$MONGO_READONLY_TESTACCOUNT_TOKEN >> $GITHUB_ENV
       - name: List test files for shard ${{ matrix['shardIndex'] }} of ${{ matrix['shardTotal']}}
-        # TEMP: smoke-testing MSRC ci.yml changes. Revert before merging.
-        run: npx playwright test test/component-fixtures/searchableDropdown/searchableDropdown.spec.ts --project="Google Chrome" --grep "renders subscription dropdown with label and placeholder" --list
+        run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --list
       - name: Run test shard ${{ matrix['shardIndex'] }} of ${{ matrix['shardTotal']}}
-        # TEMP: smoke-testing MSRC ci.yml changes. Revert before merging.
-        run: npx playwright test test/component-fixtures/searchableDropdown/searchableDropdown.spec.ts --project="Google Chrome" --grep "renders subscription dropdown with label and placeholder" --workers=1
+        run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers=3
       - name: Upload shard blob-report to Azure Storage
         if: ${{ !cancelled() }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,13 +299,19 @@ jobs:
         run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --list
       - name: Run test shard ${{ matrix['shardIndex'] }} of ${{ matrix['shardTotal']}}
         run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers=3
-      - name: Upload blob report to GitHub Actions Artifacts
+      - name: Upload shard blob-report to Azure Storage
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: blob-report-${{ matrix.shardIndex }}
-          path: blob-report
-          retention-days: 1
+        env:
+          KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+          SHARD: ${{ matrix.shardIndex }}
+        run: |
+          az storage blob upload-batch \
+            --account-name ${{ secrets.PREVIEW_STORAGE_ACCOUNT_NAME }} \
+            --auth-mode login \
+            -d playwright-reports \
+            -s blob-report \
+            --destination-path "${KEY}/shards/shard-${SHARD}" \
+            --overwrite true
 
   merge-playwright-reports:
     name: "Merge Playwright Reports"
@@ -325,29 +331,64 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download blob reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@v4
+      - name: "Az CLI login"
+        uses: Azure/login@v2
         with:
-          path: all-blob-reports
-          pattern: blob-report-*
-          merge-multiple: true
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.PREVIEW_SUBSCRIPTION_ID }}
+
+      - name: Download all shard reports from Azure Storage
+        env:
+          KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          mkdir -p all-blob-reports
+          az storage blob download-batch \
+            --account-name ${{ secrets.PREVIEW_STORAGE_ACCOUNT_NAME }} \
+            --auth-mode login \
+            -s playwright-reports \
+            --pattern "${KEY}/shards/*" \
+            -d ./all-blob-reports
 
       - name: Merge into HTML Report
         run: npx playwright merge-reports --reporter html ./all-blob-reports
 
-      - name: Upload HTML report
-        uses: actions/upload-artifact@v4
-        with:
-          name: html-report--attempt-${{ github.run_attempt }}
-          path: playwright-report
-          retention-days: 14
+      - name: Bundle merged report into a single zip
+        run: |
+          cd playwright-report
+          zip -r ../report.zip .
+          cd ..
+
+      - name: Upload report.zip to Azure Storage
+        env:
+          KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          az storage blob upload \
+            --account-name ${{ secrets.PREVIEW_STORAGE_ACCOUNT_NAME }} \
+            --auth-mode login \
+            -c playwright-reports \
+            -n "${KEY}/report.zip" \
+            -f report.zip \
+            --overwrite
+
+      - name: Clean up shard intermediates from Azure Storage
+        if: ${{ always() }}
+        env:
+          KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          az storage blob delete-batch \
+            --account-name ${{ secrets.PREVIEW_STORAGE_ACCOUNT_NAME }} \
+            --auth-mode login \
+            -s playwright-reports \
+            --pattern "${KEY}/shards/*"
 
       - name: Comment Playwright results on PR
         if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
-          REPORT_URL: https://dataexplorerpreview.z5.web.core.windows.net/playwright-reports/${{ github.run_id }}-${{ github.run_attempt }}/index.html
+          SA_ID: /subscriptions/${{ secrets.PREVIEW_SUBSCRIPTION_ID }}/resourceGroups/dataexplorer-preview/providers/Microsoft.Storage/storageAccounts/dataexplorerpreview
+          KEY: ${{ github.run_id }}-${{ github.run_attempt }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           PLAYWRIGHT_JSON_OUTPUT_NAME=results.json npx playwright merge-reports --reporter json ./all-blob-reports
@@ -355,6 +396,9 @@ jobs:
           BROKEN=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs" \
             --jq '[.jobs[] | select(.name | startswith("Run Playwright Tests")) | select(.conclusion == "failure")] | length')
           if [ "$FAILED" -gt 0 ] || [ "$BROKEN" -gt 0 ]; then ICON="❌ failed"; else ICON="✅ passed"; fi
+          SA_ENC=$(printf '%s' "$SA_ID" | jq -sRr @uri)
+          BLOB_PATH_ENC=$(printf 'playwright-reports/%s/report.zip' "$KEY" | jq -sRr @uri)
+          REPORT_URL="https://portal.azure.com/#view/Microsoft_Azure_Storage/BlobPropertiesBladeV2/storageAccountId/${SA_ENC}/path/${BLOB_PATH_ENC}"
           NOTE=""
           [ "$BROKEN" -gt 0 ] && NOTE="
 
@@ -365,38 +409,6 @@ jobs:
           | :---: | :---: | :---: | :---: |
           | $PASSED | $FAILED | $FLAKY | ${DURATION}s |
 
-          📊 [Open full report]($REPORT_URL) · [Workflow run]($RUN_URL)$NOTE"
+          📁 [Download report.zip]($REPORT_URL) (Azure sign-in required → click **Download** → unzip → open \`index.html\`) · [Workflow run]($RUN_URL)$NOTE"
 
-  publish-playwright-report:
-    name: "Publish Playwright Report to Blob"
-    if: ${{ !cancelled() }}
-    needs: [merge-playwright-reports]
 
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Download HTML report artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: html-report--attempt-${{ github.run_attempt }}
-          path: playwright-report
-
-      - name: "Az CLI login"
-        uses: Azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.PREVIEW_SUBSCRIPTION_ID }}
-
-      - name: Upload Playwright report to blob storage
-        env:
-          KEY: ${{ github.run_id }}-${{ github.run_attempt }}
-          BASE: https://dataexplorerpreview.z5.web.core.windows.net
-        run: |
-          az storage blob upload-batch -d '$web' -s playwright-report \
-            --destination-path "playwright-reports/${KEY}" \
-            --account-name ${{ secrets.PREVIEW_STORAGE_ACCOUNT_NAME }} \
-            --auth-mode login --overwrite true
-          echo "📊 [Open Playwright report](${BASE}/playwright-reports/${KEY}/index.html)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,8 +166,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
-        shardTotal: [20]
+        # TEMP: smoke-testing MSRC ci.yml changes. Revert to [1..20] / [20] before merging.
+        shardIndex: [1]
+        shardTotal: [1]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 18.x
@@ -296,9 +297,11 @@ jobs:
             echo "::add-mask::$MONGO_READONLY_TESTACCOUNT_TOKEN"
             echo MONGO_READONLY_TESTACCOUNT_TOKEN=$MONGO_READONLY_TESTACCOUNT_TOKEN >> $GITHUB_ENV
       - name: List test files for shard ${{ matrix['shardIndex'] }} of ${{ matrix['shardTotal']}}
-        run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --list
+        # TEMP: smoke-testing MSRC ci.yml changes. Revert before merging.
+        run: npx playwright test test/component-fixtures/searchableDropdown/searchableDropdown.spec.ts --project="Google Chrome" --grep "renders subscription dropdown with label and placeholder" --list
       - name: Run test shard ${{ matrix['shardIndex'] }} of ${{ matrix['shardTotal']}}
-        run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers=3
+        # TEMP: smoke-testing MSRC ci.yml changes. Revert before merging.
+        run: npx playwright test test/component-fixtures/searchableDropdown/searchableDropdown.spec.ts --project="Google Chrome" --grep "renders subscription dropdown with label and placeholder" --workers=1
       - name: Upload shard blob-report to Azure Storage
         if: ${{ !cancelled() }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,13 @@ jobs:
         run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --list
       - name: Run test shard ${{ matrix['shardIndex'] }} of ${{ matrix['shardTotal']}}
         run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers=3
+      - name: "Re-auth for upload (refresh OIDC token)"
+        if: ${{ !cancelled() }}
+        uses: Azure/login@v2
+        with:
+          client-id: ${{ secrets.E2E_TESTS_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Upload shard blob-report to Azure Storage
         if: ${{ !cancelled() }}
         env:
@@ -350,10 +357,6 @@ jobs:
             -s playwright-reports \
             --pattern "${KEY}/shards/*" \
             -d ./all-blob-reports
-          # az storage blob download-batch preserves the full blob path, so files
-          # land nested under all-blob-reports/{KEY}/shards/shard-N/report-*.zip.
-          # playwright merge-reports expects the .zip files directly in the target
-          # directory, so flatten the structure.
           find ./all-blob-reports -type f -name "*.zip" -exec mv -t ./all-blob-reports {} +
           find ./all-blob-reports -type d -empty -delete
           ls -la ./all-blob-reports
@@ -418,5 +421,3 @@ jobs:
 
           📁 **Report:** \`${KEY}/report.zip\`
           [Open container]($CONTAINER_URL) (Azure sign-in required) → click into \`${KEY}\` folder → click \`report.zip\` → **Download** → unzip → open \`index.html\` · [Workflow run]($RUN_URL)$NOTE"
-
-


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2512?feature.someFeatureFlagYouMightNeed=true)

Moves Playwright shard reports and the merged HTML report from GitHub Actions artifacts + the public $web static-site endpoint to a new private playwright-reports container on the dataexplorerpreview storage account.

Workflow changes (.github/workflows/ci.yml):

 - Shards upload their blob-report/ to playwright-reports/<run_id>-<attempt>/shards/shard-N/ via az storage blob upload-batch --auth-mode login
 - Merge job downloads shards with download-batch, flattens the nested layout, runs playwright merge-reports, zips, and uploads to playwright-reports/<run_id>-<attempt>/report.zip
 - Shard intermediates are cleaned up after merge
 - Merge job's permissions: block adds id-token: write (job-level perms replace workflow-level)
 - A fresh Azure/login@v2 runs right before each upload step to refresh the OIDC token (5-min validity window; long shards would otherwise hit AADSTS700024)
 - PR comment surfaces <run_id>-<attempt>/report.zip prominently and links to an Azure Portal ContainerMenuBlade deep link (sign-in required)
 - Two new repository secrets used: PREVIEW_STORAGE_ACCOUNT_NAME and PREVIEW_SUBSCRIPTION_ID

Storage account changes:

 - New container playwright-reports created with --public-access off
 - E2E_TESTS_CLIENT_ID SP granted Storage Blob Data Contributor at container scope (shard uploads)
 - AZURE_CLIENT_ID SP granted Storage Blob Data Contributor at container scope (merge job)
 - 3 readers (2 users + 1 SP) granted Storage Blob Data Reader at container scope
 - 30-day lifecycle policy delete-playwright-reports-after-30-days on the playwright-reports/ prefix
