### PR TITLE
Fix preview app startup (Express 5 route syntax)

### DIFF
--- a/preview/index.js
+++ b/preview/index.js
@@ -46,7 +46,7 @@ const app = express();
 app.use("/api", api);
 app.use("/proxy", proxy);
 app.use("/commit", commit);
-app.get("/pull/:pr(\\d+)", (req, res) => {
+app.get("/pull/:pr", (req, res) => {
   const pr = req.params.pr;
   if (!/^\d+$/.test(pr)) {
     return res.status(400).send("Invalid pull request number");

--- a/preview/package-lock.json
+++ b/preview/package-lock.json
@@ -12,9 +12,7 @@
         "express": "^5.2.1",
         "follow-redirects": "^1.16.0",
         "http-proxy-middleware": "^3.0.7",
-        "node": "^20.19.5",
-        "node-fetch": "^2.6.1",
-        "path-to-regexp": "^0.1.13"
+        "node-fetch": "^2.6.1"
       }
     },
     "node_modules/@types/http-proxy": {
@@ -589,20 +587,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node": {
-      "version": "20.19.5",
-      "hasInstallScript": true,
-      "license": "ISC",
-      "dependencies": {
-        "node-bin-setup": "^1.0.0"
-      },
-      "bin": {
-        "node": "bin/node.exe"
-      },
-      "engines": {
-        "npm": ">=5.0.0"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "license": "MIT",
@@ -620,10 +604,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/node/node_modules/node-bin-setup": {
-      "version": "1.1.4",
-      "license": "ISC"
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -660,12 +640,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",

--- a/preview/package.json
+++ b/preview/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "deploy": "az webapp up --name \"dataexplorer-preview\" --subscription \"cosmosdb-portalteam-runners\" --resource-group \"dataexplorer-preview\" --runtime \"NODE:20-lts\" --sku P1V2",
+    "deploy": "az webapp up --name \"dataexplorer-preview\" --subscription \"cosmosdb-portalteam-runners\" --resource-group \"dataexplorer-preview\" --runtime \"NODE:22-lts\" --sku P1V2",
     "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -15,8 +15,6 @@
     "express": "^5.2.1",
     "follow-redirects": "^1.16.0",
     "http-proxy-middleware": "^3.0.7",
-    "node": "^20.19.5",
-    "node-fetch": "^2.6.1",
-    "path-to-regexp": "^0.1.13"
+    "node-fetch": "^2.6.1"
   }
 }


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2536?feature.someFeatureFlagYouMightNeed=true)

# Fix preview app startup on Node 22 (Express 5 route syntax)

## Summary

The Cosmos Explorer Preview app (`preview/`, deployed as the `dataexplorer-preview` Azure Web App) crashes on startup after being redeployed on Node 22. This PR fixes the crash, updates the deploy runtime to Node 22, and removes two dependencies that no longer belong in `package.json`.

## Problem

On startup the app throws and the process exits:

```
PathError [TypeError]: Unexpected ( at index 9: /pull/:pr(\d+); visit https://git.new/pathToRegexpError for info
    at consumeUntil (/node_modules/router/node_modules/path-to-regexp/dist/index.js:130:23)
    ...
  originalPath: '/pull/:pr(\\d+)'
```

## Root cause

- Dependabot previously bumped `express` from **4.21.2 → 5.2.1** in `preview/`.
- Express 5 replaced its internal router with `router@2.2.0`, which depends on `path-to-regexp@8`.
- path-to-regexp v8 **removed inline-regex route parameters**. The route pattern `"/pull/:pr(\\d+)"` in `preview/index.js` is no longer valid syntax and throws when the route is registered at startup.
- The Node 20 → 22 migration was **coincidental**. The crash is caused by Express 5, not the Node runtime. The old Node 20 deployment still had `express@4` installed (where `:pr(\d+)` worked); redeploying for Node 22 ran a fresh `npm install` that resolved `express@5` from the current `package.json`, surfacing the crash.

## Changes

- **`preview/index.js`** — Change the route from `"/pull/:pr(\\d+)"` to `"/pull/:pr"`. This is behavior-preserving: the handler already validates the parameter with `/^\d+$/` and returns HTTP 400 for non-numeric PR values.
- **`preview/package.json`**
  - Deploy script `--runtime` updated from `"NODE:20-lts"` to `"NODE:22-lts"`.
  - Removed the stray `"node": "^20.19.5"` dependency (the `node` npm package bundles a Node binary and does not belong in app dependencies; App Service provides the runtime).
  - Removed the unused top-level `"path-to-regexp": "^0.1.13"` dependency (`index.js` does not require it directly; Express 5's router bundles its own `path-to-regexp@8`).
- **`preview/package-lock.json`** — Regenerated via `npm install` to drop the removed entries.

## Testing

Verified locally on Node v22.19.0:

- `npm install` succeeds.
- `node index.js` starts cleanly and logs `Example app listening on port: ...` with **no `PathError`**.
- `GET /pull/abc` → **400** ("Invalid pull request number").
- `GET /pull/123` → **302** redirect (as before). Server stayed up throughout — no crash.

Also, deployed to internal web app and verified.

## Notes

- No functional change to routing behavior; only the startup crash and the deploy runtime target are affected.
- Scope is the root-level `preview/` site, **not** `src/preview/`.
- `preview/config.json` and `preview/.azure/config` are unchanged.
