### PR TITLE
Announce resource tree selection state to screen readers (#4798482)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ src/Localization/Keys.generated.ts
 /playwright/.cache/
 .vscode/mcp.json
 .playwright-mcp/
+
+# Playwright-cli
+.claude/skills/playwright-cli/
+/playwright-cli/

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ src/Localization/Keys.generated.ts
 
 # Playwright-cli
 .claude/skills/playwright-cli/
-/playwright-cli/
+.playwright-cli/

--- a/src/Explorer/Controls/TreeComponent/TreeNodeComponent.test.tsx
+++ b/src/Explorer/Controls/TreeComponent/TreeNodeComponent.test.tsx
@@ -110,6 +110,42 @@ describe("TreeNodeComponent", () => {
     expect(component).toMatchSnapshot();
   });
 
+  it("sets aria-selected=true on a selected selectable node", () => {
+    const node = generateTestNode("root", {
+      isSelected: () => true,
+    });
+    const component = shallow(<TreeNodeComponent openItems={[]} node={node} treeNodeId={node.id} />);
+    expect(component.find(TreeItem).first().props()["aria-selected"]).toBe(true);
+  });
+
+  it("sets aria-selected=false on an unselected selectable node", () => {
+    const node = generateTestNode("root", {
+      isSelected: () => false,
+    });
+    const component = shallow(<TreeNodeComponent openItems={[]} node={node} treeNodeId={node.id} />);
+    expect(component.find(TreeItem).first().props()["aria-selected"]).toBe(false);
+  });
+
+  it("does not set aria-selected on a non-selectable (grouping) node", () => {
+    const node = generateTestNode("root");
+    delete node.isSelected;
+    const component = shallow(<TreeNodeComponent openItems={[]} node={node} treeNodeId={node.id} />);
+    expect(component.find(TreeItem).first().props()["aria-selected"]).toBeUndefined();
+  });
+
+  it("sets aria-selected=false on a selected parent when a descendant is selected", () => {
+    const node = generateTestNode("root", {
+      isSelected: () => true,
+      children: [
+        generateTestNode("child1", {
+          isSelected: () => true,
+        }),
+      ],
+    });
+    const component = shallow(<TreeNodeComponent openItems={[]} node={node} treeNodeId={node.id} />);
+    expect(component.find(TreeItem).first().props()["aria-selected"]).toBe(false);
+  });
+
   it("renders an icon if the node has one", () => {
     const node = generateTestNode("root", {
       iconSrc: "the-icon.svg",

--- a/src/Explorer/Controls/TreeComponent/TreeNodeComponent.tsx
+++ b/src/Explorer/Controls/TreeComponent/TreeNodeComponent.tsx
@@ -172,6 +172,9 @@ export const TreeNodeComponent: React.FC<TreeNodeComponentProps> = ({
       itemType={isBranch ? "branch" : "leaf"}
       onOpenChange={onOpenChange}
       className={treeStyles.treeItem}
+      // Expose selection state to screen readers for selectable nodes so they announce "selected"/"not selected".
+      // Pure grouping nodes (no isSelected) omit the attribute, matching the ARIA single-select tree pattern.
+      aria-selected={node.isSelected ? shouldShowAsSelected : undefined}
     >
       <TreeItemLayout
         className={mergeClasses(

--- a/src/Explorer/Controls/TreeComponent/__snapshots__/TreeNodeComponent.test.tsx.snap
+++ b/src/Explorer/Controls/TreeComponent/__snapshots__/TreeNodeComponent.test.tsx.snap
@@ -111,6 +111,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
   treeNodeId="root"
 >
   <TreeItem
+    aria-selected={false}
     className=""
     data-test="TreeNodeContainer:root"
     itemType="branch"
@@ -120,6 +121,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
     <div
       aria-expanded={false}
       aria-level={0}
+      aria-selected={false}
       className="fui-TreeItem r15xhw3a"
       data-fui-tree-item-value="root"
       data-test="TreeNodeContainer:root"
@@ -218,6 +220,7 @@ exports[`TreeNodeComponent fully renders a tree 1`] = `
               "current": <div
                 aria-expanded="false"
                 aria-level="0"
+                aria-selected="false"
                 class="fui-TreeItem r15xhw3a"
                 data-fui-tree-item-value="root"
                 data-test="TreeNodeContainer:root"
@@ -1595,6 +1598,7 @@ exports[`TreeNodeComponent renders an icon if the node has one 1`] = `
 
 exports[`TreeNodeComponent renders selected parent node as selected if no descendant nodes are selected 1`] = `
 <TreeItem
+  aria-selected={true}
   className=""
   data-test="TreeNodeContainer:root"
   itemType="branch"
@@ -1678,6 +1682,7 @@ exports[`TreeNodeComponent renders selected parent node as selected if no descen
 
 exports[`TreeNodeComponent renders selected parent node as unselected if any descendant node is selected 1`] = `
 <TreeItem
+  aria-selected={false}
   className=""
   data-test="TreeNodeContainer:root"
   itemType="branch"
@@ -1762,6 +1767,7 @@ exports[`TreeNodeComponent renders selected parent node as unselected if any des
 
 exports[`TreeNodeComponent renders single selected leaf node as selected 1`] = `
 <TreeItem
+  aria-selected={true}
   className=""
   data-test="TreeNodeContainer:root"
   itemType="leaf"


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2541?feature.someFeatureFlagYouMightNeed=true)

## Problem

In the Data Explorer left-navigation resource tree, screen readers (NVDA, JAWS, Narrator) announced tree items such as `"Documents, 1 of 2, level 3"` but never conveyed whether the item was **selected** or **not selected**. Screen-reader users could not tell which node represented their current context.

This failed **MAS 4.1.2 – Name, Role, Value**. The tree only reflected selection *visually* (via the `selectedItem` style class) with no corresponding accessible state.

## Fix

Selection in the resource tree is a custom application-state concept (`node.isSelected()` combined with `shouldShowAsSelected`, which highlights only the deepest selected node). It intentionally does **not** use Fluent UI v9's built-in `Tree` `selectionMode`, because that renders visible radio buttons / checkboxes.

Fluent v9's `TreeItem` explicitly supports an `aria-selected` prop. This change wires the existing selection state to that prop on each `TreeItem`:

```tsx
aria-selected={node.isSelected ? shouldShowAsSelected : undefined}
```

Behavior, following the ARIA single-select tree pattern:

- **Selectable nodes** (those that define `isSelected` — databases, collections, Items/Documents, Settings/Scale, stored procedures, UDFs, triggers, conflicts, Home) announce `aria-selected="true"` when selected and `"false"` otherwise.
- **Pure grouping nodes** (no `isSelected` — the *Stored Procedures*, *User Defined Functions*, *Triggers*, *Schema* folders and *load more*) omit the attribute entirely, so screen readers don't announce a misleading state for non-selectable containers.

Because it reuses `shouldShowAsSelected`, the announced state always mirrors the visual highlight (only the deepest selected node is `"selected"`).

## Expected screen-reader result

- `"Documents, selected, 1 of 2, level 3"` when the item is selected
- `"Documents, not selected, 1 of 2, level 3"` when it is not selected

## Changes

- `src/Explorer/Controls/TreeComponent/TreeNodeComponent.tsx` — add `aria-selected` to `TreeItem`.
- `src/Explorer/Controls/TreeComponent/TreeNodeComponent.test.tsx` — add unit tests for selected, unselected, non-selectable (grouping), and selected-parent-with-selected-descendant cases.
- `src/Explorer/Controls/TreeComponent/__snapshots__/TreeNodeComponent.test.tsx.snap` — updated snapshots.

## Testing

- **Unit tests**: `npm run test:file -- src/Explorer/Controls/TreeComponent/TreeNodeComponent.test.tsx` — 14 passed (4 new).
- **Lint / TypeScript / Prettier**: `eslint`, `tsc --noEmit`, and `prettier --check` all pass on the changed files.
- **Manual E2E** (dev server + a live SQL account): verified the rendered DOM and the platform accessibility tree.

  | Node | `aria-selected` |
  |------|-----------------|
  | Home / databases / containers | `true` when selected, `false` otherwise |
  | `container1/Items` (bug scenario) | `true` when selected, `false` otherwise |
  | `Scale & Settings` | `false` when not selected |
  | Stored Procedures / UDFs / Triggers folders | attribute omitted |

  Selecting a leaf moved `aria-selected="true"` to that leaf and flipped its ancestor container back to `"false"`, matching the visual highlight. Playwright's accessibility snapshot reported `treeitem "Home" [selected]`, confirming the state reaches the platform accessibility API that NVDA consumes.

## Risk

Low. The change is additive and scoped to a single accessibility attribute; it does not alter selection logic, styling, or navigation behavior.

