### PR TITLE
feat: Add Cosmos DB Shell (NoSQL) support to Cloud Shell

### DIFF
--- a/src/Contracts/ViewModels.ts
+++ b/src/Contracts/ViewModels.ts
@@ -406,6 +406,7 @@ export enum TerminalKind {
   Cassandra = 2,
   Postgres = 3,
   VCoreMongo = 4,
+  CosmosDB = 5,
 }
 
 export interface DataExplorerInputsFrame {

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -666,6 +666,10 @@ export default class Explorer {
         title = "Mongo Shell";
         break;
 
+      case ViewModels.TerminalKind.CosmosDB:
+        title = "Cosmos DB Shell";
+        break;
+
       default:
         throw new Error("Terminal kind: ${kind} not supported");
     }

--- a/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
@@ -17,11 +17,11 @@ import SynapseIcon from "../../../../images/synapse-link.svg";
 import VSCodeIcon from "../../../../images/vscode.svg";
 import { AuthType } from "../../../AuthType";
 import * as Constants from "../../../Common/Constants";
-import { Platform, configContext } from "../../../ConfigContext";
+import { configContext, Platform } from "../../../ConfigContext";
 import * as ViewModels from "../../../Contracts/ViewModels";
 import {
-  userContext,
   isVCoreMongoNativeAuthDisabled,
+  userContext,
   VCoreMongoNativeAuthDisabledMessage,
   VCoreMongoNativeAuthLearnMoreUrl,
 } from "../../../UserContext";
@@ -79,6 +79,11 @@ export function createStaticCommandBarButtons(
       addDivider();
       buttons.push(loginButtonProps);
     }
+  }
+
+  if (userContext.apiType === "SQL" && userContext.features.enableCloudShell) {
+    addDivider();
+    buttons.push(createOpenTerminalButtonByKind(container, ViewModels.TerminalKind.CosmosDB));
   }
 
   if (!selectedNodeState.isDatabaseNodeOrNoneSelected()) {
@@ -498,6 +503,8 @@ function createOpenTerminalButtonByKind(
         return "PSQL";
       case ViewModels.TerminalKind.VCoreMongo:
         return "MongoDB (DocumentDB)";
+      case ViewModels.TerminalKind.CosmosDB:
+        return "Cosmos DB";
       default:
         return "";
     }
@@ -507,7 +514,9 @@ function createOpenTerminalButtonByKind(
     "This feature is not yet available in your account's region. View supported regions here: https://aka.ms/cosmos-enable-notebooks.";
   const isNativeAuthDisabled = terminalKind === ViewModels.TerminalKind.VCoreMongo && isVCoreMongoNativeAuthDisabled();
   const disableButton =
-    (!useNotebook.getState().isNotebooksEnabledForAccount && !useNotebook.getState().isNotebookEnabled) ||
+    (!useNotebook.getState().isNotebooksEnabledForAccount &&
+      !useNotebook.getState().isNotebookEnabled &&
+      !userContext.features.enableCloudShell) ||
     isNativeAuthDisabled;
   return {
     iconSrc: HostedTerminalIcon,

--- a/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
+++ b/src/Explorer/Menus/CommandBar/CommandBarComponentButtonFactory.tsx
@@ -81,7 +81,11 @@ export function createStaticCommandBarButtons(
     }
   }
 
-  if (userContext.apiType === "SQL" && userContext.features.enableCloudShell) {
+  if (
+    userContext.apiType === "SQL" &&
+    userContext.features.enableCloudShell &&
+    userContext.features.enableCosmosDBShell
+  ) {
     addDivider();
     buttons.push(createOpenTerminalButtonByKind(container, ViewModels.TerminalKind.CosmosDB));
   }

--- a/src/Explorer/Tabs/CloudShellTab/Data/CloudShellClient.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/Data/CloudShellClient.test.tsx
@@ -127,6 +127,7 @@ describe("CloudShellClient", () => {
             vnetSettings: {},
           },
         },
+        timeoutMs: 30000,
       });
       expect(result).toEqual(mockResponse);
     });
@@ -154,6 +155,7 @@ describe("CloudShellClient", () => {
             vnetSettings: mockVNetSettings,
           },
         },
+        timeoutMs: 30000,
       });
     });
 
@@ -212,6 +214,7 @@ describe("CloudShellClient", () => {
         path: "/subscriptions/sub-id/providers/Microsoft.CloudShell/register",
         method: "POST",
         apiVersion: "2022-12-01",
+        timeoutMs: 30000,
       });
       expect(result).toEqual(mockResponse);
     });
@@ -227,6 +230,7 @@ describe("CloudShellClient", () => {
         path: "/subscriptions/sub-id/providers/Microsoft.CloudShell/register",
         method: "POST",
         apiVersion: "2022-12-01",
+        timeoutMs: 30000,
       });
     });
   });
@@ -251,6 +255,7 @@ describe("CloudShellClient", () => {
             osType: OsType.Linux,
           },
         },
+        timeoutMs: 30000,
       });
       expect(result).toEqual(mockResponse);
     });
@@ -274,6 +279,7 @@ describe("CloudShellClient", () => {
             osType: OsType.Linux,
           },
         },
+        timeoutMs: 30000,
       });
     });
   });

--- a/src/Explorer/Tabs/CloudShellTab/Data/CloudShellClient.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/Data/CloudShellClient.tsx
@@ -14,6 +14,13 @@ import {
 } from "../Models/DataModels";
 import { getLocale } from "../Utils/CommonUtils";
 
+// armRequest defaults to a 5s timeout with no retry for PUT/POST. Cloud Shell provisioning
+// (registering the provider, applying settings, and provisioning the console itself) can
+// legitimately take much longer than that on first use or when the console region differs
+// from the user's usual region, so a much more generous timeout is used for these calls to
+// avoid a spurious AbortError ("User aborted query.") aborting the whole session start.
+const CLOUDSHELL_ARM_TIMEOUT_MS = 30000;
+
 export const getUserSettings = async (): Promise<CloudShellSettings> => {
   return await armRequest<CloudShellSettings>({
     host: configContext.ARM_ENDPOINT,
@@ -51,6 +58,7 @@ export const putEphemeralUserSettings = async (
     method: "PUT",
     apiVersion: "2023-02-01-preview",
     body: ephemeralSettings,
+    timeoutMs: CLOUDSHELL_ARM_TIMEOUT_MS,
   });
 };
 
@@ -69,6 +77,7 @@ export const registerCloudShellProvider = async (subscriptionId: string) => {
     path: `/subscriptions/${subscriptionId}/providers/Microsoft.CloudShell/register`,
     method: "POST",
     apiVersion: "2022-12-01",
+    timeoutMs: CLOUDSHELL_ARM_TIMEOUT_MS,
   });
 };
 
@@ -88,6 +97,7 @@ export const provisionConsole = async (consoleLocation: string): Promise<Provisi
       "x-ms-console-preferred-location": consoleLocation,
     },
     body: data,
+    timeoutMs: CLOUDSHELL_ARM_TIMEOUT_MS,
   });
 };
 

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.test.tsx
@@ -111,5 +111,13 @@ describe("CosmosDBShellHandler", () => {
       expect(connectionCommand).toContain("Unable to acquire a Cosmos DB credential");
       expect(connectionCommand).toContain("Login for Entra ID");
     });
+
+    it("should echo the specific reason when one is provided", () => {
+      const handler = new CosmosDBShellHandler(undefined, "listing the account keys failed (Forbidden)");
+      const connectionCommand = handler.getConnectionCommand();
+
+      expect(connectionCommand).toContain("Unable to acquire a Cosmos DB credential");
+      expect(connectionCommand).toContain("listing the account keys failed (Forbidden)");
+    });
   });
 });

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.test.tsx
@@ -1,0 +1,108 @@
+import { isCloudShellEntraAuthEnabled } from "../../../../Utils/AuthorizationUtils";
+import { CosmosDBShellHandler } from "./CosmosDBShellHandler";
+
+// Mock dependencies
+jest.mock("../../../../UserContext", () => ({
+  userContext: {
+    tenantId: "test-tenant-id",
+    databaseAccount: {
+      properties: {
+        documentEndpoint: "https://test-account.documents.azure.com:443/",
+      },
+    },
+  },
+}));
+
+jest.mock("../../../../Utils/AuthorizationUtils", () => ({
+  isCloudShellEntraAuthEnabled: jest.fn().mockReturnValue(false),
+}));
+
+describe("CosmosDBShellHandler", () => {
+  const mockKey = "testKey";
+  let cosmosDBShellHandler: CosmosDBShellHandler;
+
+  beforeEach(() => {
+    (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(false);
+    cosmosDBShellHandler = new CosmosDBShellHandler(mockKey);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  describe("Positive Tests", () => {
+    it("should return correct shell name", () => {
+      expect(cosmosDBShellHandler.getShellName()).toBe("Cosmos DB");
+    });
+
+    it("should install the CosmosDBShell tool in setup commands", () => {
+      const commands = cosmosDBShellHandler.getSetUpCommands();
+
+      expect(Array.isArray(commands)).toBe(true);
+      expect(commands.some((c) => c.includes("dotnet tool install --global CosmosDBShell --prerelease"))).toBe(true);
+      expect(commands.some((c) => c.includes("$HOME/.dotnet/tools"))).toBe(true);
+    });
+
+    it("should bootstrap a .NET SDK 10 when the tool and SDK are missing", () => {
+      const commands = cosmosDBShellHandler.getSetUpCommands();
+
+      expect(commands.some((c) => c.includes("dotnet-install.sh") && c.includes("--channel 10.0"))).toBe(true);
+      expect(commands.some((c) => c === "export DOTNET_ROOT=$HOME/.dotnet")).toBe(true);
+    });
+
+    it("should export the account key env var when RBAC is disabled", () => {
+      (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(false);
+      const handler = new CosmosDBShellHandler(mockKey);
+      const commands = handler.getSetUpCommands();
+
+      expect(commands.some((c) => c === `export COSMOSDB_SHELL_ACCOUNT_KEY='${mockKey}'`)).toBe(true);
+    });
+
+    it("should export the token env var when RBAC is enabled", () => {
+      (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(true);
+      const handler = new CosmosDBShellHandler("aadToken123");
+      const commands = handler.getSetUpCommands();
+
+      expect(commands.some((c) => c === `export COSMOSDB_SHELL_TOKEN='aadToken123'`)).toBe(true);
+    });
+
+    it("should generate proper connection command with endpoint", () => {
+      const connectionCommand = cosmosDBShellHandler.getConnectionCommand();
+
+      expect(connectionCommand).toBe(
+        "cosmosdbshell --connect 'https://test-account.documents.azure.com:443/' --connect-mode gateway --verbose",
+      );
+    });
+
+    it("should not add the tenant flag on the Entra ID connection command", () => {
+      (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(true);
+      const handler = new CosmosDBShellHandler("aadToken123");
+      const connectionCommand = handler.getConnectionCommand();
+
+      expect(connectionCommand).toBe(
+        "cosmosdbshell --connect 'https://test-account.documents.azure.com:443/' --connect-mode gateway --verbose",
+      );
+      expect(connectionCommand).not.toContain("--connect-tenant");
+    });
+
+    it("should return empty array for terminal suppressed data", () => {
+      expect(cosmosDBShellHandler.getTerminalSuppressedData()).toEqual([]);
+    });
+  });
+
+  describe("Negative Tests", () => {
+    it("should not export a credential env var when key is empty", () => {
+      const handler = new CosmosDBShellHandler("");
+      const commands = handler.getSetUpCommands();
+
+      expect(commands.some((c) => c.includes("COSMOSDB_SHELL_"))).toBe(false);
+    });
+  });
+});

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.test.tsx
@@ -1,18 +1,8 @@
-import { isCloudShellEntraAuthEnabled } from "../../../../Utils/AuthorizationUtils";
 import { CosmosDBShellHandler } from "./CosmosDBShellHandler";
 
 // Mock dependencies
-jest.mock("../../../../ConfigContext", () => ({
-  configContext: {
-    AAD_ENDPOINT: "https://login.microsoftonline.com/",
-  },
-}));
-
 jest.mock("../../../../UserContext", () => ({
   userContext: {
-    tenantId: "test-tenant-id",
-    subscriptionId: "test-subscription-id",
-    resourceGroup: "test-resource-group",
     databaseAccount: {
       properties: {
         documentEndpoint: "https://test-account.documents.azure.com:443/",
@@ -21,17 +11,14 @@ jest.mock("../../../../UserContext", () => ({
   },
 }));
 
-jest.mock("../../../../Utils/AuthorizationUtils", () => ({
-  isCloudShellEntraAuthEnabled: jest.fn().mockReturnValue(false),
-}));
-
 describe("CosmosDBShellHandler", () => {
   const mockKey = "testKey";
+  const expectedConnectionCommand =
+    "cosmosdbshell --connect 'https://test-account.documents.azure.com:443/' --connect-mode gateway --verbose";
   let cosmosDBShellHandler: CosmosDBShellHandler;
 
   beforeEach(() => {
-    (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(false);
-    cosmosDBShellHandler = new CosmosDBShellHandler(mockKey);
+    cosmosDBShellHandler = new CosmosDBShellHandler({ kind: "key", value: mockKey });
     jest.clearAllMocks();
   });
 
@@ -66,71 +53,41 @@ describe("CosmosDBShellHandler", () => {
       expect(commands.some((c) => c === "export DOTNET_ROOT=$HOME/.dotnet")).toBe(true);
     });
 
-    it("should export the account key env var when RBAC is disabled", () => {
-      (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(false);
-      const handler = new CosmosDBShellHandler(mockKey);
-      const commands = handler.getSetUpCommands();
+    it("should export the account key env var for a key credential", () => {
+      const commands = cosmosDBShellHandler.getSetUpCommands();
 
       expect(commands.some((c) => c === `export COSMOSDB_SHELL_ACCOUNT_KEY='${mockKey}'`)).toBe(true);
+      expect(commands.some((c) => c.includes("COSMOSDB_SHELL_TOKEN"))).toBe(false);
     });
 
-    it("should export the token env var when RBAC is enabled", () => {
-      (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(true);
-      const handler = new CosmosDBShellHandler("aadToken123");
+    it("should export the token env var for a token credential", () => {
+      const handler = new CosmosDBShellHandler({ kind: "token", value: "aadToken123" });
       const commands = handler.getSetUpCommands();
 
       expect(commands.some((c) => c === `export COSMOSDB_SHELL_TOKEN='aadToken123'`)).toBe(true);
+      expect(commands.some((c) => c.includes("COSMOSDB_SHELL_ACCOUNT_KEY"))).toBe(false);
     });
 
-    it("should generate proper connection command with endpoint", () => {
-      const connectionCommand = cosmosDBShellHandler.getConnectionCommand();
-
-      expect(connectionCommand).toBe(
-        "cosmosdbshell --connect 'https://test-account.documents.azure.com:443/' --connect-mode gateway --verbose",
-      );
+    it("should generate proper connection command with endpoint for a key credential", () => {
+      expect(cosmosDBShellHandler.getConnectionCommand()).toBe(expectedConnectionCommand);
     });
 
-    it("should not add the tenant flag on the Entra ID connection command", () => {
-      (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(true);
-      const handler = new CosmosDBShellHandler("aadToken123");
+    it("should generate the same connection command for a token credential", () => {
+      const handler = new CosmosDBShellHandler({ kind: "token", value: "aadToken123" });
+
+      expect(handler.getConnectionCommand()).toBe(expectedConnectionCommand);
+    });
+
+    it("should never pass an interactive or ambient credential flag", () => {
+      const handler = new CosmosDBShellHandler({ kind: "token", value: "aadToken123" });
       const connectionCommand = handler.getConnectionCommand();
 
-      expect(connectionCommand).toBe(
-        "cosmosdbshell --connect 'https://test-account.documents.azure.com:443/' --connect-mode gateway --verbose",
-      );
       expect(connectionCommand).not.toContain("--connect-tenant");
-    });
-
-    it("should use interactive Entra authentication when no token was fetched", () => {
-      (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(true);
-      const handler = new CosmosDBShellHandler("");
-      const connectionCommand = handler.getConnectionCommand();
-
-      expect(connectionCommand).toBe(
-        "cosmosdbshell --connect 'https://test-account.documents.azure.com:443/' --connect-mode gateway --connect-tenant 'test-tenant-id' --connect-authority-host 'https://login.microsoftonline.com/' --connect-subscription 'test-subscription-id' --connect-resource-group 'test-resource-group' --verbose",
-      );
+      expect(connectionCommand).not.toContain("--connect-hint");
+      expect(connectionCommand).not.toContain("--connect-authority-host");
       expect(connectionCommand).not.toContain("--connect-azure-cli");
-    });
-
-    it("should not use interactive Entra authentication when a token env var is exported", () => {
-      (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(true);
-      const handler = new CosmosDBShellHandler("aadToken123");
-
-      expect(handler.getConnectionCommand()).not.toContain("--connect-tenant");
-    });
-
-    it("should use interactive Entra authentication when no credential could be resolved on the key-auth path", () => {
-      (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(false);
-      const handler = new CosmosDBShellHandler("");
-
-      expect(handler.getConnectionCommand()).toContain("--connect-tenant 'test-tenant-id'");
-    });
-
-    it("should not use interactive Entra authentication when an account key env var is exported", () => {
-      (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(false);
-      const handler = new CosmosDBShellHandler("someKey");
-
-      expect(handler.getConnectionCommand()).not.toContain("--connect-tenant");
+      expect(connectionCommand).not.toContain("--connect-managed-identity");
+      expect(connectionCommand).not.toContain("--connect-vscode-credential");
     });
 
     it("should return empty array for terminal suppressed data", () => {
@@ -139,11 +96,20 @@ describe("CosmosDBShellHandler", () => {
   });
 
   describe("Negative Tests", () => {
-    it("should not export a credential env var when key is empty", () => {
-      const handler = new CosmosDBShellHandler("");
+    it("should not export a credential env var when no credential was resolved", () => {
+      const handler = new CosmosDBShellHandler(undefined);
       const commands = handler.getSetUpCommands();
 
       expect(commands.some((c) => c.includes("COSMOSDB_SHELL_"))).toBe(false);
+    });
+
+    it("should not launch the shell when no credential was resolved", () => {
+      const handler = new CosmosDBShellHandler(undefined);
+      const connectionCommand = handler.getConnectionCommand();
+
+      expect(connectionCommand).not.toContain("cosmosdbshell --connect");
+      expect(connectionCommand).toContain("Unable to acquire a Cosmos DB credential");
+      expect(connectionCommand).toContain("Login for Entra ID");
     });
   });
 });

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.test.tsx
@@ -47,6 +47,7 @@ describe("CosmosDBShellHandler", () => {
 
       expect(Array.isArray(commands)).toBe(true);
       expect(commands.some((c) => c.includes("dotnet tool install --global CosmosDBShell --prerelease"))).toBe(true);
+      expect(commands.some((c) => c.includes("dotnet tool update --global CosmosDBShell --prerelease"))).toBe(true);
       expect(commands.some((c) => c.includes("$HOME/.dotnet/tools"))).toBe(true);
     });
 
@@ -90,6 +91,37 @@ describe("CosmosDBShellHandler", () => {
         "cosmosdbshell --connect 'https://test-account.documents.azure.com:443/' --connect-mode gateway --verbose",
       );
       expect(connectionCommand).not.toContain("--connect-tenant");
+    });
+
+    it("should use the Azure CLI credential on the Entra ID path when no token was fetched", () => {
+      (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(true);
+      const handler = new CosmosDBShellHandler("");
+      const connectionCommand = handler.getConnectionCommand();
+
+      expect(connectionCommand).toBe(
+        "cosmosdbshell --connect 'https://test-account.documents.azure.com:443/' --connect-mode gateway --connect-azure-cli --verbose",
+      );
+    });
+
+    it("should not use the Azure CLI credential when a token env var is exported", () => {
+      (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(true);
+      const handler = new CosmosDBShellHandler("aadToken123");
+
+      expect(handler.getConnectionCommand()).not.toContain("--connect-azure-cli");
+    });
+
+    it("should use the Azure CLI credential when no credential could be resolved on the key-auth path", () => {
+      (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(false);
+      const handler = new CosmosDBShellHandler("");
+
+      expect(handler.getConnectionCommand()).toContain("--connect-azure-cli");
+    });
+
+    it("should not use the Azure CLI credential when an account key env var is exported", () => {
+      (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(false);
+      const handler = new CosmosDBShellHandler("someKey");
+
+      expect(handler.getConnectionCommand()).not.toContain("--connect-azure-cli");
     });
 
     it("should return empty array for terminal suppressed data", () => {

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.test.tsx
@@ -2,9 +2,17 @@ import { isCloudShellEntraAuthEnabled } from "../../../../Utils/AuthorizationUti
 import { CosmosDBShellHandler } from "./CosmosDBShellHandler";
 
 // Mock dependencies
+jest.mock("../../../../ConfigContext", () => ({
+  configContext: {
+    AAD_ENDPOINT: "https://login.microsoftonline.com/",
+  },
+}));
+
 jest.mock("../../../../UserContext", () => ({
   userContext: {
     tenantId: "test-tenant-id",
+    subscriptionId: "test-subscription-id",
+    resourceGroup: "test-resource-group",
     databaseAccount: {
       properties: {
         documentEndpoint: "https://test-account.documents.azure.com:443/",
@@ -93,35 +101,36 @@ describe("CosmosDBShellHandler", () => {
       expect(connectionCommand).not.toContain("--connect-tenant");
     });
 
-    it("should use the Azure CLI credential on the Entra ID path when no token was fetched", () => {
+    it("should use interactive Entra authentication when no token was fetched", () => {
       (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(true);
       const handler = new CosmosDBShellHandler("");
       const connectionCommand = handler.getConnectionCommand();
 
       expect(connectionCommand).toBe(
-        "cosmosdbshell --connect 'https://test-account.documents.azure.com:443/' --connect-mode gateway --connect-azure-cli --verbose",
+        "cosmosdbshell --connect 'https://test-account.documents.azure.com:443/' --connect-mode gateway --connect-tenant 'test-tenant-id' --connect-authority-host 'https://login.microsoftonline.com/' --connect-subscription 'test-subscription-id' --connect-resource-group 'test-resource-group' --verbose",
       );
+      expect(connectionCommand).not.toContain("--connect-azure-cli");
     });
 
-    it("should not use the Azure CLI credential when a token env var is exported", () => {
+    it("should not use interactive Entra authentication when a token env var is exported", () => {
       (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(true);
       const handler = new CosmosDBShellHandler("aadToken123");
 
-      expect(handler.getConnectionCommand()).not.toContain("--connect-azure-cli");
+      expect(handler.getConnectionCommand()).not.toContain("--connect-tenant");
     });
 
-    it("should use the Azure CLI credential when no credential could be resolved on the key-auth path", () => {
+    it("should use interactive Entra authentication when no credential could be resolved on the key-auth path", () => {
       (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(false);
       const handler = new CosmosDBShellHandler("");
 
-      expect(handler.getConnectionCommand()).toContain("--connect-azure-cli");
+      expect(handler.getConnectionCommand()).toContain("--connect-tenant 'test-tenant-id'");
     });
 
-    it("should not use the Azure CLI credential when an account key env var is exported", () => {
+    it("should not use interactive Entra authentication when an account key env var is exported", () => {
       (isCloudShellEntraAuthEnabled as jest.Mock).mockReturnValue(false);
       const handler = new CosmosDBShellHandler("someKey");
 
-      expect(handler.getConnectionCommand()).not.toContain("--connect-azure-cli");
+      expect(handler.getConnectionCommand()).not.toContain("--connect-tenant");
     });
 
     it("should return empty array for terminal suppressed data", () => {

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.test.tsx
@@ -13,8 +13,9 @@ jest.mock("../../../../UserContext", () => ({
 
 describe("CosmosDBShellHandler", () => {
   const mockKey = "testKey";
-  const expectedConnectionCommand =
-    "cosmosdbshell --connect 'https://test-account.documents.azure.com:443/' --connect-mode gateway --verbose";
+  const endpoint = "https://test-account.documents.azure.com:443/";
+  const tokenConnectionCommand = `cosmosdbshell --connect '${endpoint}' --connect-mode gateway --verbose`;
+  const keyConnectionCommand = `cosmosdbshell --connect 'AccountEndpoint=${endpoint};AccountKey=${mockKey};' --connect-mode gateway --verbose`;
   let cosmosDBShellHandler: CosmosDBShellHandler;
 
   beforeEach(() => {
@@ -53,11 +54,10 @@ describe("CosmosDBShellHandler", () => {
       expect(commands.some((c) => c === "export DOTNET_ROOT=$HOME/.dotnet")).toBe(true);
     });
 
-    it("should export the account key env var for a key credential", () => {
+    it("should not export any credential env var for a key credential", () => {
       const commands = cosmosDBShellHandler.getSetUpCommands();
 
-      expect(commands.some((c) => c === `export COSMOSDB_SHELL_ACCOUNT_KEY='${mockKey}'`)).toBe(true);
-      expect(commands.some((c) => c.includes("COSMOSDB_SHELL_TOKEN"))).toBe(false);
+      expect(commands.some((c) => c.includes("COSMOSDB_SHELL_"))).toBe(false);
     });
 
     it("should export the token env var for a token credential", () => {
@@ -68,14 +68,14 @@ describe("CosmosDBShellHandler", () => {
       expect(commands.some((c) => c.includes("COSMOSDB_SHELL_ACCOUNT_KEY"))).toBe(false);
     });
 
-    it("should generate proper connection command with endpoint for a key credential", () => {
-      expect(cosmosDBShellHandler.getConnectionCommand()).toBe(expectedConnectionCommand);
+    it("should deliver a key credential as a full connection string on the connect line", () => {
+      expect(cosmosDBShellHandler.getConnectionCommand()).toBe(keyConnectionCommand);
     });
 
-    it("should generate the same connection command for a token credential", () => {
+    it("should connect to the bare endpoint for a token credential", () => {
       const handler = new CosmosDBShellHandler({ kind: "token", value: "aadToken123" });
 
-      expect(handler.getConnectionCommand()).toBe(expectedConnectionCommand);
+      expect(handler.getConnectionCommand()).toBe(tokenConnectionCommand);
     });
 
     it("should never pass an interactive or ambient credential flag", () => {

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.test.tsx
@@ -14,8 +14,8 @@ jest.mock("../../../../UserContext", () => ({
 describe("CosmosDBShellHandler", () => {
   const mockKey = "testKey";
   const endpoint = "https://test-account.documents.azure.com:443/";
-  const tokenConnectionCommand = `cosmosdbshell --connect '${endpoint}' --connect-mode gateway --verbose`;
-  const keyConnectionCommand = `cosmosdbshell --connect 'AccountEndpoint=${endpoint};AccountKey=${mockKey};' --connect-mode gateway --verbose`;
+  const tokenConnectionCommand = `export COSMOSDB_SHELL_TOKEN='aadToken123'; cosmosdbshell --connect '${endpoint}' --connect-mode gateway --verbose`;
+  const keyConnectionCommand = `export COSMOSDB_SHELL_ACCOUNT_KEY='${mockKey}'; cosmosdbshell --connect '${endpoint}' --connect-mode gateway --verbose`;
   let cosmosDBShellHandler: CosmosDBShellHandler;
 
   beforeEach(() => {
@@ -54,25 +54,24 @@ describe("CosmosDBShellHandler", () => {
       expect(commands.some((c) => c === "export DOTNET_ROOT=$HOME/.dotnet")).toBe(true);
     });
 
-    it("should not export any credential env var for a key credential", () => {
+    it("should not export any credential env var in setup commands for a key credential", () => {
       const commands = cosmosDBShellHandler.getSetUpCommands();
 
       expect(commands.some((c) => c.includes("COSMOSDB_SHELL_"))).toBe(false);
     });
 
-    it("should export the token env var for a token credential", () => {
+    it("should not export any credential env var in setup commands for a token credential", () => {
       const handler = new CosmosDBShellHandler({ kind: "token", value: "aadToken123" });
       const commands = handler.getSetUpCommands();
 
-      expect(commands.some((c) => c === `export COSMOSDB_SHELL_TOKEN='aadToken123'`)).toBe(true);
-      expect(commands.some((c) => c.includes("COSMOSDB_SHELL_ACCOUNT_KEY"))).toBe(false);
+      expect(commands.some((c) => c.includes("COSMOSDB_SHELL_"))).toBe(false);
     });
 
-    it("should deliver a key credential as a full connection string on the connect line", () => {
+    it("should export the account key and connect to the bare endpoint on the same command line", () => {
       expect(cosmosDBShellHandler.getConnectionCommand()).toBe(keyConnectionCommand);
     });
 
-    it("should connect to the bare endpoint for a token credential", () => {
+    it("should export the token and connect to the bare endpoint on the same command line", () => {
       const handler = new CosmosDBShellHandler({ kind: "token", value: "aadToken123" });
 
       expect(handler.getConnectionCommand()).toBe(tokenConnectionCommand);

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
@@ -25,7 +25,10 @@ export interface CosmosDBShellCredential {
 export class CosmosDBShellHandler extends AbstractShellHandler {
   private _endpoint: string | undefined;
 
-  constructor(private credential: CosmosDBShellCredential | undefined) {
+  constructor(
+    private credential: CosmosDBShellCredential | undefined,
+    private unavailableReason?: string,
+  ) {
     super();
     this._endpoint = userContext?.databaseAccount?.properties?.documentEndpoint;
   }
@@ -91,7 +94,11 @@ export class CosmosDBShellHandler extends AbstractShellHandler {
       // token for the *.documents.azure.com audience). The interactive browser and
       // device-code flows are not usable from this embedded terminal either, so fail
       // fast with actionable guidance instead.
-      return `echo 'Unable to acquire a ${this.getShellName()} credential. Use "Login for Entra ID" in the Data Explorer toolbar, verify you have Cosmos DB data-plane RBAC access to this account, then reopen the shell.'`;
+      //
+      // There is no way to inspect the browser dev tools console from inside this remote
+      // terminal, so the specific reason (when known) is echoed here too.
+      const reasonSuffix = this.unavailableReason ? ` — ${this.unavailableReason}` : "";
+      return `echo 'Unable to acquire a ${this.getShellName()} credential${reasonSuffix}. Use "Login for Entra ID" in the Data Explorer toolbar, verify you have Cosmos DB data-plane RBAC access to this account, then reopen the shell.'`;
     }
 
     // Force gateway (HTTPS/443) connection mode. The shell otherwise defaults to

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
@@ -110,6 +110,14 @@ export class CosmosDBShellHandler extends AbstractShellHandler {
     // direct (TCP) mode for real accounts, and Azure Cloud Shell blocks the
     // direct-mode TCP ports, causing the connection to fail. `--verbose` surfaces
     // the full exception details when a connection attempt fails.
+    //
+    // Surface which credential kind Explorer resolved in the browser console. A wrong
+    // guess here (e.g. a token when the account actually needs a key) otherwise fails
+    // silently inside the remote shell with no client-side signal to debug against.
+    console.warn(`CloudShell: connecting to Cosmos DB shell with a "${this.credential.kind}" credential`, {
+      endpoint: this._endpoint,
+    });
+
     return this.credential.kind === "key"
       ? this._getKeyConnectionCommand(this.credential.value)
       : this._getTokenConnectionCommand(this.credential.value);

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
@@ -4,14 +4,16 @@ import { AbstractShellHandler } from "./AbstractShellHandler";
 /**
  * A credential resolved by Data Explorer and handed to the Cosmos DB Shell.
  *
- * - `token` is an Entra ID (AAD) bearer token scoped to the account's data plane. It is
- *   exported as COSMOSDB_SHELL_TOKEN (a connection string cannot carry an AAD token) and
- *   the connect command targets the bare account endpoint.
- * - `key` is an account master (or read-only) key. It is delivered as a full connection
- *   string (`AccountEndpoint=...;AccountKey=...;`) passed directly to `--connect`, so a
- *   single string carries everything the tool needs.
+ * Both kinds are delivered the same way the Mongo shell delivers its credential: exported
+ * as an environment variable on the same command line as the `cosmosdbshell` invocation
+ * (`export VAR='...'; cosmosdbshell --connect <endpoint>`), immediately before the tool
+ * reads it, rather than as a separate setup step or embedded in a connection string.
  *
- * The kind is tracked explicitly so the correct delivery mechanism is always used.
+ * - `token` is an Entra ID (AAD) bearer token scoped to the account's data plane, exported
+ *   as COSMOSDB_SHELL_TOKEN.
+ * - `key` is an account master (or read-only) key, exported as COSMOSDB_SHELL_ACCOUNT_KEY.
+ *
+ * The kind is tracked explicitly so the correct environment variable is always used.
  */
 export interface CosmosDBShellCredential {
   kind: "token" | "key";
@@ -51,16 +53,16 @@ export class CosmosDBShellHandler extends AbstractShellHandler {
    *    update it to the latest release when it is (so an older cached install in
    *    the persistent Cloud Shell $HOME picks up newer connect options).
    * 4. Persist the PATH/DOTNET_ROOT changes for future sessions.
-   * 5. For an Entra ID token credential, export it as an environment variable so it never
-   *    appears in the process arguments or shell history on the Cloud Shell host. (A key
-   *    credential is instead delivered as a connection string on the connect command; see
-   *    getConnectionCommand.)
+   *
+   * The credential itself is not exported here: it travels on the same command line as
+   * the `cosmosdbshell` invocation (see getConnectionCommand), mirroring how the Mongo
+   * shell handler builds its connection command.
    *
    * Installation steps run conditionally only if cosmosdbshell is not already
    * present in the environment.
    */
   public getSetUpCommands(): string[] {
-    const setUpCommands = [
+    return [
       "export DOTNET_ROOT=$HOME/.dotnet",
       "export PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH",
       "if ! command -v cosmosdbshell &> /dev/null; then echo '⚠️ cosmosdbshell not found. Installing .NET SDK 10 and CosmosDBShell...'; fi",
@@ -69,16 +71,19 @@ export class CosmosDBShellHandler extends AbstractShellHandler {
       "grep -qxF 'export DOTNET_ROOT=$HOME/.dotnet' ~/.bashrc || echo 'export DOTNET_ROOT=$HOME/.dotnet' >> ~/.bashrc",
       "grep -qxF 'export PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH' ~/.bashrc || echo 'export PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH' >> ~/.bashrc",
     ];
+  }
 
-    if (this.credential?.kind === "token") {
-      // Data Explorer resolved an Entra ID token; pass it to the shell out-of-band via an
-      // environment variable so it never appears in argv/ps/history on the remote Cloud
-      // Shell host (the CosmosDBShell tool reads COSMOSDB_SHELL_TOKEN natively). A key
-      // credential is delivered as a connection string on the connect line instead.
-      setUpCommands.push(`export COSMOSDB_SHELL_TOKEN='${this.credential.value}'`);
-    }
+  private _getKeyConnectionCommand(key: string): string {
+    // Export the key immediately before invoking the tool, on the same command line, so it
+    // never appears as a --connect flag value or lands in a separate setup step. The tool
+    // reads the account key from COSMOSDB_SHELL_ACCOUNT_KEY and connects to the bare endpoint.
+    return `export COSMOSDB_SHELL_ACCOUNT_KEY='${key}'; cosmosdbshell --connect '${this._endpoint}' --connect-mode gateway --verbose`;
+  }
 
-    return setUpCommands;
+  private _getTokenConnectionCommand(token: string): string {
+    // Same pattern for the Entra ID token: exported right before the invocation so it never
+    // appears in argv/ps, then the tool reads it from COSMOSDB_SHELL_TOKEN.
+    return `export COSMOSDB_SHELL_TOKEN='${token}'; cosmosdbshell --connect '${this._endpoint}' --connect-mode gateway --verbose`;
   }
 
   public getConnectionCommand(): string {
@@ -105,16 +110,9 @@ export class CosmosDBShellHandler extends AbstractShellHandler {
     // direct (TCP) mode for real accounts, and Azure Cloud Shell blocks the
     // direct-mode TCP ports, causing the connection to fail. `--verbose` surfaces
     // the full exception details when a connection attempt fails.
-    //
-    // For a key credential, pass a full connection string (endpoint + key in one value)
-    // straight to `--connect`. The CosmosDBShell tool reads the connect argument without
-    // echoing it, so the key does not land in ps/history. For a token credential, connect
-    // to the bare endpoint and let the exported COSMOSDB_SHELL_TOKEN resolve the identity.
-    const connectTarget =
-      this.credential.kind === "key"
-        ? `AccountEndpoint=${this._endpoint};AccountKey=${this.credential.value};`
-        : this._endpoint;
-    return `cosmosdbshell --connect '${connectTarget}' --connect-mode gateway --verbose`;
+    return this.credential.kind === "key"
+      ? this._getKeyConnectionCommand(this.credential.value)
+      : this._getTokenConnectionCommand(this.credential.value);
   }
 
   public getTerminalSuppressedData(): string[] {

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
@@ -1,3 +1,4 @@
+import { configContext } from "../../../../ConfigContext";
 import { userContext } from "../../../../UserContext";
 import { isCloudShellEntraAuthEnabled } from "../../../../Utils/AuthorizationUtils";
 import { AbstractShellHandler } from "./AbstractShellHandler";
@@ -76,18 +77,21 @@ export class CosmosDBShellHandler extends AbstractShellHandler {
     // - A credential is available (`this.key`): it is exported out-of-band as an env
     //   var (COSMOSDB_SHELL_ACCOUNT_KEY for key auth, COSMOSDB_SHELL_TOKEN for a cached
     //   Entra token), which the tool reads natively — no connect flag needed.
-    // - No credential is available (`!this.key`): we force the Azure CLI credential.
-    //   Otherwise the tool falls back to DefaultAzureCredential, which in Azure Cloud
-    //   Shell always tries the managed identity (live IMDS endpoint) first — and that
-    //   fails outright for Cosmos with "AudienceNotSupported" because the Cloud Shell
-    //   MSI cannot mint a token for the *.documents.azure.com audience. Even when it
-    //   can, the MSI usually lacks Cosmos data-plane RBAC (403). `--connect-azure-cli`
-    //   deterministically uses the signed-in `az` session identity instead (and
-    //   attaches an ARM context for resource ops). It is mutually exclusive with the
-    //   credential env vars, which the tool rejects — but we only add it when none is
-    //   exported.
+    // - No credential is available (`!this.key`): select the shell's interactive Entra
+    //   flow by supplying a tenant. InteractiveBrowserCredential cannot launch a browser
+    //   in the headless Cloud Shell, so the tool falls back to DeviceCodeCredential and
+    //   prints a login URL and code in the terminal. This does not depend on `az login`.
+    //   It also avoids DefaultAzureCredential, whose managed identity path fails for the
+    //   Cosmos audience with AudienceNotSupported in this environment.
     if (!this.key) {
-      args.push("--connect-azure-cli");
+      args.push(`--connect-tenant '${userContext.tenantId || "organizations"}'`);
+      if (configContext.AAD_ENDPOINT) {
+        args.push(`--connect-authority-host '${configContext.AAD_ENDPOINT}'`);
+      }
+      if (userContext.subscriptionId && userContext.resourceGroup) {
+        args.push(`--connect-subscription '${userContext.subscriptionId}'`);
+        args.push(`--connect-resource-group '${userContext.resourceGroup}'`);
+      }
     }
 
     args.push("--verbose");

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
@@ -1,7 +1,18 @@
-import { configContext } from "../../../../ConfigContext";
 import { userContext } from "../../../../UserContext";
-import { isCloudShellEntraAuthEnabled } from "../../../../Utils/AuthorizationUtils";
 import { AbstractShellHandler } from "./AbstractShellHandler";
+
+/**
+ * A credential resolved by Data Explorer and handed to the Cosmos DB Shell.
+ *
+ * `token` is an Entra ID (AAD) bearer token scoped to the account's data plane and is
+ * exported as COSMOSDB_SHELL_TOKEN; `key` is an account master key and is exported as
+ * COSMOSDB_SHELL_ACCOUNT_KEY. The kind is tracked explicitly so the correct environment
+ * variable is always used — exporting one as the other silently breaks authentication.
+ */
+export interface CosmosDBShellCredential {
+  kind: "token" | "key";
+  value: string;
+}
 
 /**
  * Shell handler for the Azure Cosmos DB Shell (https://github.com/Azure/CosmosDBShell),
@@ -9,9 +20,8 @@ import { AbstractShellHandler } from "./AbstractShellHandler";
  */
 export class CosmosDBShellHandler extends AbstractShellHandler {
   private _endpoint: string | undefined;
-  private _isEntraIdEnabled: boolean = isCloudShellEntraAuthEnabled(userContext);
 
-  constructor(private key: string) {
+  constructor(private credential: CosmosDBShellCredential | undefined) {
     super();
     this._endpoint = userContext?.databaseAccount?.properties?.documentEndpoint;
   }
@@ -51,12 +61,12 @@ export class CosmosDBShellHandler extends AbstractShellHandler {
       "grep -qxF 'export PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH' ~/.bashrc || echo 'export PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH' >> ~/.bashrc",
     ];
 
-    if (this.key) {
-      // Entra ID (RBAC) uses a pre-fetched AAD bearer token; key auth uses the account master key.
-      // Passing the credential via an environment variable keeps it out of argv/ps/history on the
-      // remote Cloud Shell host (the CosmosDBShell tool reads these variables natively).
-      const envVar = this._isEntraIdEnabled ? "COSMOSDB_SHELL_TOKEN" : "COSMOSDB_SHELL_ACCOUNT_KEY";
-      setUpCommands.push(`export ${envVar}='${this.key}'`);
+    if (this.credential) {
+      // Data Explorer already resolved a credential for this account; pass it to the shell
+      // out-of-band via an environment variable so it never appears in argv/ps/history on
+      // the remote Cloud Shell host (the CosmosDBShell tool reads both variables natively).
+      const envVar = this.credential.kind === "token" ? "COSMOSDB_SHELL_TOKEN" : "COSMOSDB_SHELL_ACCOUNT_KEY";
+      setUpCommands.push(`export ${envVar}='${this.credential.value}'`);
     }
 
     return setUpCommands;
@@ -67,35 +77,26 @@ export class CosmosDBShellHandler extends AbstractShellHandler {
       return `echo '${this.getShellName()} endpoint not found.'`;
     }
 
+    if (!this.credential) {
+      // Never let the tool continue without a credential. With no account key and no
+      // COSMOSDB_SHELL_TOKEN exported, its credential chain would fall through to
+      // DefaultAzureCredential, which in Azure Cloud Shell tries the managed identity
+      // first and fails with "AudienceNotSupported" (the Cloud Shell MSI cannot mint a
+      // token for the *.documents.azure.com audience). The interactive browser and
+      // device-code flows are not usable from this embedded terminal either, so fail
+      // fast with actionable guidance instead.
+      return `echo 'Unable to acquire a ${this.getShellName()} credential. Use "Login for Entra ID" in the Data Explorer toolbar, verify you have Cosmos DB data-plane RBAC access to this account, then reopen the shell.'`;
+    }
+
     // Force gateway (HTTPS/443) connection mode. The shell otherwise defaults to
     // direct (TCP) mode for real accounts, and Azure Cloud Shell blocks the
     // direct-mode TCP ports, causing the connection to fail. `--verbose` surfaces
     // the full exception details when a connection attempt fails.
-    const args = [`--connect '${this._endpoint}'`, "--connect-mode gateway"];
-
-    // Credential selection:
-    // - A credential is available (`this.key`): it is exported out-of-band as an env
-    //   var (COSMOSDB_SHELL_ACCOUNT_KEY for key auth, COSMOSDB_SHELL_TOKEN for a cached
-    //   Entra token), which the tool reads natively — no connect flag needed.
-    // - No credential is available (`!this.key`): select the shell's interactive Entra
-    //   flow by supplying a tenant. InteractiveBrowserCredential cannot launch a browser
-    //   in the headless Cloud Shell, so the tool falls back to DeviceCodeCredential and
-    //   prints a login URL and code in the terminal. This does not depend on `az login`.
-    //   It also avoids DefaultAzureCredential, whose managed identity path fails for the
-    //   Cosmos audience with AudienceNotSupported in this environment.
-    if (!this.key) {
-      args.push(`--connect-tenant '${userContext.tenantId || "organizations"}'`);
-      if (configContext.AAD_ENDPOINT) {
-        args.push(`--connect-authority-host '${configContext.AAD_ENDPOINT}'`);
-      }
-      if (userContext.subscriptionId && userContext.resourceGroup) {
-        args.push(`--connect-subscription '${userContext.subscriptionId}'`);
-        args.push(`--connect-resource-group '${userContext.resourceGroup}'`);
-      }
-    }
-
-    args.push("--verbose");
-    return `cosmosdbshell ${args.join(" ")}`;
+    //
+    // No credential flags are passed: the exported environment variable resolves to the
+    // account key (step 1) or the static token credential (step 3) in the tool's
+    // credential chain, both of which are terminal and require no interactive sign-in.
+    return `cosmosdbshell --connect '${this._endpoint}' --connect-mode gateway --verbose`;
   }
 
   public getTerminalSuppressedData(): string[] {

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
@@ -1,0 +1,85 @@
+import { userContext } from "../../../../UserContext";
+import { isCloudShellEntraAuthEnabled } from "../../../../Utils/AuthorizationUtils";
+import { AbstractShellHandler } from "./AbstractShellHandler";
+
+/**
+ * Shell handler for the Azure Cosmos DB Shell (https://github.com/Azure/CosmosDBShell),
+ * a .NET global tool that targets the Cosmos DB NoSQL (SQL Core) API.
+ */
+export class CosmosDBShellHandler extends AbstractShellHandler {
+  private _endpoint: string | undefined;
+  private _isEntraIdEnabled: boolean = isCloudShellEntraAuthEnabled(userContext);
+
+  constructor(private key: string) {
+    super();
+    this._endpoint = userContext?.databaseAccount?.properties?.documentEndpoint;
+  }
+
+  public getShellName(): string {
+    return "Cosmos DB";
+  }
+
+  /**
+   * Setup commands for the Cosmos DB Shell:
+   *
+   * 1. Put the private .NET install dir and global tools dir on PATH (and set
+   *    DOTNET_ROOT) so both the `dotnet` host and installed tool resolve.
+   * 2. Bootstrap a private .NET SDK 10 into $HOME/.dotnet when neither the
+   *    cosmosdbshell tool nor a suitable SDK is already available. The
+   *    CosmosDBShell global tool targets net10.0, so `dotnet tool install`
+   *    requires the .NET SDK 10.0+, which the Azure Cloud Shell host does not
+   *    ship by default.
+   * 3. Install the CosmosDBShell global tool if it is not already available.
+   * 4. Persist the PATH/DOTNET_ROOT changes for future sessions.
+   * 5. Export the credential as an environment variable so it never appears in
+   *    the process arguments or shell history on the Cloud Shell host.
+   *
+   * Installation steps run conditionally only if cosmosdbshell is not already
+   * present in the environment.
+   */
+  public getSetUpCommands(): string[] {
+    const setUpCommands = [
+      "export DOTNET_ROOT=$HOME/.dotnet",
+      "export PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH",
+      "if ! command -v cosmosdbshell &> /dev/null; then echo '⚠️ cosmosdbshell not found. Installing .NET SDK 10 and CosmosDBShell...'; fi",
+      "if ! command -v cosmosdbshell &> /dev/null && ! dotnet --list-sdks 2>/dev/null | grep -q '^10\\.'; then curl -sSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0 --install-dir $HOME/.dotnet; fi",
+      "if ! command -v cosmosdbshell &> /dev/null; then dotnet tool install --global CosmosDBShell --prerelease; fi",
+      "grep -qxF 'export DOTNET_ROOT=$HOME/.dotnet' ~/.bashrc || echo 'export DOTNET_ROOT=$HOME/.dotnet' >> ~/.bashrc",
+      "grep -qxF 'export PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH' ~/.bashrc || echo 'export PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH' >> ~/.bashrc",
+    ];
+
+    if (this.key) {
+      // Entra ID (RBAC) uses a pre-fetched AAD bearer token; key auth uses the account master key.
+      // Passing the credential via an environment variable keeps it out of argv/ps/history on the
+      // remote Cloud Shell host (the CosmosDBShell tool reads these variables natively).
+      const envVar = this._isEntraIdEnabled ? "COSMOSDB_SHELL_TOKEN" : "COSMOSDB_SHELL_ACCOUNT_KEY";
+      setUpCommands.push(`export ${envVar}='${this.key}'`);
+    }
+
+    return setUpCommands;
+  }
+
+  public getConnectionCommand(): string {
+    if (!this._endpoint) {
+      return `echo '${this.getShellName()} endpoint not found.'`;
+    }
+
+    // Force gateway (HTTPS/443) connection mode. The shell otherwise defaults to
+    // direct (TCP) mode for real accounts, and Azure Cloud Shell blocks the
+    // direct-mode TCP ports, causing the connection to fail. `--verbose` surfaces
+    // the full exception details when a connection attempt fails.
+    //
+    // Auth is supplied out-of-band via env vars (COSMOSDB_SHELL_TOKEN for Entra ID,
+    // COSMOSDB_SHELL_ACCOUNT_KEY for key auth), which the tool reads natively. We
+    // deliberately do NOT pass --connect-tenant here: it has no effect on the static
+    // token path, and if the token is ever missing it would push the tool into
+    // interactive browser / device-code auth, which cannot complete inside Azure
+    // Cloud Shell. Omitting it lets the tool fall back to DefaultAzureCredential
+    // (which uses the Cloud Shell's signed-in az session) instead.
+    return `cosmosdbshell --connect '${this._endpoint}' --connect-mode gateway --verbose`;
+  }
+
+  public getTerminalSuppressedData(): string[] {
+    return [];
+  }
+}

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
@@ -4,10 +4,14 @@ import { AbstractShellHandler } from "./AbstractShellHandler";
 /**
  * A credential resolved by Data Explorer and handed to the Cosmos DB Shell.
  *
- * `token` is an Entra ID (AAD) bearer token scoped to the account's data plane and is
- * exported as COSMOSDB_SHELL_TOKEN; `key` is an account master key and is exported as
- * COSMOSDB_SHELL_ACCOUNT_KEY. The kind is tracked explicitly so the correct environment
- * variable is always used — exporting one as the other silently breaks authentication.
+ * - `token` is an Entra ID (AAD) bearer token scoped to the account's data plane. It is
+ *   exported as COSMOSDB_SHELL_TOKEN (a connection string cannot carry an AAD token) and
+ *   the connect command targets the bare account endpoint.
+ * - `key` is an account master (or read-only) key. It is delivered as a full connection
+ *   string (`AccountEndpoint=...;AccountKey=...;`) passed directly to `--connect`, so a
+ *   single string carries everything the tool needs.
+ *
+ * The kind is tracked explicitly so the correct delivery mechanism is always used.
  */
 export interface CosmosDBShellCredential {
   kind: "token" | "key";
@@ -44,8 +48,10 @@ export class CosmosDBShellHandler extends AbstractShellHandler {
    *    update it to the latest release when it is (so an older cached install in
    *    the persistent Cloud Shell $HOME picks up newer connect options).
    * 4. Persist the PATH/DOTNET_ROOT changes for future sessions.
-   * 5. Export the credential as an environment variable so it never appears in
-   *    the process arguments or shell history on the Cloud Shell host.
+   * 5. For an Entra ID token credential, export it as an environment variable so it never
+   *    appears in the process arguments or shell history on the Cloud Shell host. (A key
+   *    credential is instead delivered as a connection string on the connect command; see
+   *    getConnectionCommand.)
    *
    * Installation steps run conditionally only if cosmosdbshell is not already
    * present in the environment.
@@ -61,12 +67,12 @@ export class CosmosDBShellHandler extends AbstractShellHandler {
       "grep -qxF 'export PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH' ~/.bashrc || echo 'export PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH' >> ~/.bashrc",
     ];
 
-    if (this.credential) {
-      // Data Explorer already resolved a credential for this account; pass it to the shell
-      // out-of-band via an environment variable so it never appears in argv/ps/history on
-      // the remote Cloud Shell host (the CosmosDBShell tool reads both variables natively).
-      const envVar = this.credential.kind === "token" ? "COSMOSDB_SHELL_TOKEN" : "COSMOSDB_SHELL_ACCOUNT_KEY";
-      setUpCommands.push(`export ${envVar}='${this.credential.value}'`);
+    if (this.credential?.kind === "token") {
+      // Data Explorer resolved an Entra ID token; pass it to the shell out-of-band via an
+      // environment variable so it never appears in argv/ps/history on the remote Cloud
+      // Shell host (the CosmosDBShell tool reads COSMOSDB_SHELL_TOKEN natively). A key
+      // credential is delivered as a connection string on the connect line instead.
+      setUpCommands.push(`export COSMOSDB_SHELL_TOKEN='${this.credential.value}'`);
     }
 
     return setUpCommands;
@@ -93,10 +99,15 @@ export class CosmosDBShellHandler extends AbstractShellHandler {
     // direct-mode TCP ports, causing the connection to fail. `--verbose` surfaces
     // the full exception details when a connection attempt fails.
     //
-    // No credential flags are passed: the exported environment variable resolves to the
-    // account key (step 1) or the static token credential (step 3) in the tool's
-    // credential chain, both of which are terminal and require no interactive sign-in.
-    return `cosmosdbshell --connect '${this._endpoint}' --connect-mode gateway --verbose`;
+    // For a key credential, pass a full connection string (endpoint + key in one value)
+    // straight to `--connect`. The CosmosDBShell tool reads the connect argument without
+    // echoing it, so the key does not land in ps/history. For a token credential, connect
+    // to the bare endpoint and let the exported COSMOSDB_SHELL_TOKEN resolve the identity.
+    const connectTarget =
+      this.credential.kind === "key"
+        ? `AccountEndpoint=${this._endpoint};AccountKey=${this.credential.value};`
+        : this._endpoint;
+    return `cosmosdbshell --connect '${connectTarget}' --connect-mode gateway --verbose`;
   }
 
   public getTerminalSuppressedData(): string[] {

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/CosmosDBShellHandler.tsx
@@ -29,7 +29,9 @@ export class CosmosDBShellHandler extends AbstractShellHandler {
    *    CosmosDBShell global tool targets net10.0, so `dotnet tool install`
    *    requires the .NET SDK 10.0+, which the Azure Cloud Shell host does not
    *    ship by default.
-   * 3. Install the CosmosDBShell global tool if it is not already available.
+   * 3. Install the CosmosDBShell global tool if it is not already available, or
+   *    update it to the latest release when it is (so an older cached install in
+   *    the persistent Cloud Shell $HOME picks up newer connect options).
    * 4. Persist the PATH/DOTNET_ROOT changes for future sessions.
    * 5. Export the credential as an environment variable so it never appears in
    *    the process arguments or shell history on the Cloud Shell host.
@@ -43,7 +45,7 @@ export class CosmosDBShellHandler extends AbstractShellHandler {
       "export PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH",
       "if ! command -v cosmosdbshell &> /dev/null; then echo '⚠️ cosmosdbshell not found. Installing .NET SDK 10 and CosmosDBShell...'; fi",
       "if ! command -v cosmosdbshell &> /dev/null && ! dotnet --list-sdks 2>/dev/null | grep -q '^10\\.'; then curl -sSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0 --install-dir $HOME/.dotnet; fi",
-      "if ! command -v cosmosdbshell &> /dev/null; then dotnet tool install --global CosmosDBShell --prerelease; fi",
+      "if ! command -v cosmosdbshell &> /dev/null; then dotnet tool install --global CosmosDBShell --prerelease; else dotnet tool update --global CosmosDBShell --prerelease; fi",
       "grep -qxF 'export DOTNET_ROOT=$HOME/.dotnet' ~/.bashrc || echo 'export DOTNET_ROOT=$HOME/.dotnet' >> ~/.bashrc",
       "grep -qxF 'export PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH' ~/.bashrc || echo 'export PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH' >> ~/.bashrc",
     ];
@@ -68,15 +70,28 @@ export class CosmosDBShellHandler extends AbstractShellHandler {
     // direct (TCP) mode for real accounts, and Azure Cloud Shell blocks the
     // direct-mode TCP ports, causing the connection to fail. `--verbose` surfaces
     // the full exception details when a connection attempt fails.
-    //
-    // Auth is supplied out-of-band via env vars (COSMOSDB_SHELL_TOKEN for Entra ID,
-    // COSMOSDB_SHELL_ACCOUNT_KEY for key auth), which the tool reads natively. We
-    // deliberately do NOT pass --connect-tenant here: it has no effect on the static
-    // token path, and if the token is ever missing it would push the tool into
-    // interactive browser / device-code auth, which cannot complete inside Azure
-    // Cloud Shell. Omitting it lets the tool fall back to DefaultAzureCredential
-    // (which uses the Cloud Shell's signed-in az session) instead.
-    return `cosmosdbshell --connect '${this._endpoint}' --connect-mode gateway --verbose`;
+    const args = [`--connect '${this._endpoint}'`, "--connect-mode gateway"];
+
+    // Credential selection:
+    // - A credential is available (`this.key`): it is exported out-of-band as an env
+    //   var (COSMOSDB_SHELL_ACCOUNT_KEY for key auth, COSMOSDB_SHELL_TOKEN for a cached
+    //   Entra token), which the tool reads natively — no connect flag needed.
+    // - No credential is available (`!this.key`): we force the Azure CLI credential.
+    //   Otherwise the tool falls back to DefaultAzureCredential, which in Azure Cloud
+    //   Shell always tries the managed identity (live IMDS endpoint) first — and that
+    //   fails outright for Cosmos with "AudienceNotSupported" because the Cloud Shell
+    //   MSI cannot mint a token for the *.documents.azure.com audience. Even when it
+    //   can, the MSI usually lacks Cosmos data-plane RBAC (403). `--connect-azure-cli`
+    //   deterministically uses the signed-in `az` session identity instead (and
+    //   attaches an ARM context for resource ops). It is mutually exclusive with the
+    //   credential env vars, which the tool rejects — but we only add it when none is
+    //   exported.
+    if (!this.key) {
+      args.push("--connect-azure-cli");
+    }
+
+    args.push("--verbose");
+    return `cosmosdbshell ${args.join(" ")}`;
   }
 
   public getTerminalSuppressedData(): string[] {

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
@@ -6,11 +6,11 @@ import { CassandraShellHandler } from "./CassandraShellHandler";
 import { CosmosDBShellHandler } from "./CosmosDBShellHandler";
 import { MongoShellHandler } from "./MongoShellHandler";
 import { PostgresShellHandler } from "./PostgresShellHandler";
-import { getHandler, getKey } from "./ShellTypeFactory";
+import { getCosmosDBShellCredential, getHandler, getKey } from "./ShellTypeFactory";
 import { VCoreMongoShellHandler } from "./VCoreMongoShellHandler";
 
 interface UserContextType {
-  databaseAccount: { name: string };
+  databaseAccount: { name: string; properties?: { disableLocalAuth?: boolean } };
   subscriptionId: string;
   resourceGroup: string;
   features: { enableAadDataPlane: boolean };
@@ -206,6 +206,94 @@ describe("ShellTypeHandlerFactory", () => {
       await expect(getHandler("UnknownShell" as unknown as TerminalKind)).rejects.toThrow(
         "Unsupported shell type: UnknownShell",
       );
+    });
+  });
+
+  describe("getCosmosDBShellCredential", () => {
+    beforeEach(() => {
+      (userContext as UserContextType).aadToken = undefined;
+      (userContext as UserContextType).apiType = "SQL";
+      (userContext as UserContextType).features.enableAadDataPlane = false;
+      (userContext as UserContextType).dataPlaneRbacEnabled = false;
+      (userContext as UserContextType).databaseAccount.properties = { disableLocalAuth: false };
+    });
+
+    it("should return the account key when Entra ID auth is not enabled", async () => {
+      const credential = await getCosmosDBShellCredential();
+
+      expect(credential).toEqual({ kind: "key", value: mockKey });
+      expect(listKeys).toHaveBeenCalledWith("testSubId", "testResourceGroup", "testDbName");
+    });
+
+    it("should return the cached aadToken when Entra ID auth is enabled", async () => {
+      (userContext as UserContextType).dataPlaneRbacEnabled = true;
+      (userContext as UserContextType).aadToken = "aadToken123";
+
+      const credential = await getCosmosDBShellCredential();
+
+      expect(credential).toEqual({ kind: "token", value: "aadToken123" });
+      expect(listKeys).not.toHaveBeenCalled();
+    });
+
+    it("should return a silently minted token when an MSAL account is cached", async () => {
+      (userContext as UserContextType).dataPlaneRbacEnabled = true;
+      (getMsalInstance as jest.Mock).mockResolvedValue({ getAllAccounts: () => [{ username: "user@contoso.com" }] });
+      (acquireMsalTokenForAccount as jest.Mock).mockResolvedValue("mintedToken123");
+
+      const credential = await getCosmosDBShellCredential();
+
+      expect(credential).toEqual({ kind: "token", value: "mintedToken123" });
+      expect(listKeys).not.toHaveBeenCalled();
+    });
+
+    it("should fall back to the account key when no token could be resolved", async () => {
+      (userContext as UserContextType).dataPlaneRbacEnabled = true;
+
+      const credential = await getCosmosDBShellCredential();
+
+      expect(acquireMsalTokenForAccount).not.toHaveBeenCalled();
+      expect(credential).toEqual({ kind: "key", value: mockKey });
+    });
+
+    it("should fall back to the account key when the silent token acquisition throws", async () => {
+      (userContext as UserContextType).dataPlaneRbacEnabled = true;
+      (getMsalInstance as jest.Mock).mockResolvedValue({ getAllAccounts: () => [{ username: "user@contoso.com" }] });
+      (acquireMsalTokenForAccount as jest.Mock).mockRejectedValue(new Error("interaction_required"));
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+      const credential = await getCosmosDBShellCredential();
+
+      expect(credential).toEqual({ kind: "key", value: mockKey });
+    });
+
+    it("should not fall back to the account key when local auth is disabled", async () => {
+      (userContext as UserContextType).databaseAccount.properties = { disableLocalAuth: true };
+      jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      const credential = await getCosmosDBShellCredential();
+
+      expect(credential).toBeUndefined();
+      expect(listKeys).not.toHaveBeenCalled();
+    });
+
+    it("should return undefined when listing the account keys fails", async () => {
+      (listKeys as jest.Mock).mockRejectedValue(new Error("Forbidden"));
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+      const credential = await getCosmosDBShellCredential();
+
+      expect(credential).toBeUndefined();
+    });
+
+    it("should return undefined when the database name is missing", async () => {
+      (userContext as UserContextType).databaseAccount.name = "";
+
+      const credential = await getCosmosDBShellCredential();
+
+      expect(credential).toBeUndefined();
+      expect(listKeys).not.toHaveBeenCalled();
+
+      (userContext as UserContextType).databaseAccount.name = "testDbName";
     });
   });
 });

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
@@ -1,6 +1,7 @@
 import { TerminalKind } from "../../../../Contracts/ViewModels";
 import { userContext } from "../../../../UserContext";
 import { listKeys } from "../../../../Utils/arm/generatedClients/cosmos/databaseAccounts";
+import { acquireMsalTokenForAccount, getMsalInstance } from "../../../../Utils/AuthorizationUtils";
 import { CassandraShellHandler } from "./CassandraShellHandler";
 import { CosmosDBShellHandler } from "./CosmosDBShellHandler";
 import { MongoShellHandler } from "./MongoShellHandler";
@@ -33,11 +34,22 @@ jest.mock("../../../../Utils/arm/generatedClients/cosmos/databaseAccounts", () =
   listKeys: jest.fn(),
 }));
 
+jest.mock("../../../../Utils/AuthorizationUtils", () => {
+  const actual = jest.requireActual("../../../../Utils/AuthorizationUtils");
+  return {
+    ...actual,
+    getMsalInstance: jest.fn(),
+    acquireMsalTokenForAccount: jest.fn(),
+  };
+});
+
 describe("ShellTypeHandlerFactory", () => {
   const mockKey = "testKey";
 
   beforeEach(() => {
     (listKeys as jest.Mock).mockResolvedValue({ primaryMasterKey: mockKey });
+    (getMsalInstance as jest.Mock).mockResolvedValue({ getAllAccounts: () => [] });
+    (acquireMsalTokenForAccount as jest.Mock).mockResolvedValue("");
   });
 
   afterEach(() => {
@@ -136,8 +148,32 @@ describe("ShellTypeHandlerFactory", () => {
       expect(listKeys).not.toHaveBeenCalled();
     });
 
-    it("should return an empty string when Entra ID auth is requested but no cached token exists", async () => {
+    it("should return an empty string when Entra ID auth is requested but no cached token or account exists", async () => {
       (userContext as UserContextType).aadToken = undefined;
+      (getMsalInstance as jest.Mock).mockResolvedValue({ getAllAccounts: () => [] });
+
+      const key = await getKey(true);
+      expect(key).toBe("");
+      expect(acquireMsalTokenForAccount).not.toHaveBeenCalled();
+      expect(listKeys).not.toHaveBeenCalled();
+    });
+
+    it("should silently mint a Cosmos token when Entra ID auth is requested and an MSAL account is cached", async () => {
+      (userContext as UserContextType).aadToken = undefined;
+      (getMsalInstance as jest.Mock).mockResolvedValue({ getAllAccounts: () => [{ username: "user@contoso.com" }] });
+      (acquireMsalTokenForAccount as jest.Mock).mockResolvedValue("mintedToken123");
+
+      const key = await getKey(true);
+      expect(key).toBe("mintedToken123");
+      expect(acquireMsalTokenForAccount).toHaveBeenCalled();
+      expect(listKeys).not.toHaveBeenCalled();
+    });
+
+    it("should return an empty string when the silent token acquisition fails", async () => {
+      (userContext as UserContextType).aadToken = undefined;
+      (getMsalInstance as jest.Mock).mockResolvedValue({ getAllAccounts: () => [{ username: "user@contoso.com" }] });
+      (acquireMsalTokenForAccount as jest.Mock).mockRejectedValue(new Error("interaction_required"));
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
 
       const key = await getKey(true);
       expect(key).toBe("");

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
@@ -1,6 +1,6 @@
 import { TerminalKind } from "../../../../Contracts/ViewModels";
 import { userContext } from "../../../../UserContext";
-import { listKeys } from "../../../../Utils/arm/generatedClients/cosmos/databaseAccounts";
+import { getReadOnlyKeys, listKeys } from "../../../../Utils/arm/generatedClients/cosmos/databaseAccounts";
 import { acquireMsalTokenForAccount, getMsalInstance } from "../../../../Utils/AuthorizationUtils";
 import { CassandraShellHandler } from "./CassandraShellHandler";
 import { CosmosDBShellHandler } from "./CosmosDBShellHandler";
@@ -16,6 +16,7 @@ interface UserContextType {
   features: { enableAadDataPlane: boolean };
   dataPlaneRbacEnabled: boolean;
   aadToken?: string;
+  masterKey?: string;
   apiType?: string;
 }
 
@@ -32,6 +33,7 @@ jest.mock("../../../../UserContext", () => ({
 
 jest.mock("../../../../Utils/arm/generatedClients/cosmos/databaseAccounts", () => ({
   listKeys: jest.fn(),
+  getReadOnlyKeys: jest.fn(),
 }));
 
 jest.mock("../../../../Utils/AuthorizationUtils", () => {
@@ -216,10 +218,43 @@ describe("ShellTypeHandlerFactory", () => {
   describe("getCosmosDBShellCredential", () => {
     beforeEach(() => {
       (userContext as UserContextType).aadToken = undefined;
+      (userContext as UserContextType).masterKey = undefined;
       (userContext as UserContextType).apiType = "SQL";
       (userContext as UserContextType).features.enableAadDataPlane = false;
       (userContext as UserContextType).dataPlaneRbacEnabled = false;
       (userContext as UserContextType).databaseAccount.properties = { disableLocalAuth: false };
+    });
+
+    it("should reuse the master key Data Explorer already resolved without calling ARM", async () => {
+      (userContext as UserContextType).masterKey = "cachedMasterKey";
+
+      const credential = await getCosmosDBShellCredential();
+
+      expect(credential).toEqual({ kind: "key", value: "cachedMasterKey" });
+      expect(listKeys).not.toHaveBeenCalled();
+      expect(getReadOnlyKeys).not.toHaveBeenCalled();
+    });
+
+    it("should fall back to the read-only keys when the caller lacks list-keys permission", async () => {
+      const authorizationFailed = Object.assign(new Error("AuthorizationFailed"), { code: "AuthorizationFailed" });
+      (listKeys as jest.Mock).mockRejectedValue(authorizationFailed);
+      (getReadOnlyKeys as jest.Mock).mockResolvedValue({ primaryReadonlyMasterKey: "readOnlyKey" });
+
+      const credential = await getCosmosDBShellCredential();
+
+      expect(credential).toEqual({ kind: "key", value: "readOnlyKey" });
+      expect(getReadOnlyKeys).toHaveBeenCalledWith("testSubId", "testResourceGroup", "testDbName");
+    });
+
+    it("should return undefined when both the read-write and read-only key fetches fail", async () => {
+      const authorizationFailed = Object.assign(new Error("AuthorizationFailed"), { code: "AuthorizationFailed" });
+      (listKeys as jest.Mock).mockRejectedValue(authorizationFailed);
+      (getReadOnlyKeys as jest.Mock).mockRejectedValue(new Error("Forbidden"));
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+      const credential = await getCosmosDBShellCredential();
+
+      expect(credential).toBeUndefined();
     });
 
     it("should return the account key when Entra ID auth is not enabled", async () => {

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
@@ -1,7 +1,9 @@
 import { TerminalKind } from "../../../../Contracts/ViewModels";
 import { userContext } from "../../../../UserContext";
 import { listKeys } from "../../../../Utils/arm/generatedClients/cosmos/databaseAccounts";
+import { acquireMsalTokenForAccount } from "../../../../Utils/AuthorizationUtils";
 import { CassandraShellHandler } from "./CassandraShellHandler";
+import { CosmosDBShellHandler } from "./CosmosDBShellHandler";
 import { MongoShellHandler } from "./MongoShellHandler";
 import { PostgresShellHandler } from "./PostgresShellHandler";
 import { getHandler, getKey } from "./ShellTypeFactory";
@@ -30,6 +32,11 @@ jest.mock("../../../../UserContext", () => ({
 
 jest.mock("../../../../Utils/arm/generatedClients/cosmos/databaseAccounts", () => ({
   listKeys: jest.fn(),
+}));
+
+jest.mock("../../../../Utils/AuthorizationUtils", () => ({
+  ...jest.requireActual("../../../../Utils/AuthorizationUtils"),
+  acquireMsalTokenForAccount: jest.fn(),
 }));
 
 describe("ShellTypeHandlerFactory", () => {
@@ -69,7 +76,7 @@ describe("ShellTypeHandlerFactory", () => {
       type DatabaseAccountType = { name: string };
       (userContext.databaseAccount as DatabaseAccountType).name = "";
 
-      const key = await getKey();
+      const key = await getKey(false);
       expect(key).toBe("");
       expect(listKeys).not.toHaveBeenCalled();
 
@@ -80,7 +87,7 @@ describe("ShellTypeHandlerFactory", () => {
     it("should return empty string when listKeys returns null", async () => {
       (listKeys as jest.Mock).mockResolvedValue(null);
 
-      const key = await getKey();
+      const key = await getKey(false);
       expect(key).toBe("");
     });
 
@@ -89,7 +96,7 @@ describe("ShellTypeHandlerFactory", () => {
         /* no primaryMasterKey */
       });
 
-      const key = await getKey();
+      const key = await getKey(false);
       expect(key).toBe("");
     });
   });
@@ -116,10 +123,34 @@ describe("ShellTypeHandlerFactory", () => {
       expect(handler).toBeInstanceOf(CassandraShellHandler);
     });
 
+    it("should return CosmosDBShellHandler with key for CosmosDB terminal kind", async () => {
+      const handler = await getHandler(TerminalKind.CosmosDB);
+      expect(handler).toBeInstanceOf(CosmosDBShellHandler);
+    });
+
     it("should get key successfully when database name exists", async () => {
-      const key = await getKey();
+      const key = await getKey(false);
       expect(key).toBe(mockKey);
       expect(listKeys).toHaveBeenCalledWith("testSubId", "testResourceGroup", "testDbName");
+    });
+
+    it("should return the aadToken without listing keys when Entra ID auth is requested", async () => {
+      (userContext as UserContextType).aadToken = "aadToken123";
+
+      const key = await getKey(true);
+      expect(key).toBe("aadToken123");
+      expect(listKeys).not.toHaveBeenCalled();
+      expect(acquireMsalTokenForAccount).not.toHaveBeenCalled();
+    });
+
+    it("should acquire a token when Entra ID auth is requested but no cached token exists", async () => {
+      (userContext as UserContextType).aadToken = undefined;
+      (acquireMsalTokenForAccount as jest.Mock).mockResolvedValue("freshToken123");
+
+      const key = await getKey(true);
+      expect(key).toBe("freshToken123");
+      expect(listKeys).not.toHaveBeenCalled();
+      expect(acquireMsalTokenForAccount).toHaveBeenCalled();
     });
 
     it("should return MongoShellHandler with primaryMasterKey for TerminalKind.Mongo when RBAC is disabled", async () => {

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
@@ -7,6 +7,7 @@ import { CosmosDBShellHandler } from "./CosmosDBShellHandler";
 import { MongoShellHandler } from "./MongoShellHandler";
 import { PostgresShellHandler } from "./PostgresShellHandler";
 import { getCosmosDBShellCredential, getHandler, getKey } from "./ShellTypeFactory";
+import type { CosmosDBShellCredentialDiagnostics } from "./ShellTypeFactory";
 import { VCoreMongoShellHandler } from "./VCoreMongoShellHandler";
 
 interface UserContextType {
@@ -333,6 +334,29 @@ describe("ShellTypeHandlerFactory", () => {
       expect(listKeys).not.toHaveBeenCalled();
 
       (userContext as UserContextType).databaseAccount.name = "testDbName";
+    });
+
+    it("should populate a specific reason when both key fetches fail, for the shell to echo", async () => {
+      (listKeys as jest.Mock).mockRejectedValue(new Error("Forbidden"));
+      (getReadOnlyKeys as jest.Mock).mockRejectedValue(new Error("Forbidden"));
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+      const diagnostics: CosmosDBShellCredentialDiagnostics = {};
+      const credential = await getCosmosDBShellCredential(diagnostics);
+
+      expect(credential).toBeUndefined();
+      expect(diagnostics.reason).toContain("Forbidden");
+    });
+
+    it("should populate a reason when local auth is disabled and no token was resolved", async () => {
+      (userContext as UserContextType).databaseAccount.properties = { disableLocalAuth: true };
+      jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      const diagnostics: CosmosDBShellCredentialDiagnostics = {};
+      const credential = await getCosmosDBShellCredential(diagnostics);
+
+      expect(credential).toBeUndefined();
+      expect(diagnostics.reason).toContain("local (key) auth is disabled");
     });
   });
 });

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
@@ -46,9 +46,13 @@ jest.mock("../../../../Utils/AuthorizationUtils", () => {
 describe("ShellTypeHandlerFactory", () => {
   const mockKey = "testKey";
 
+  const mockMsalAccounts = (accounts: { username: string }[]): void => {
+    (getMsalInstance as jest.Mock).mockResolvedValue({ getAllAccounts: (): { username: string }[] => accounts });
+  };
+
   beforeEach(() => {
     (listKeys as jest.Mock).mockResolvedValue({ primaryMasterKey: mockKey });
-    (getMsalInstance as jest.Mock).mockResolvedValue({ getAllAccounts: () => [] });
+    mockMsalAccounts([]);
     (acquireMsalTokenForAccount as jest.Mock).mockResolvedValue("");
   });
 
@@ -150,7 +154,7 @@ describe("ShellTypeHandlerFactory", () => {
 
     it("should return an empty string when Entra ID auth is requested but no cached token or account exists", async () => {
       (userContext as UserContextType).aadToken = undefined;
-      (getMsalInstance as jest.Mock).mockResolvedValue({ getAllAccounts: () => [] });
+      mockMsalAccounts([]);
 
       const key = await getKey(true);
       expect(key).toBe("");
@@ -160,7 +164,7 @@ describe("ShellTypeHandlerFactory", () => {
 
     it("should silently mint a Cosmos token when Entra ID auth is requested and an MSAL account is cached", async () => {
       (userContext as UserContextType).aadToken = undefined;
-      (getMsalInstance as jest.Mock).mockResolvedValue({ getAllAccounts: () => [{ username: "user@contoso.com" }] });
+      mockMsalAccounts([{ username: "user@contoso.com" }]);
       (acquireMsalTokenForAccount as jest.Mock).mockResolvedValue("mintedToken123");
 
       const key = await getKey(true);
@@ -171,7 +175,7 @@ describe("ShellTypeHandlerFactory", () => {
 
     it("should return an empty string when the silent token acquisition fails", async () => {
       (userContext as UserContextType).aadToken = undefined;
-      (getMsalInstance as jest.Mock).mockResolvedValue({ getAllAccounts: () => [{ username: "user@contoso.com" }] });
+      mockMsalAccounts([{ username: "user@contoso.com" }]);
       (acquireMsalTokenForAccount as jest.Mock).mockRejectedValue(new Error("interaction_required"));
       jest.spyOn(console, "error").mockImplementation(() => undefined);
 
@@ -237,7 +241,7 @@ describe("ShellTypeHandlerFactory", () => {
 
     it("should return a silently minted token when an MSAL account is cached", async () => {
       (userContext as UserContextType).dataPlaneRbacEnabled = true;
-      (getMsalInstance as jest.Mock).mockResolvedValue({ getAllAccounts: () => [{ username: "user@contoso.com" }] });
+      mockMsalAccounts([{ username: "user@contoso.com" }]);
       (acquireMsalTokenForAccount as jest.Mock).mockResolvedValue("mintedToken123");
 
       const credential = await getCosmosDBShellCredential();
@@ -257,7 +261,7 @@ describe("ShellTypeHandlerFactory", () => {
 
     it("should fall back to the account key when the silent token acquisition throws", async () => {
       (userContext as UserContextType).dataPlaneRbacEnabled = true;
-      (getMsalInstance as jest.Mock).mockResolvedValue({ getAllAccounts: () => [{ username: "user@contoso.com" }] });
+      mockMsalAccounts([{ username: "user@contoso.com" }]);
       (acquireMsalTokenForAccount as jest.Mock).mockRejectedValue(new Error("interaction_required"));
       jest.spyOn(console, "error").mockImplementation(() => undefined);
 

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
@@ -6,8 +6,8 @@ import { CassandraShellHandler } from "./CassandraShellHandler";
 import { CosmosDBShellHandler } from "./CosmosDBShellHandler";
 import { MongoShellHandler } from "./MongoShellHandler";
 import { PostgresShellHandler } from "./PostgresShellHandler";
-import { getCosmosDBShellCredential, getHandler, getKey } from "./ShellTypeFactory";
 import type { CosmosDBShellCredentialDiagnostics } from "./ShellTypeFactory";
+import { getCosmosDBShellCredential, getHandler, getKey } from "./ShellTypeFactory";
 import { VCoreMongoShellHandler } from "./VCoreMongoShellHandler";
 
 interface UserContextType {

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.test.tsx
@@ -1,7 +1,6 @@
 import { TerminalKind } from "../../../../Contracts/ViewModels";
 import { userContext } from "../../../../UserContext";
 import { listKeys } from "../../../../Utils/arm/generatedClients/cosmos/databaseAccounts";
-import { acquireMsalTokenForAccount } from "../../../../Utils/AuthorizationUtils";
 import { CassandraShellHandler } from "./CassandraShellHandler";
 import { CosmosDBShellHandler } from "./CosmosDBShellHandler";
 import { MongoShellHandler } from "./MongoShellHandler";
@@ -32,11 +31,6 @@ jest.mock("../../../../UserContext", () => ({
 
 jest.mock("../../../../Utils/arm/generatedClients/cosmos/databaseAccounts", () => ({
   listKeys: jest.fn(),
-}));
-
-jest.mock("../../../../Utils/AuthorizationUtils", () => ({
-  ...jest.requireActual("../../../../Utils/AuthorizationUtils"),
-  acquireMsalTokenForAccount: jest.fn(),
 }));
 
 describe("ShellTypeHandlerFactory", () => {
@@ -140,17 +134,14 @@ describe("ShellTypeHandlerFactory", () => {
       const key = await getKey(true);
       expect(key).toBe("aadToken123");
       expect(listKeys).not.toHaveBeenCalled();
-      expect(acquireMsalTokenForAccount).not.toHaveBeenCalled();
     });
 
-    it("should acquire a token when Entra ID auth is requested but no cached token exists", async () => {
+    it("should return an empty string when Entra ID auth is requested but no cached token exists", async () => {
       (userContext as UserContextType).aadToken = undefined;
-      (acquireMsalTokenForAccount as jest.Mock).mockResolvedValue("freshToken123");
 
       const key = await getKey(true);
-      expect(key).toBe("freshToken123");
+      expect(key).toBe("");
       expect(listKeys).not.toHaveBeenCalled();
-      expect(acquireMsalTokenForAccount).toHaveBeenCalled();
     });
 
     it("should return MongoShellHandler with primaryMasterKey for TerminalKind.Mongo when RBAC is disabled", async () => {

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
@@ -27,11 +27,24 @@ export async function getHandler(shellType: TerminalKind): Promise<AbstractShell
       return new VCoreMongoShellHandler();
     case TerminalKind.Cassandra:
       return new CassandraShellHandler(await getKey(isDataplaneRbacEnabledForProxyApi(userContext)));
-    case TerminalKind.CosmosDB:
-      return new CosmosDBShellHandler(await getCosmosDBShellCredential());
+    case TerminalKind.CosmosDB: {
+      const diagnostics: CosmosDBShellCredentialDiagnostics = {};
+      const credential = await getCosmosDBShellCredential(diagnostics);
+      return new CosmosDBShellHandler(credential, diagnostics.reason);
+    }
     default:
       throw new Error(`Unsupported shell type: ${shellType}`);
   }
+}
+
+/**
+ * Populated by {@link getCosmosDBShellCredential} (and its helpers) with a human-readable
+ * explanation when no credential could be resolved, so the shell can echo a specific cause
+ * instead of a generic message. There is no way to inspect the browser dev tools console
+ * from inside the remote Cloud Shell terminal, so this is surfaced directly in the shell.
+ */
+export interface CosmosDBShellCredentialDiagnostics {
+  reason?: string;
 }
 
 /**
@@ -56,9 +69,14 @@ export async function getHandler(shellType: TerminalKind): Promise<AbstractShell
  * Returns `undefined` when nothing could be resolved, which makes the handler surface
  * actionable guidance instead of letting the tool attempt its own sign-in.
  */
-export async function getCosmosDBShellCredential(): Promise<CosmosDBShellCredential | undefined> {
+export async function getCosmosDBShellCredential(
+  diagnostics?: CosmosDBShellCredentialDiagnostics,
+): Promise<CosmosDBShellCredential | undefined> {
   const dbName = userContext.databaseAccount?.name;
   if (!dbName) {
+    if (diagnostics) {
+      diagnostics.reason = "no database account name is available";
+    }
     return undefined;
   }
 
@@ -70,21 +88,28 @@ export async function getCosmosDBShellCredential(): Promise<CosmosDBShellCredent
   }
 
   if (userContext.databaseAccount?.properties?.disableLocalAuth) {
-    console.warn(
-      "CloudShell: could not resolve an Entra ID token and local auth is disabled on this account, " +
-        "so no credential can be passed to the Cosmos DB shell.",
-    );
+    const reason =
+      "local (key) auth is disabled on this account and no Entra ID token could be resolved; sign in via " +
+      '"Login for Entra ID" in the toolbar and reopen the shell';
+    console.warn(`CloudShell: ${reason}.`);
+    if (diagnostics) {
+      diagnostics.reason = reason;
+    }
     return undefined;
   }
 
-  const key = await resolveAccountKey(dbName);
+  const key = await resolveAccountKey(dbName, diagnostics);
   if (!key) {
-    console.warn(
-      "CloudShell: no Entra ID token or account key could be resolved for the Cosmos DB shell. " +
-        "Data Explorer may be authenticating through the portal proxy (per-request tokens), which " +
-        "cannot be reused by the shell. Ensure you have either data-plane RBAC access (then use " +
-        '"Login for Entra ID") or permission to list the account keys.',
-    );
+    if (!diagnostics?.reason) {
+      const reason =
+        "no account key could be resolved. Data Explorer may be authenticating through the portal proxy " +
+        "(per-request tokens), which cannot be reused by the shell. Ensure you have either data-plane RBAC " +
+        'access (then use "Login for Entra ID") or permission to list the account keys';
+      console.warn(`CloudShell: ${reason}.`);
+      if (diagnostics) {
+        diagnostics.reason = reason;
+      }
+    }
     return undefined;
   }
   return { kind: "key", value: key };
@@ -134,7 +159,7 @@ function resolveAccountArmScope(): { subscriptionId: string; resourceGroup: stri
   return { subscriptionId, resourceGroup };
 }
 
-async function resolveAccountKey(dbName: string): Promise<string> {
+async function resolveAccountKey(dbName: string, diagnostics?: CosmosDBShellCredentialDiagnostics): Promise<string> {
   // Prefer the key Data Explorer already resolved for this account so the shell reuses the
   // exact credential DE is connected with and avoids a redundant ARM round-trip.
   if (userContext.masterKey) {
@@ -148,27 +173,45 @@ async function resolveAccountKey(dbName: string): Promise<string> {
   // and the shell cannot connect.
   const { subscriptionId, resourceGroup } = resolveAccountArmScope();
   if (!subscriptionId || !resourceGroup) {
-    console.error(
-      "CloudShell: cannot list Cosmos DB account keys because the subscription id or resource group " +
-        "could not be determined for this account.",
-    );
+    const reason = "the subscription id or resource group for this account could not be determined";
+    console.error(`CloudShell: cannot list Cosmos DB account keys because ${reason}.`);
+    if (diagnostics) {
+      diagnostics.reason = reason;
+    }
     return "";
   }
 
+  let listKeysErrorMessage: string | undefined;
   try {
     const keys = await listKeys(subscriptionId, resourceGroup, dbName);
     if (keys?.primaryMasterKey) {
       return keys.primaryMasterKey;
     }
+    listKeysErrorMessage = "the response did not include a usable key";
   } catch (error) {
+    listKeysErrorMessage = error instanceof Error ? error.message : String(error);
     console.error("Failed to list read-write account keys for the Cloud Shell; trying read-only keys", error);
   }
 
   try {
     const readOnlyKeys = await getReadOnlyKeys(subscriptionId, resourceGroup, dbName);
-    return readOnlyKeys?.primaryReadonlyMasterKey || "";
+    if (readOnlyKeys?.primaryReadonlyMasterKey) {
+      return readOnlyKeys.primaryReadonlyMasterKey;
+    }
+    if (diagnostics) {
+      diagnostics.reason =
+        `listing account keys failed (${listKeysErrorMessage}) and the read-only keys response did not ` +
+        "include a usable key either";
+    }
+    return "";
   } catch (readOnlyError) {
     console.error("Failed to list read-only account keys for the Cloud Shell", readOnlyError);
+    if (diagnostics) {
+      const readOnlyErrorMessage = readOnlyError instanceof Error ? readOnlyError.message : String(readOnlyError);
+      diagnostics.reason =
+        `listing the account keys failed (${listKeysErrorMessage}) and listing the read-only keys also failed ` +
+        `(${readOnlyErrorMessage}) — this is usually a missing listKeys/listReadOnlyKeys RBAC permission`;
+    }
     return "";
   }
 }

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
@@ -69,9 +69,17 @@ export async function getKey(useEntraIdAuth: boolean): Promise<string> {
       if (msalInstance.getAllAccounts().length === 0) {
         // No cached account to silently acquire against; a token request here would
         // require an interactive popup, which cannot complete in the Cloud Shell.
+        console.warn(
+          "CloudShell: no cached MSAL account available to mint a Cosmos data-plane token; " +
+            "the shell will fall back to the Azure CLI credential.",
+        );
         return "";
       }
-      return (await acquireMsalTokenForAccount(userContext.databaseAccount, true)) || "";
+      const token = (await acquireMsalTokenForAccount(userContext.databaseAccount, true)) || "";
+      if (!token) {
+        console.warn("CloudShell: silent Cosmos data-plane token acquisition returned an empty token.");
+      }
+      return token;
     } catch (error) {
       console.error("Failed to silently acquire a Cosmos data-plane token for the Cloud Shell", error);
       return "";

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
@@ -51,8 +51,8 @@ export async function getHandler(shellType: TerminalKind): Promise<AbstractShell
  * is not logged in ("Please run 'az login'"). The silent acquisition is only attempted
  * when an MSAL account is already cached, so it can never fall back to an interactive
  * popup (popups cannot complete inside the hosted Cloud Shell context). On any failure
- * an empty string is returned so no credential is exported and the shell tool falls
- * through to its Azure CLI credential.
+ * an empty string is returned so no credential is exported and the shell tool uses its
+ * interactive Entra flow, with device-code authentication as the headless fallback.
  */
 export async function getKey(useEntraIdAuth: boolean): Promise<string> {
   const dbName = userContext.databaseAccount.name;
@@ -71,7 +71,7 @@ export async function getKey(useEntraIdAuth: boolean): Promise<string> {
         // require an interactive popup, which cannot complete in the Cloud Shell.
         console.warn(
           "CloudShell: no cached MSAL account available to mint a Cosmos data-plane token; " +
-            "the shell will fall back to the Azure CLI credential.",
+            "the shell will use interactive device-code authentication.",
         );
         return "";
       }

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
@@ -63,8 +63,9 @@ export interface CosmosDBShellCredentialDiagnostics {
  * 2. Account master key — the key Data Explorer already resolved (`userContext.masterKey`),
  *    or, if that is not populated, one fetched via ARM (`listKeys`, falling back to
  *    `getReadOnlyKeys` on any failure for read-only callers). The key is handed to the
- *    handler, which delivers it as a full connection string. Skipped when the account has
- *    local auth disabled (keys do not exist).
+ *    handler, which exports it as COSMOSDB_SHELL_ACCOUNT_KEY on the same command line as
+ *    the `cosmosdbshell` invocation. Skipped when the account has local auth disabled
+ *    (keys do not exist).
  *
  * Returns `undefined` when nothing could be resolved, which makes the handler surface
  * actionable guidance instead of letting the tool attempt its own sign-in.

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
@@ -1,7 +1,12 @@
 import { TerminalKind } from "../../../../Contracts/ViewModels";
 import { userContext } from "../../../../UserContext";
 import { listKeys } from "../../../../Utils/arm/generatedClients/cosmos/databaseAccounts";
-import { isCloudShellEntraAuthEnabled, isDataplaneRbacEnabledForProxyApi } from "../../../../Utils/AuthorizationUtils";
+import {
+  acquireMsalTokenForAccount,
+  getMsalInstance,
+  isCloudShellEntraAuthEnabled,
+  isDataplaneRbacEnabledForProxyApi,
+} from "../../../../Utils/AuthorizationUtils";
 import { AbstractShellHandler } from "./AbstractShellHandler";
 import { CassandraShellHandler } from "./CassandraShellHandler";
 import { CosmosDBShellHandler } from "./CosmosDBShellHandler";
@@ -39,10 +44,15 @@ export async function getHandler(shellType: TerminalKind): Promise<AbstractShell
  *
  * On the Entra ID path the cached `userContext.aadToken` is used when available. When
  * none is cached (for example an account with local auth disabled while Data Explorer
- * itself is still in key mode) an empty string is returned so no credential is
- * exported; the shell tool then falls through to DefaultAzureCredential, which uses
- * the Cloud Shell's signed-in `az` session. We deliberately do NOT mint a token via a
- * browser popup here, which cannot complete inside the hosted Cloud Shell context.
+ * itself is still in key mode) we try to silently mint a Cosmos data-plane token so it
+ * can be exported to the Cloud Shell. This is required because neither credential the
+ * ephemeral Cloud Shell has access to can obtain one: its managed identity fails with
+ * "AudienceNotSupported" for the `*.documents.azure.com` audience, and its `az` session
+ * is not logged in ("Please run 'az login'"). The silent acquisition is only attempted
+ * when an MSAL account is already cached, so it can never fall back to an interactive
+ * popup (popups cannot complete inside the hosted Cloud Shell context). On any failure
+ * an empty string is returned so no credential is exported and the shell tool falls
+ * through to its Azure CLI credential.
  */
 export async function getKey(useEntraIdAuth: boolean): Promise<string> {
   const dbName = userContext.databaseAccount.name;
@@ -50,7 +60,22 @@ export async function getKey(useEntraIdAuth: boolean): Promise<string> {
     return "";
   }
   if (useEntraIdAuth) {
-    return userContext.aadToken || "";
+    if (userContext.aadToken) {
+      return userContext.aadToken;
+    }
+
+    try {
+      const msalInstance = await getMsalInstance();
+      if (msalInstance.getAllAccounts().length === 0) {
+        // No cached account to silently acquire against; a token request here would
+        // require an interactive popup, which cannot complete in the Cloud Shell.
+        return "";
+      }
+      return (await acquireMsalTokenForAccount(userContext.databaseAccount, true)) || "";
+    } catch (error) {
+      console.error("Failed to silently acquire a Cosmos data-plane token for the Cloud Shell", error);
+      return "";
+    }
   }
 
   const keys = await listKeys(userContext.subscriptionId, userContext.resourceGroup, dbName);

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
@@ -1,9 +1,14 @@
 import { TerminalKind } from "../../../../Contracts/ViewModels";
 import { userContext } from "../../../../UserContext";
 import { listKeys } from "../../../../Utils/arm/generatedClients/cosmos/databaseAccounts";
-import { isDataplaneRbacEnabledForProxyApi } from "../../../../Utils/AuthorizationUtils";
+import {
+  acquireMsalTokenForAccount,
+  isCloudShellEntraAuthEnabled,
+  isDataplaneRbacEnabledForProxyApi,
+} from "../../../../Utils/AuthorizationUtils";
 import { AbstractShellHandler } from "./AbstractShellHandler";
 import { CassandraShellHandler } from "./CassandraShellHandler";
+import { CosmosDBShellHandler } from "./CosmosDBShellHandler";
 import { MongoShellHandler } from "./MongoShellHandler";
 import { PostgresShellHandler } from "./PostgresShellHandler";
 import { VCoreMongoShellHandler } from "./VCoreMongoShellHandler";
@@ -16,23 +21,42 @@ export async function getHandler(shellType: TerminalKind): Promise<AbstractShell
     case TerminalKind.Postgres:
       return new PostgresShellHandler();
     case TerminalKind.Mongo:
-      return new MongoShellHandler(await getKey());
+      return new MongoShellHandler(await getKey(isDataplaneRbacEnabledForProxyApi(userContext)));
     case TerminalKind.VCoreMongo:
       return new VCoreMongoShellHandler();
     case TerminalKind.Cassandra:
-      return new CassandraShellHandler(await getKey());
+      return new CassandraShellHandler(await getKey(isDataplaneRbacEnabledForProxyApi(userContext)));
+    case TerminalKind.CosmosDB:
+      return new CosmosDBShellHandler(await getKey(isCloudShellEntraAuthEnabled(userContext)));
     default:
       throw new Error(`Unsupported shell type: ${shellType}`);
   }
 }
 
-export async function getKey(): Promise<string> {
+/**
+ * Resolves the credential to inject into the Cloud Shell for a connection.
+ *
+ * @param useEntraIdAuth When true, returns an Entra ID (AAD) bearer token scoped to
+ * the account's data plane; otherwise returns the account master key. The caller
+ * decides which credential applies so it stays in sync with the connection command
+ * the matching handler builds.
+ *
+ * On the Entra ID path a cached `userContext.aadToken` is preferred, but when none
+ * is available (for example an account with local auth disabled while Data Explorer
+ * itself is still in key mode) a token is acquired on demand. Without this, the
+ * shell would export no credential and silently fall back to interactive browser /
+ * device-code auth, which cannot complete inside Azure Cloud Shell.
+ */
+export async function getKey(useEntraIdAuth: boolean): Promise<string> {
   const dbName = userContext.databaseAccount.name;
   if (!dbName) {
     return "";
   }
-  if (isDataplaneRbacEnabledForProxyApi(userContext)) {
-    return userContext.aadToken || "";
+  if (useEntraIdAuth) {
+    if (userContext.aadToken) {
+      return userContext.aadToken;
+    }
+    return (await acquireMsalTokenForAccount(userContext.databaseAccount, true)) || "";
   }
 
   const keys = await listKeys(userContext.subscriptionId, userContext.resourceGroup, dbName);

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../../../Utils/AuthorizationUtils";
 import { AbstractShellHandler } from "./AbstractShellHandler";
 import { CassandraShellHandler } from "./CassandraShellHandler";
-import { CosmosDBShellHandler } from "./CosmosDBShellHandler";
+import { CosmosDBShellCredential, CosmosDBShellHandler } from "./CosmosDBShellHandler";
 import { MongoShellHandler } from "./MongoShellHandler";
 import { PostgresShellHandler } from "./PostgresShellHandler";
 import { VCoreMongoShellHandler } from "./VCoreMongoShellHandler";
@@ -28,31 +28,100 @@ export async function getHandler(shellType: TerminalKind): Promise<AbstractShell
     case TerminalKind.Cassandra:
       return new CassandraShellHandler(await getKey(isDataplaneRbacEnabledForProxyApi(userContext)));
     case TerminalKind.CosmosDB:
-      return new CosmosDBShellHandler(await getKey(isCloudShellEntraAuthEnabled(userContext)));
+      return new CosmosDBShellHandler(await getCosmosDBShellCredential());
     default:
       throw new Error(`Unsupported shell type: ${shellType}`);
   }
 }
 
 /**
- * Resolves the credential to inject into the Cloud Shell for a connection.
+ * Resolves the credential Data Explorer already holds for the current account and hands
+ * it to the Cosmos DB Shell.
+ *
+ * The Cloud Shell cannot authenticate to Cosmos DB on its own: its managed identity is
+ * rejected with "AudienceNotSupported" for the `*.documents.azure.com` audience, its `az`
+ * session is not signed in, and the interactive browser/device-code flows are not usable
+ * from the embedded terminal. The credential therefore has to come from Data Explorer.
+ *
+ * Resolution order:
+ * 1. Entra ID data-plane token — the cached `userContext.aadToken`, or a silently minted
+ *    one. Silent acquisition is only attempted when an MSAL account is already cached so
+ *    it can never trigger an interactive popup.
+ * 2. Account master key via ARM `listKeys` — used when no token applies or none could be
+ *    resolved, and skipped when the account has local auth disabled (keys do not exist).
+ *
+ * Returns `undefined` when nothing could be resolved, which makes the handler surface
+ * actionable guidance instead of letting the tool attempt its own sign-in.
+ */
+export async function getCosmosDBShellCredential(): Promise<CosmosDBShellCredential | undefined> {
+  const dbName = userContext.databaseAccount?.name;
+  if (!dbName) {
+    return undefined;
+  }
+
+  if (isCloudShellEntraAuthEnabled(userContext)) {
+    const token = await resolveCosmosDataPlaneToken();
+    if (token) {
+      return { kind: "token", value: token };
+    }
+  }
+
+  if (userContext.databaseAccount?.properties?.disableLocalAuth) {
+    console.warn(
+      "CloudShell: could not resolve an Entra ID token and local auth is disabled on this account, " +
+        "so no credential can be passed to the Cosmos DB shell.",
+    );
+    return undefined;
+  }
+
+  const key = await tryGetPrimaryMasterKey(dbName);
+  return key ? { kind: "key", value: key } : undefined;
+}
+
+/**
+ * Returns a Cosmos data-plane token without ever prompting. Silent acquisition is guarded
+ * on an existing cached MSAL account because `acquireMsalTokenForAccount` falls back to an
+ * interactive popup when none exists, which cannot complete in the hosted Cloud Shell.
+ */
+async function resolveCosmosDataPlaneToken(): Promise<string> {
+  if (userContext.aadToken) {
+    return userContext.aadToken;
+  }
+
+  try {
+    const msalInstance = await getMsalInstance();
+    if (msalInstance.getAllAccounts().length === 0) {
+      return "";
+    }
+    return (await acquireMsalTokenForAccount(userContext.databaseAccount, true)) || "";
+  } catch (error) {
+    console.error("Failed to silently acquire a Cosmos data-plane token for the Cloud Shell", error);
+    return "";
+  }
+}
+
+async function tryGetPrimaryMasterKey(dbName: string): Promise<string> {
+  try {
+    const keys = await listKeys(userContext.subscriptionId, userContext.resourceGroup, dbName);
+    return keys?.primaryMasterKey || "";
+  } catch (error) {
+    console.error("Failed to list account keys for the Cloud Shell", error);
+    return "";
+  }
+}
+
+/**
+ * Resolves the credential to inject into the Cloud Shell for a Mongo or Cassandra
+ * connection.
  *
  * @param useEntraIdAuth When true, returns an Entra ID (AAD) bearer token scoped to
  * the account's data plane; otherwise returns the account master key. The caller
  * decides which credential applies so it stays in sync with the connection command
  * the matching handler builds.
  *
- * On the Entra ID path the cached `userContext.aadToken` is used when available. When
- * none is cached (for example an account with local auth disabled while Data Explorer
- * itself is still in key mode) we try to silently mint a Cosmos data-plane token so it
- * can be exported to the Cloud Shell. This is required because neither credential the
- * ephemeral Cloud Shell has access to can obtain one: its managed identity fails with
- * "AudienceNotSupported" for the `*.documents.azure.com` audience, and its `az` session
- * is not logged in ("Please run 'az login'"). The silent acquisition is only attempted
- * when an MSAL account is already cached, so it can never fall back to an interactive
- * popup (popups cannot complete inside the hosted Cloud Shell context). On any failure
- * an empty string is returned so no credential is exported and the shell tool uses its
- * interactive Entra flow, with device-code authentication as the headless fallback.
+ * The Cosmos DB (NoSQL) shell does not use this function — see
+ * {@link getCosmosDBShellCredential}, which also reports which kind of credential it
+ * resolved so the correct environment variable is exported.
  */
 export async function getKey(useEntraIdAuth: boolean): Promise<string> {
   const dbName = userContext.databaseAccount.name;

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
@@ -49,8 +49,9 @@ export async function getHandler(shellType: TerminalKind): Promise<AbstractShell
  *    it can never trigger an interactive popup.
  * 2. Account master key — the key Data Explorer already resolved (`userContext.masterKey`),
  *    or, if that is not populated, one fetched via ARM (`listKeys`, falling back to
- *    `getReadOnlyKeys` for read-only callers, mirroring `fetchAndUpdateKeys`). Skipped when
- *    the account has local auth disabled (keys do not exist).
+ *    `getReadOnlyKeys` on any failure for read-only callers). The key is handed to the
+ *    handler, which delivers it as a full connection string. Skipped when the account has
+ *    local auth disabled (keys do not exist).
  *
  * Returns `undefined` when nothing could be resolved, which makes the handler surface
  * actionable guidance instead of letting the tool attempt its own sign-in.
@@ -77,7 +78,16 @@ export async function getCosmosDBShellCredential(): Promise<CosmosDBShellCredent
   }
 
   const key = await resolveAccountKey(dbName);
-  return key ? { kind: "key", value: key } : undefined;
+  if (!key) {
+    console.warn(
+      "CloudShell: no Entra ID token or account key could be resolved for the Cosmos DB shell. " +
+        "Data Explorer may be authenticating through the portal proxy (per-request tokens), which " +
+        "cannot be reused by the shell. Ensure you have either data-plane RBAC access (then use " +
+        '"Login for Entra ID") or permission to list the account keys.',
+    );
+    return undefined;
+  }
+  return { kind: "key", value: key };
 }
 
 /**
@@ -102,6 +112,28 @@ async function resolveCosmosDataPlaneToken(): Promise<string> {
   }
 }
 
+/**
+ * Resolves the subscription id and resource group for the current account. These are
+ * normally populated on `userContext`, but in some hosting contexts they can be missing,
+ * so they are parsed from the account's ARM resource id as a fallback. The id has the form
+ * `/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.DocumentDB/databaseAccounts/<name>`.
+ */
+function resolveAccountArmScope(): { subscriptionId: string; resourceGroup: string } {
+  let subscriptionId = userContext.subscriptionId;
+  let resourceGroup = userContext.resourceGroup;
+
+  const accountId = userContext.databaseAccount?.id;
+  if ((!subscriptionId || !resourceGroup) && accountId) {
+    const match = accountId.match(/\/subscriptions\/([^/]+)\/resourceGroups\/([^/]+)\//i);
+    if (match) {
+      subscriptionId = subscriptionId || match[1];
+      resourceGroup = resourceGroup || match[2];
+    }
+  }
+
+  return { subscriptionId, resourceGroup };
+}
+
 async function resolveAccountKey(dbName: string): Promise<string> {
   // Prefer the key Data Explorer already resolved for this account so the shell reuses the
   // exact credential DE is connected with and avoids a redundant ARM round-trip.
@@ -109,24 +141,34 @@ async function resolveAccountKey(dbName: string): Promise<string> {
     return userContext.masterKey;
   }
 
-  // Otherwise fetch it the same way DE's own `fetchAndUpdateKeys` does: try the read-write
-  // keys, and fall back to the read-only keys when the caller only has read access (ARM
-  // returns "AuthorizationFailed"). Without this fallback a read-only user gets no
-  // credential at all and the shell cannot connect.
+  // Otherwise fetch it via ARM, mirroring DE's own `fetchAndUpdateKeys`: try the read-write
+  // keys first, then fall back to the read-only keys. The fallback is attempted on any
+  // failure (not just "AuthorizationFailed") because a read-only caller can surface the
+  // missing-permission error in different shapes; without it such a user gets no credential
+  // and the shell cannot connect.
+  const { subscriptionId, resourceGroup } = resolveAccountArmScope();
+  if (!subscriptionId || !resourceGroup) {
+    console.error(
+      "CloudShell: cannot list Cosmos DB account keys because the subscription id or resource group " +
+        "could not be determined for this account.",
+    );
+    return "";
+  }
+
   try {
-    const keys = await listKeys(userContext.subscriptionId, userContext.resourceGroup, dbName);
-    return keys?.primaryMasterKey || "";
-  } catch (error) {
-    if (error?.code === "AuthorizationFailed") {
-      try {
-        const readOnlyKeys = await getReadOnlyKeys(userContext.subscriptionId, userContext.resourceGroup, dbName);
-        return readOnlyKeys?.primaryReadonlyMasterKey || "";
-      } catch (readOnlyError) {
-        console.error("Failed to list read-only account keys for the Cloud Shell", readOnlyError);
-        return "";
-      }
+    const keys = await listKeys(subscriptionId, resourceGroup, dbName);
+    if (keys?.primaryMasterKey) {
+      return keys.primaryMasterKey;
     }
-    console.error("Failed to list account keys for the Cloud Shell", error);
+  } catch (error) {
+    console.error("Failed to list read-write account keys for the Cloud Shell; trying read-only keys", error);
+  }
+
+  try {
+    const readOnlyKeys = await getReadOnlyKeys(subscriptionId, resourceGroup, dbName);
+    return readOnlyKeys?.primaryReadonlyMasterKey || "";
+  } catch (readOnlyError) {
+    console.error("Failed to list read-only account keys for the Cloud Shell", readOnlyError);
     return "";
   }
 }

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
@@ -1,6 +1,6 @@
 import { TerminalKind } from "../../../../Contracts/ViewModels";
 import { userContext } from "../../../../UserContext";
-import { listKeys } from "../../../../Utils/arm/generatedClients/cosmos/databaseAccounts";
+import { getReadOnlyKeys, listKeys } from "../../../../Utils/arm/generatedClients/cosmos/databaseAccounts";
 import {
   acquireMsalTokenForAccount,
   getMsalInstance,
@@ -47,8 +47,10 @@ export async function getHandler(shellType: TerminalKind): Promise<AbstractShell
  * 1. Entra ID data-plane token — the cached `userContext.aadToken`, or a silently minted
  *    one. Silent acquisition is only attempted when an MSAL account is already cached so
  *    it can never trigger an interactive popup.
- * 2. Account master key via ARM `listKeys` — used when no token applies or none could be
- *    resolved, and skipped when the account has local auth disabled (keys do not exist).
+ * 2. Account master key — the key Data Explorer already resolved (`userContext.masterKey`),
+ *    or, if that is not populated, one fetched via ARM (`listKeys`, falling back to
+ *    `getReadOnlyKeys` for read-only callers, mirroring `fetchAndUpdateKeys`). Skipped when
+ *    the account has local auth disabled (keys do not exist).
  *
  * Returns `undefined` when nothing could be resolved, which makes the handler surface
  * actionable guidance instead of letting the tool attempt its own sign-in.
@@ -74,7 +76,7 @@ export async function getCosmosDBShellCredential(): Promise<CosmosDBShellCredent
     return undefined;
   }
 
-  const key = await tryGetPrimaryMasterKey(dbName);
+  const key = await resolveAccountKey(dbName);
   return key ? { kind: "key", value: key } : undefined;
 }
 
@@ -100,11 +102,30 @@ async function resolveCosmosDataPlaneToken(): Promise<string> {
   }
 }
 
-async function tryGetPrimaryMasterKey(dbName: string): Promise<string> {
+async function resolveAccountKey(dbName: string): Promise<string> {
+  // Prefer the key Data Explorer already resolved for this account so the shell reuses the
+  // exact credential DE is connected with and avoids a redundant ARM round-trip.
+  if (userContext.masterKey) {
+    return userContext.masterKey;
+  }
+
+  // Otherwise fetch it the same way DE's own `fetchAndUpdateKeys` does: try the read-write
+  // keys, and fall back to the read-only keys when the caller only has read access (ARM
+  // returns "AuthorizationFailed"). Without this fallback a read-only user gets no
+  // credential at all and the shell cannot connect.
   try {
     const keys = await listKeys(userContext.subscriptionId, userContext.resourceGroup, dbName);
     return keys?.primaryMasterKey || "";
   } catch (error) {
+    if (error?.code === "AuthorizationFailed") {
+      try {
+        const readOnlyKeys = await getReadOnlyKeys(userContext.subscriptionId, userContext.resourceGroup, dbName);
+        return readOnlyKeys?.primaryReadonlyMasterKey || "";
+      } catch (readOnlyError) {
+        console.error("Failed to list read-only account keys for the Cloud Shell", readOnlyError);
+        return "";
+      }
+    }
     console.error("Failed to list account keys for the Cloud Shell", error);
     return "";
   }

--- a/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/ShellTypes/ShellTypeFactory.tsx
@@ -1,11 +1,7 @@
 import { TerminalKind } from "../../../../Contracts/ViewModels";
 import { userContext } from "../../../../UserContext";
 import { listKeys } from "../../../../Utils/arm/generatedClients/cosmos/databaseAccounts";
-import {
-  acquireMsalTokenForAccount,
-  isCloudShellEntraAuthEnabled,
-  isDataplaneRbacEnabledForProxyApi,
-} from "../../../../Utils/AuthorizationUtils";
+import { isCloudShellEntraAuthEnabled, isDataplaneRbacEnabledForProxyApi } from "../../../../Utils/AuthorizationUtils";
 import { AbstractShellHandler } from "./AbstractShellHandler";
 import { CassandraShellHandler } from "./CassandraShellHandler";
 import { CosmosDBShellHandler } from "./CosmosDBShellHandler";
@@ -41,11 +37,12 @@ export async function getHandler(shellType: TerminalKind): Promise<AbstractShell
  * decides which credential applies so it stays in sync with the connection command
  * the matching handler builds.
  *
- * On the Entra ID path a cached `userContext.aadToken` is preferred, but when none
- * is available (for example an account with local auth disabled while Data Explorer
- * itself is still in key mode) a token is acquired on demand. Without this, the
- * shell would export no credential and silently fall back to interactive browser /
- * device-code auth, which cannot complete inside Azure Cloud Shell.
+ * On the Entra ID path the cached `userContext.aadToken` is used when available. When
+ * none is cached (for example an account with local auth disabled while Data Explorer
+ * itself is still in key mode) an empty string is returned so no credential is
+ * exported; the shell tool then falls through to DefaultAzureCredential, which uses
+ * the Cloud Shell's signed-in `az` session. We deliberately do NOT mint a token via a
+ * browser popup here, which cannot complete inside the hosted Cloud Shell context.
  */
 export async function getKey(useEntraIdAuth: boolean): Promise<string> {
   const dbName = userContext.databaseAccount.name;
@@ -53,10 +50,7 @@ export async function getKey(useEntraIdAuth: boolean): Promise<string> {
     return "";
   }
   if (useEntraIdAuth) {
-    if (userContext.aadToken) {
-      return userContext.aadToken;
-    }
-    return (await acquireMsalTokenForAccount(userContext.databaseAccount, true)) || "";
+    return userContext.aadToken || "";
   }
 
   const keys = await listKeys(userContext.subscriptionId, userContext.resourceGroup, dbName);

--- a/src/Explorer/Tabs/CloudShellTab/Utils/CommonUtils.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/Utils/CommonUtils.test.tsx
@@ -1,0 +1,67 @@
+import { Terminal } from "xterm";
+import { askConfirmation } from "./CommonUtils";
+
+describe("askConfirmation", () => {
+  const createTerminalMock = () => {
+    let keyHandler: ((event: { key: string }) => void) | undefined;
+    const dispose = jest.fn();
+    const terminal = {
+      writeln: jest.fn(),
+      focus: jest.fn(),
+      onKey: jest.fn((handler: (event: { key: string }) => void) => {
+        keyHandler = handler;
+        return { dispose };
+      }),
+    } as unknown as Terminal;
+
+    return {
+      terminal,
+      dispose,
+      pressKey: (key: string) => keyHandler?.({ key }),
+    };
+  };
+
+  it("resolves true when the user presses Y", async () => {
+    const { terminal, dispose, pressKey } = createTerminalMock();
+    const promise = askConfirmation(terminal, "Proceed?");
+
+    pressKey("Y");
+
+    await expect(promise).resolves.toBe(true);
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves true when the user presses lowercase y", async () => {
+    const { terminal, pressKey } = createTerminalMock();
+    const promise = askConfirmation(terminal, "Proceed?");
+
+    pressKey("y");
+
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it("resolves false when the user presses N", async () => {
+    const { terminal, dispose, pressKey } = createTerminalMock();
+    const promise = askConfirmation(terminal, "Proceed?");
+
+    pressKey("N");
+
+    await expect(promise).resolves.toBe(false);
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores keys other than Y or N and keeps listening until a valid answer", async () => {
+    const { terminal, dispose, pressKey } = createTerminalMock();
+    const promise = askConfirmation(terminal, "Proceed?");
+
+    pressKey("a");
+    pressKey("1");
+    pressKey("\r");
+    expect(dispose).not.toHaveBeenCalled();
+
+    pressKey("y");
+
+    await expect(promise).resolves.toBe(true);
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/Explorer/Tabs/CloudShellTab/Utils/CommonUtils.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/Utils/CommonUtils.tsx
@@ -46,6 +46,8 @@ export const getShellNameForDisplay = (terminalKind: TerminalKind): string => {
     case TerminalKind.Mongo:
     case TerminalKind.VCoreMongo:
       return "MongoDB";
+    case TerminalKind.CosmosDB:
+      return "Cosmos DB";
     default:
       return "";
   }

--- a/src/Explorer/Tabs/CloudShellTab/Utils/CommonUtils.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/Utils/CommonUtils.tsx
@@ -24,9 +24,15 @@ export const askConfirmation = async (terminal: Terminal, question: string): Pro
   terminal.focus();
   return new Promise<boolean>((resolve) => {
     const keyListener = terminal.onKey(({ key }: { key: string }) => {
+      const normalizedKey = key.toLowerCase();
+      // Only "y" or "n" are accepted. Any other key is ignored so an accidental
+      // keypress does not abort the flow; keep listening until a valid answer.
+      if (normalizedKey !== "y" && normalizedKey !== "n") {
+        return;
+      }
       keyListener.dispose();
       terminal.writeln(key);
-      return resolve(key.toLowerCase() === "y");
+      return resolve(normalizedKey === "y");
     });
   });
 };

--- a/src/Platform/Hosted/extractFeatures.ts
+++ b/src/Platform/Hosted/extractFeatures.ts
@@ -35,6 +35,7 @@ export type Features = {
   readonly disableConnectionStringLogin: boolean;
   readonly enableContainerCopy: boolean;
   readonly enableCloudShell: boolean;
+  readonly enableCosmosDBShell: boolean;
   readonly enableRestoreContainer: boolean; // only for Fabric
   readonly mongoDisableNativeAuth: boolean;
 
@@ -104,6 +105,7 @@ export function extractFeatures(given = new URLSearchParams(window.location.sear
     enableContainerCopy: "true" === get("enablecontainercopy"),
     enableRestoreContainer: "true" === get("enablerestorecontainer"),
     enableCloudShell: true,
+    enableCosmosDBShell: "true" === get("enablecosmosdbshell"),
     mongoDisableNativeAuth: "true" === get("mongodisablenativeauth"),
   };
 }

--- a/src/Utils/AuthorizationUtils.test.ts
+++ b/src/Utils/AuthorizationUtils.test.ts
@@ -17,6 +17,7 @@ describe("AuthorizationUtils", () => {
     updateUserContext({
       features: {
         enableContainerCopy: false,
+        enableCosmosDBShell: false,
         enableAadDataPlane: enabled,
         canExceedMaximumValue: false,
         cosmosdb: false,

--- a/src/Utils/AuthorizationUtils.ts
+++ b/src/Utils/AuthorizationUtils.ts
@@ -236,3 +236,21 @@ export function useDataplaneRbacAuthorization(userContext: UserContext): boolean
 export function isDataplaneRbacEnabledForProxyApi(userContext: UserContext): boolean {
   return useDataplaneRbacAuthorization(userContext) && hasProxyServer(userContext.apiType);
 }
+
+/**
+ * Determines whether Cloud Shell connections should authenticate with an Entra ID
+ * token (COSMOSDB_SHELL_TOKEN) instead of the account master key.
+ *
+ * Returns true when data-plane RBAC authorization is in effect, or when the account
+ * has local (key) auth disabled — in the latter case a master key would be rejected
+ * by the service, so we must fall back to Entra ID even if the RBAC toggle is off.
+ *
+ * Unlike {@link isDataplaneRbacEnabledForProxyApi}, this does not require a proxy
+ * server, so it works for the SQL/CosmosDB API which connects directly to the
+ * data plane.
+ */
+export function isCloudShellEntraAuthEnabled(userContext: UserContext): boolean {
+  return (
+    useDataplaneRbacAuthorization(userContext) || userContext.databaseAccount?.properties?.disableLocalAuth === true
+  );
+}


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2549?feature.enableCosmosDBShell=true)

## Summary

Added support for cosmos db shell. Cosmos db shell & environment is installed if missing.

## Changes

- New `CosmosDB` value in the `TerminalKind` enum (`src/Contracts/ViewModels.ts`).
- New `CosmosDBShellHandler` that:
  - Ensures `\C:\Users\mikkrg/.dotnet/tools` is on `PATH` and installs the `CosmosDBShell` global tool (`--prerelease`) if not already present.
  - Passes credentials via environment variables (`COSMOSDB_SHELL_ACCOUNT_KEY` for key auth, `COSMOSDB_SHELL_TOKEN` for Entra ID / RBAC) to keep them out of argv / process list / shell history on the Cloud Shell host.
  - Connects with `cosmosdbshell --connect '<documentEndpoint>'`.
- Wired the new handler into `ShellTypeFactory`.
- Added an "Open Cosmos DB Shell" command bar button for `SQL` accounts, gated behind the `enableCloudShell` feature flag.
- Terminal tab title + display-name mappings for the new shell kind.
- Unit tests for `CosmosDBShellHandler` and `ShellTypeFactory`.

## Testing

- Unit tests pass (`CosmosDBShellHandler.test.tsx`, `ShellTypeFactory.test.tsx`).
- Manual tested