### PR TITLE
Add path-to-regexp and picomatch overrides to local-proxy

### DIFF
--- a/utils/local-proxy/package-lock.json
+++ b/utils/local-proxy/package-lock.json
@@ -708,15 +708,15 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha1-myLsFrw6uI0FoMfjaYaUIUAasX0=",
       "license": "MIT"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/utils/local-proxy/package.json
+++ b/utils/local-proxy/package.json
@@ -13,5 +13,9 @@
   "dependencies": {
     "express": "^4.21.1",
     "http-proxy-middleware": "^3.0.3"
+  },
+  "overrides": {
+    "path-to-regexp": "0.1.13",
+    "picomatch": "2.3.2"
   }
 }


### PR DESCRIPTION
Adds npm `overrides` to `utils/local-proxy/package.json` to pin transitive dependencies to non-vulnerable versions:

- `path-to-regexp`: `0.1.13`
- `picomatch`: `2.3.2`

The `utils/local-proxy/package-lock.json` was regenerated via `npm install` so the fixed versions are locked, letting the vNext proxy image pick up the patched lock on `npm ci`.