### PR TITLE
Update vector embed policy remove preview and make spherical default

### DIFF
--- a/src/Explorer/Controls/VectorSearch/VectorEmbeddingPoliciesComponent.tsx
+++ b/src/Explorer/Controls/VectorSearch/VectorEmbeddingPoliciesComponent.tsx
@@ -166,7 +166,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
         indexType: matchingType || "none",
         indexingSearchListSize: matchingIndex?.indexingSearchListSize || undefined,
         quantizationByteSize: matchingIndex?.quantizationByteSize || undefined,
-        quantizerType: supportsQuantizer ? matchingIndex?.quantizerType || "product" : undefined,
+        quantizerType: supportsQuantizer ? matchingIndex?.quantizerType || "spherical" : undefined,
         vectorIndexShardKey: matchingIndex?.vectorIndexShardKey || undefined,
         pathError: onVectorEmbeddingPathError(embedding.path),
         dimensionsError: onVectorEmbeddingDimensionError(embedding.dimensions, matchingIndex?.type || "none"),
@@ -256,7 +256,7 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
       vectorEmbedding.indexingSearchListSize = undefined;
     }
     if (supportsQuantization(vectorEmbedding.indexType)) {
-      vectorEmbedding.quantizerType = vectorEmbedding.quantizerType || "product";
+      vectorEmbedding.quantizerType = vectorEmbedding.quantizerType || "spherical";
     } else {
       vectorEmbedding.quantizerType = undefined;
     }

--- a/src/Explorer/Controls/VectorSearch/VectorSearchUtils.ts
+++ b/src/Explorer/Controls/VectorSearch/VectorSearchUtils.ts
@@ -1,6 +1,5 @@
 import { IDropdownOption } from "@fluentui/react";
 import { VectorIndex } from "Contracts/DataModels";
-import { Keys, t } from "Localization";
 
 const dataTypes = ["float32", "uint8", "int8", "float16"];
 const distanceFunctions = ["euclidean", "cosine", "dotproduct"];
@@ -10,8 +9,8 @@ export const getDataTypeOptions = (): IDropdownOption[] => createDropdownOptions
 export const getDistanceFunctionOptions = (): IDropdownOption[] => createDropdownOptionsFromLiterals(distanceFunctions);
 export const getIndexTypeOptions = (): IDropdownOption[] => createDropdownOptionsFromLiterals(indexTypes);
 export const getQuantizerTypeOptions = (): IDropdownOption[] => [
+  { key: "spherical", text: "Spherical" },
   { key: "product", text: "Product" },
-  { key: "spherical", text: `Spherical (${t(Keys.common.preview)})` },
 ];
 
 export const supportsQuantization = (indexType: VectorIndex["type"] | "none" | undefined): boolean =>

--- a/src/Localization/en/Resources.json
+++ b/src/Localization/en/Resources.json
@@ -990,6 +990,8 @@
       "quantizationByteSizeTooltipContainerName": "container",
       "quantizationByteSizeTooltipGlobalSecondaryIndexName": "global secondary index",
       "quantizerType": "Quantizer type",
+      "quantizerTypeProduct": "Product",
+      "quantizerTypeSpherical": "Spherical",
       "quantizerTypeTooltip": "The quantization method used by the vector index.",
       "indexingSearchListSize": "Indexing search list size",
       "vectorIndexShardKey": "Vector index shard key",


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2555)

For Container Vector Policy, the quantizer type Spherical is no longer in preview so that label has been removed. Also, the vector indexing team would like that type to be the default selected. Obviously, this only applies to the index types that support quantizing (diskANN & quantizedFlat).

Old:
<img width="363" height="630" alt="image" src="https://github.com/user-attachments/assets/a40000ff-3d03-47c8-a46c-25c6c72b88a5" />

New:
<img width="381" height="635" alt="image" src="https://github.com/user-attachments/assets/638fd8c6-33a8-4dc1-b564-15ef995f64b3" />

