### PR TITLE
Disabled quantize byte size when the quantizer type does not support it

### DIFF
--- a/src/Explorer/Controls/VectorSearch/VectorEmbeddingPoliciesComponent.tsx
+++ b/src/Explorer/Controls/VectorSearch/VectorEmbeddingPoliciesComponent.tsx
@@ -2,6 +2,7 @@ import {
   DefaultButton,
   Dropdown,
   IDropdownOption,
+  ILabelStyleProps,
   IStyleFunctionOrObject,
   ITextFieldStyleProps,
   ITextFieldStyles,
@@ -18,6 +19,7 @@ import {
   getIndexTypeOptions,
   getQuantizerTypeOptions,
   supportsQuantization,
+  supportsQuantizationByteSize,
 } from "Explorer/Controls/VectorSearch/VectorSearchUtils";
 import { Keys, t } from "Localization";
 import React, { FunctionComponent, useState } from "react";
@@ -54,11 +56,13 @@ export interface VectorEmbeddingPolicyData {
 
 type VectorEmbeddingPolicyProperty = "dataType" | "distanceFunction" | "indexType";
 
-const labelStyles = {
-  root: {
-    fontSize: 12,
-    color: "var(--colorNeutralForeground1)",
-  },
+const labelStyles = (props: ILabelStyleProps) => {
+  return {
+    root: {
+      fontSize: 12,
+      color: props.disabled ? "var(--colorNeutralForeground3)" : "var(--colorNeutralForeground1)",
+    },
+  };
 };
 
 const textFieldStyles: IStyleFunctionOrObject<ITextFieldStyleProps, ITextFieldStyles> = {
@@ -260,12 +264,19 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
     } else {
       vectorEmbedding.quantizerType = undefined;
     }
+    if (!supportsQuantizationByteSize(vectorEmbedding.quantizerType)) {
+      vectorEmbedding.quantizationByteSize = undefined;
+    }
     setVectorEmbeddingPolicyData(vectorEmbeddings);
   };
 
   const onQuantizerTypeChange = (index: number, option: IDropdownOption): void => {
     const vectorEmbeddings = [...vectorEmbeddingPolicyData];
-    vectorEmbeddings[index].quantizerType = option.key as VectorIndex["quantizerType"];
+    const quantizerType = option.key as VectorIndex["quantizerType"];
+    vectorEmbeddings[index].quantizerType = quantizerType;
+    if (!supportsQuantizationByteSize(quantizerType)) {
+      vectorEmbeddings[index].quantizationByteSize = undefined;
+    }
     setVectorEmbeddingPolicyData(vectorEmbeddings);
   };
 
@@ -442,30 +453,6 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
                         }
                         styles={labelStyles}
                       >
-                        {t(Keys.controls.vectorEmbeddingPolicies.quantizationByteSize)}
-                        <InfoTooltip>{getQuantizationByteSizeTooltipContent()}</InfoTooltip>
-                      </Label>
-                      <TextField
-                        disabled={
-                          isExistingPolicy(vectorEmbeddingPolicy) ||
-                          !supportsQuantization(vectorEmbeddingPolicy.indexType)
-                        }
-                        id={`vector-policy-quantizationByteSize-${index + 1}`}
-                        styles={textFieldStyles}
-                        value={String(vectorEmbeddingPolicy.quantizationByteSize || "")}
-                        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                          onQuantizationByteSizeChange(index, event)
-                        }
-                      />
-                    </Stack>
-                    <Stack style={{ marginLeft: "10px" }}>
-                      <Label
-                        disabled={
-                          isExistingPolicy(vectorEmbeddingPolicy) ||
-                          !supportsQuantization(vectorEmbeddingPolicy.indexType)
-                        }
-                        styles={labelStyles}
-                      >
                         {t(Keys.controls.vectorEmbeddingPolicies.quantizerType)}
                         <InfoTooltip>{t(Keys.controls.vectorEmbeddingPolicies.quantizerTypeTooltip)}</InfoTooltip>
                       </Label>
@@ -480,6 +467,32 @@ export const VectorEmbeddingPoliciesComponent: FunctionComponent<IVectorEmbeddin
                         selectedKey={vectorEmbeddingPolicy.quantizerType ?? null}
                         onChange={(_event: React.FormEvent<HTMLDivElement>, option: IDropdownOption) =>
                           onQuantizerTypeChange(index, option)
+                        }
+                      />
+                    </Stack>
+                    <Stack style={{ marginLeft: "10px" }}>
+                      <Label
+                        disabled={
+                          isExistingPolicy(vectorEmbeddingPolicy) ||
+                          !supportsQuantization(vectorEmbeddingPolicy.indexType) ||
+                          !supportsQuantizationByteSize(vectorEmbeddingPolicy.quantizerType)
+                        }
+                        styles={labelStyles}
+                      >
+                        {t(Keys.controls.vectorEmbeddingPolicies.quantizationByteSize)}
+                        <InfoTooltip>{getQuantizationByteSizeTooltipContent()}</InfoTooltip>
+                      </Label>
+                      <TextField
+                        disabled={
+                          isExistingPolicy(vectorEmbeddingPolicy) ||
+                          !supportsQuantization(vectorEmbeddingPolicy.indexType) ||
+                          !supportsQuantizationByteSize(vectorEmbeddingPolicy.quantizerType)
+                        }
+                        id={`vector-policy-quantizationByteSize-${index + 1}`}
+                        styles={textFieldStyles}
+                        value={String(vectorEmbeddingPolicy.quantizationByteSize || "")}
+                        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                          onQuantizationByteSizeChange(index, event)
                         }
                       />
                     </Stack>

--- a/src/Explorer/Controls/VectorSearch/VectorSearchUtils.ts
+++ b/src/Explorer/Controls/VectorSearch/VectorSearchUtils.ts
@@ -16,6 +16,9 @@ export const getQuantizerTypeOptions = (): IDropdownOption[] => [
 export const supportsQuantization = (indexType: VectorIndex["type"] | "none" | undefined): boolean =>
   indexType === "quantizedFlat" || indexType === "diskANN";
 
+export const supportsQuantizationByteSize = (quantizerType: VectorIndex["quantizerType"] | undefined): boolean =>
+  quantizerType === "product";
+
 function createDropdownOptionsFromLiterals<T extends string>(literals: T[]): IDropdownOption[] {
   return literals.map((value) => ({
     key: value,


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2556)

This PR address 1 functional issue and 2 stylistic issues.

Functionally, as of now, when the quantizer type is anything but "Product", the quantization byte size field should be empty and raises an exception in the backend if it is not.

Stylistically, the quantization byte size field was moved below the quantizer type field since the size is dependent on the type and it is a bad user experience to change/disable a control above some selection (flow should follow the same rules as reading).

Additionally, the fields when disabled gave no visual indication they were disabled, so this change makes the label for disabled fields more distinctly disabled.

Old flow:
Selecting am index type and quantization type that supports byte size:
<img width="292" height="312" alt="image" src="https://github.com/user-attachments/assets/4cef0bfd-e858-4836-b294-9efa1d0ab048" />

Changing to a type that does not support byte size, byte size remains:
<img width="299" height="326" alt="image" src="https://github.com/user-attachments/assets/06f8790d-55a0-43be-8480-81cef0c86e11" />

It also remains if you choose an index type that does not support quantization:
<img width="293" height="325" alt="image" src="https://github.com/user-attachments/assets/67fcbc47-b77b-4ec2-8ad9-36de5b256799" />


New flow:
No index type is chosen so no properties are enabled and are more visually telling of being disabled:
<img width="284" height="310" alt="image" src="https://github.com/user-attachments/assets/3e1a5858-1472-4d1a-b05d-143146cd8272" />

Choosing an index type that supports quantization, the type defaults to "Spherical" which does not support byte size:
<img width="289" height="286" alt="image" src="https://github.com/user-attachments/assets/1b6afa6b-6654-442f-a691-8410d817bf26" />

Choosing "Product" enables the byte size field:
<img width="287" height="295" alt="image" src="https://github.com/user-attachments/assets/9fd48489-257a-478c-ae9a-4333af40dcbf" />

Choosing a different index type which also supports quantization keeps the quantization fields intact:
<img width="287" height="314" alt="image" src="https://github.com/user-attachments/assets/50b74b3d-4935-4037-8615-08b481f7a554" />

Choosing "Spherical" disables byte size and clears the value:
<img width="296" height="323" alt="image" src="https://github.com/user-attachments/assets/f136397c-0183-429e-9401-0fc8cf55e91f" />

Alternatively, choosing an index type that does not support quantization, disables both quantization fields:
<img width="283" height="313" alt="image" src="https://github.com/user-attachments/assets/f1243dc9-25f3-42dc-9df0-681adbe22ef4" />

