### PR TITLE
fix: improve Data Explorer health signal accuracy

### DIFF
--- a/src/Common/ErrorHandlingUtils.ts
+++ b/src/Common/ErrorHandlingUtils.ts
@@ -1,8 +1,6 @@
 import { stringifyError } from "Common/stringifyError";
 import { MessageTypes } from "../Contracts/ExplorerContracts";
 import { SubscriptionType } from "../Contracts/SubscriptionType";
-import { isExpectedError } from "../Metrics/ErrorClassification";
-import { scenarioMonitor } from "../Metrics/ScenarioMonitor";
 import { userContext } from "../UserContext";
 import { ARMError } from "../Utils/arm/request";
 import { logConsoleError } from "../Utils/NotificationConsoleUtils";
@@ -34,12 +32,6 @@ export const handleError = (
 
   // checks for errors caused by firewall and sends them to portal to handle
   sendNotificationForError(errorMessage, errorCode);
-
-  // Mark expected failures for health metrics (auth, firewall, permissions, etc.)
-  // This ensures timeouts with expected failures emit healthy instead of unhealthy
-  if (isExpectedError(error)) {
-    scenarioMonitor.markExpectedFailure();
-  }
 };
 
 export const getErrorMessage = (error: string | Error = ""): string => {

--- a/src/Explorer/Explorer.tsx
+++ b/src/Explorer/Explorer.tsx
@@ -33,6 +33,7 @@ import * as DataModels from "../Contracts/DataModels";
 import { ContainerConnectionInfo, IPhoenixServiceInfo, IProvisionData, IResponse } from "../Contracts/DataModels";
 import * as ViewModels from "../Contracts/ViewModels";
 import { UploadDetailsRecord } from "../Contracts/ViewModels";
+import { classifyError } from "../Metrics/ErrorClassification";
 import MetricScenario from "../Metrics/MetricEvents";
 import { ApplicationMetricPhase } from "../Metrics/ScenarioConfig";
 import { scenarioMonitor } from "../Metrics/ScenarioMonitor";
@@ -367,10 +368,19 @@ export default class Explorer {
       return;
     }
 
-    const collection: DataModels.Collection = await readCollection(databaseId, collectionId);
-    const resourceTokenCollection = new ResourceTokenCollection(this, databaseId, collection);
-    useDatabases.setState({ resourceTokenCollection });
-    useSelectedNode.getState().setSelectedNode(resourceTokenCollection);
+    try {
+      const collection: DataModels.Collection = await readCollection(databaseId, collectionId);
+      const resourceTokenCollection = new ResourceTokenCollection(this, databaseId, collection);
+      useDatabases.setState({ resourceTokenCollection });
+      useSelectedNode.getState().setSelectedNode(resourceTokenCollection);
+    } catch (error) {
+      scenarioMonitor.failPhase(
+        MetricScenario.DatabaseLoad,
+        ApplicationMetricPhase.DatabasesFetched,
+        classifyError(error),
+      );
+      throw error;
+    }
   }
 
   public async refreshAllDatabases(): Promise<void> {
@@ -412,7 +422,11 @@ export default class Explorer {
       );
       logConsoleError(`Error while refreshing databases: ${errorMessage}`);
       useDatabases.setState({ databasesFetchedSuccessfully: false });
-      scenarioMonitor.failPhase(MetricScenario.DatabaseLoad, ApplicationMetricPhase.DatabasesFetched);
+      scenarioMonitor.failPhase(
+        MetricScenario.DatabaseLoad,
+        ApplicationMetricPhase.DatabasesFetched,
+        classifyError(error),
+      );
     }
   }
 
@@ -625,7 +639,11 @@ export default class Explorer {
         },
         startKey,
       );
-      scenarioMonitor.failPhase(MetricScenario.DatabaseLoad, ApplicationMetricPhase.CollectionsLoaded);
+      scenarioMonitor.failPhase(
+        MetricScenario.DatabaseLoad,
+        ApplicationMetricPhase.CollectionsLoaded,
+        classifyError(error),
+      );
     }
   }
 

--- a/src/Metrics/ErrorClassification.test.ts
+++ b/src/Metrics/ErrorClassification.test.ts
@@ -1,7 +1,17 @@
 import { ARMError } from "../Utils/arm/request";
-import { isExpectedError } from "./ErrorClassification";
+import { classifyError, ErrorCategory, isExpectedError } from "./ErrorClassification";
 
 describe("ErrorClassification", () => {
+  describe("classifyError", () => {
+    it("returns a typed expected category", () => {
+      expect(classifyError({ status: 403 })).toBe(ErrorCategory.Expected);
+    });
+
+    it("returns a typed unexpected category", () => {
+      expect(classifyError({ status: 500 })).toBe(ErrorCategory.Unexpected);
+    });
+  });
+
   describe("isExpectedError", () => {
     describe("ARMError with expected codes", () => {
       it("returns true for AuthorizationFailed code", () => {

--- a/src/Metrics/ErrorClassification.ts
+++ b/src/Metrics/ErrorClassification.ts
@@ -51,8 +51,13 @@ interface HttpError {
   status?: number;
 }
 
+export enum ErrorCategory {
+  Expected = "Expected",
+  Unexpected = "Unexpected",
+}
+
 /**
- * Determines if an error is an expected failure that should not mark the scenario as unhealthy.
+ * Classifies whether an error is an expected failure that should not mark the scenario as unhealthy.
  *
  * Expected failures include:
  * - Authentication/authorization errors (user not logged in, permissions)
@@ -60,20 +65,20 @@ interface HttpError {
  * - User-cancelled operations
  *
  * @param error - The error to classify
- * @returns true if the error is expected and should not affect health metrics
+ * @returns the health category for the error
  */
-export function isExpectedError(error: unknown): boolean {
+export function classifyError(error: unknown): ErrorCategory {
   if (!error) {
-    return false;
+    return ErrorCategory.Unexpected;
   }
 
   // Check ARMError code
   if (error instanceof ARMError && error.code !== undefined) {
     if (typeof error.code === "string" && EXPECTED_ARM_ERROR_CODES.has(error.code)) {
-      return true;
+      return ErrorCategory.Expected;
     }
     if (typeof error.code === "number" && EXPECTED_HTTP_STATUS_CODES.has(error.code)) {
-      return true;
+      return ErrorCategory.Expected;
     }
   }
 
@@ -81,7 +86,7 @@ export function isExpectedError(error: unknown): boolean {
   const msalError = error as MsalAuthError;
   if (msalError.errorCode && typeof msalError.errorCode === "string") {
     if (EXPECTED_MSAL_ERROR_CODES.has(msalError.errorCode)) {
-      return true;
+      return ErrorCategory.Expected;
     }
   }
 
@@ -89,21 +94,28 @@ export function isExpectedError(error: unknown): boolean {
   const httpError = error as HttpError;
   if (httpError.status && typeof httpError.status === "number") {
     if (EXPECTED_HTTP_STATUS_CODES.has(httpError.status)) {
-      return true;
+      return ErrorCategory.Expected;
     }
   }
 
   // Check for firewall error in message (the only message-based check)
   if (error instanceof Error && error.message) {
     if (FIREWALL_ERROR_PATTERN.test(error.message)) {
-      return true;
+      return ErrorCategory.Expected;
     }
   }
 
   // Check for string errors with firewall pattern
   if (typeof error === "string" && FIREWALL_ERROR_PATTERN.test(error)) {
-    return true;
+    return ErrorCategory.Expected;
   }
 
-  return false;
+  return ErrorCategory.Unexpected;
+}
+
+/**
+ * Determines if an error is an expected failure that should not mark the scenario as unhealthy.
+ */
+export function isExpectedError(error: unknown): boolean {
+  return classifyError(error) === ErrorCategory.Expected;
 }

--- a/src/Metrics/MetricEvents.test.ts
+++ b/src/Metrics/MetricEvents.test.ts
@@ -1,4 +1,6 @@
+import { HttpHeaders } from "../Common/Constants";
 import { configContext, Platform } from "../ConfigContext";
+import { userContext } from "../UserContext";
 import { getAuthorizationHeader } from "../Utils/AuthorizationUtils";
 import { fetchWithTimeout } from "../Utils/FetchWithTimeout";
 import { MetricScenario } from "./Constants";
@@ -40,10 +42,12 @@ describe("MetricEvents", () => {
 
     const callArgs = mockFetchWithTimeout.mock.calls[0];
     expect(callArgs[0]).toContain("/api/dataexplorer/metrics/health");
-    expect(callArgs[1]?.headers).toEqual({
+    expect(callArgs[1]?.headers).toMatchObject({
       "Content-Type": "application/json",
       authorization: "Bearer test-token",
     });
+
+    expect((callArgs[1]?.headers as Record<string, string>)[HttpHeaders.sessionId]).toBe(userContext.sessionId);
 
     const body = JSON.parse(callArgs[1]?.body as string);
     expect(body.scenario).toBe(MetricScenario.ApplicationLoad);

--- a/src/Metrics/MetricEvents.ts
+++ b/src/Metrics/MetricEvents.ts
@@ -1,7 +1,9 @@
 // Metrics module: scenario metric emission logic.
 import { MetricEvent, MetricScenario } from "Metrics/Constants";
+import { HttpHeaders } from "../Common/Constants";
 import { createUri } from "../Common/UrlUtility";
 import { configContext } from "../ConfigContext";
+import { userContext } from "../UserContext";
 import { getAuthorizationHeader } from "../Utils/AuthorizationUtils";
 import { fetchWithTimeout } from "../Utils/FetchWithTimeout";
 
@@ -21,7 +23,11 @@ const send = async (event: MetricEvent): Promise<Response> => {
 
   return await fetchWithTimeout(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json", [authHeader.header]: authHeader.token },
+    headers: {
+      "Content-Type": "application/json",
+      [authHeader.header]: authHeader.token,
+      [HttpHeaders.sessionId]: userContext.sessionId,
+    },
     body: JSON.stringify(event),
   });
 };

--- a/src/Metrics/ScenarioMonitor.test.ts
+++ b/src/Metrics/ScenarioMonitor.test.ts
@@ -3,11 +3,11 @@
  */
 
 import { updateUserContext } from "../UserContext";
+import { ErrorCategory } from "./ErrorClassification";
 import MetricScenario, { reportMetric } from "./MetricEvents";
 import { ApplicationMetricPhase, CommonMetricPhase } from "./ScenarioConfig";
 import { scenarioMonitor } from "./ScenarioMonitor";
 
-// Mock the MetricEvents module
 jest.mock("./MetricEvents", () => ({
   __esModule: true,
   default: {
@@ -17,7 +17,6 @@ jest.mock("./MetricEvents", () => ({
   reportMetric: jest.fn().mockResolvedValue({ ok: true }),
 }));
 
-// Mock configContext
 jest.mock("../ConfigContext", () => ({
   configContext: {
     platform: "Portal",
@@ -32,12 +31,32 @@ jest.mock("../ConfigContext", () => ({
 }));
 
 describe("ScenarioMonitor", () => {
+  let documentHidden = false;
+
+  const getMetric = (scenario: MetricScenario) => {
+    const call = (reportMetric as jest.Mock).mock.calls.find(([event]) => event.scenario === scenario);
+    return call?.[0];
+  };
+
+  const completeApplicationLoad = () => {
+    scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.PlatformConfigured);
+    scenarioMonitor.startPhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.ExplorerInitialized);
+    scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.ExplorerInitialized);
+    scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, CommonMetricPhase.Interactive);
+  };
+
+  beforeAll(() => {
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => documentHidden,
+    });
+  });
+
   beforeEach(() => {
+    documentHidden = false;
     jest.clearAllMocks();
-    // Use legacy fake timers to avoid conflicts with performance API
     jest.useFakeTimers({ legacyFakeTimers: true });
 
-    // Ensure performance mock is available (setupTests.ts sets this but fake timers may override)
     if (typeof performance.mark !== "function") {
       Object.defineProperty(global, "performance", {
         writable: true,
@@ -55,220 +74,211 @@ describe("ScenarioMonitor", () => {
       });
     }
 
-    // Reset userContext
-    updateUserContext({
-      apiType: "SQL",
-    });
-
-    // Reset the scenario monitor to clear any previous state
+    updateUserContext({ apiType: "SQL" });
     scenarioMonitor.reset();
   });
 
   afterEach(() => {
-    // Reset scenarios before switching to real timers
     scenarioMonitor.reset();
     jest.useRealTimers();
   });
 
-  describe("markExpectedFailure", () => {
-    it("sets hasExpectedFailure flag on active scenarios", () => {
-      // Start a scenario
-      scenarioMonitor.start(MetricScenario.ApplicationLoad);
-
-      // Mark expected failure
-      scenarioMonitor.markExpectedFailure();
-
-      // Let timeout fire - should emit healthy because of expected failure
-      jest.advanceTimersByTime(10000);
-
-      expect(reportMetric).toHaveBeenCalledWith(
-        expect.objectContaining({
-          scenario: MetricScenario.ApplicationLoad,
-          healthy: true,
-          hasExpectedFailure: true,
-          timedOut: true,
-        }),
-      );
-    });
-
-    it("sets flag on multiple active scenarios", () => {
-      // Start two scenarios
-      scenarioMonitor.start(MetricScenario.ApplicationLoad);
-      scenarioMonitor.start(MetricScenario.DatabaseLoad);
-
-      // Mark expected failure - should affect both
-      scenarioMonitor.markExpectedFailure();
-
-      // Let timeouts fire
-      jest.advanceTimersByTime(10000);
-
-      expect(reportMetric).toHaveBeenCalledTimes(2);
-      expect(reportMetric).toHaveBeenCalledWith(expect.objectContaining({ healthy: true, hasExpectedFailure: true }));
-    });
-
-    it("does not affect already emitted scenarios", () => {
-      // Start scenario
-      scenarioMonitor.start(MetricScenario.ApplicationLoad);
-
-      // Complete all phases to emit (PlatformConfigured auto-started, deferred phases need start+complete)
-      scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.PlatformConfigured);
-      scenarioMonitor.startPhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.ExplorerInitialized);
-      scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.ExplorerInitialized);
-      scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, CommonMetricPhase.Interactive);
-
-      // Now mark expected failure - should not change anything
-      scenarioMonitor.markExpectedFailure();
-
-      // reportMetric was called when phases completed
-      expect(reportMetric).toHaveBeenCalledTimes(1);
-      expect(reportMetric).toHaveBeenCalledWith(expect.objectContaining({ healthy: true }));
-    });
+  afterAll(() => {
+    delete (document as unknown as { hidden?: boolean }).hidden;
   });
 
-  describe("timeout behavior", () => {
-    it("emits unhealthy on timeout without expected failure", () => {
-      scenarioMonitor.start(MetricScenario.ApplicationLoad);
+  it("does not apply an ApplicationLoad expected error to DatabaseLoad", () => {
+    scenarioMonitor.start(MetricScenario.ApplicationLoad);
+    scenarioMonitor.start(MetricScenario.DatabaseLoad);
 
-      // Let timeout fire without marking expected failure
-      jest.advanceTimersByTime(10000);
+    scenarioMonitor.failPhase(
+      MetricScenario.ApplicationLoad,
+      ApplicationMetricPhase.PlatformConfigured,
+      ErrorCategory.Expected,
+    );
+    jest.advanceTimersByTime(10000);
 
-      expect(reportMetric).toHaveBeenCalledWith(
-        expect.objectContaining({
-          scenario: MetricScenario.ApplicationLoad,
-          healthy: false,
-          timedOut: true,
-        }),
-      );
-    });
-
-    it("emits healthy on timeout with expected failure", () => {
-      scenarioMonitor.start(MetricScenario.ApplicationLoad);
-
-      // Mark expected failure
-      scenarioMonitor.markExpectedFailure();
-
-      // Let timeout fire
-      jest.advanceTimersByTime(10000);
-
-      expect(reportMetric).toHaveBeenCalledWith(
-        expect.objectContaining({
-          scenario: MetricScenario.ApplicationLoad,
-          healthy: true,
-          timedOut: true,
-          hasExpectedFailure: true,
-        }),
-      );
-    });
-
-    it("emits healthy even with partial phase completion and expected failure", () => {
-      scenarioMonitor.start(MetricScenario.ApplicationLoad);
-
-      // Complete one non-deferred phase
-      scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.PlatformConfigured);
-
-      // Mark expected failure
-      scenarioMonitor.markExpectedFailure();
-
-      // Let timeout fire (deferred phases and Interactive not completed)
-      jest.advanceTimersByTime(10000);
-
-      expect(reportMetric).toHaveBeenCalledWith(
-        expect.objectContaining({
-          healthy: true,
-          timedOut: true,
-          hasExpectedFailure: true,
-          completedPhases: expect.arrayContaining(["PlatformConfigured"]),
-        }),
-      );
-    });
+    expect(getMetric(MetricScenario.ApplicationLoad)).toEqual(
+      expect.objectContaining({ healthy: true, hasExpectedFailure: true, timedOut: true }),
+    );
+    expect(getMetric(MetricScenario.DatabaseLoad)).toEqual(
+      expect.objectContaining({ healthy: false, hasExpectedFailure: false, timedOut: true }),
+    );
   });
 
-  describe("failPhase behavior", () => {
-    it("emits unhealthy immediately on unexpected failure", () => {
-      scenarioMonitor.start(MetricScenario.DatabaseLoad);
+  it("emits unhealthy when an unexpected DatabaseLoad phase fails after expected evidence", () => {
+    scenarioMonitor.start(MetricScenario.DatabaseLoad);
+    scenarioMonitor.failPhase(
+      MetricScenario.DatabaseLoad,
+      ApplicationMetricPhase.DatabasesFetched,
+      ErrorCategory.Expected,
+    );
+    scenarioMonitor.startPhase(MetricScenario.DatabaseLoad, ApplicationMetricPhase.CollectionsLoaded);
 
-      // Fail a phase (simulating unexpected error)
-      scenarioMonitor.failPhase(MetricScenario.DatabaseLoad, ApplicationMetricPhase.DatabasesFetched);
+    scenarioMonitor.failPhase(
+      MetricScenario.DatabaseLoad,
+      ApplicationMetricPhase.CollectionsLoaded,
+      ErrorCategory.Unexpected,
+    );
 
-      // Should emit unhealthy immediately, not wait for timeout
-      expect(reportMetric).toHaveBeenCalledWith(
-        expect.objectContaining({
-          scenario: MetricScenario.DatabaseLoad,
-          healthy: false,
-          timedOut: false,
-        }),
-      );
-    });
-
-    it("does not emit twice after failPhase and timeout", () => {
-      scenarioMonitor.start(MetricScenario.DatabaseLoad);
-
-      // Fail a phase
-      scenarioMonitor.failPhase(MetricScenario.DatabaseLoad, ApplicationMetricPhase.DatabasesFetched);
-
-      // Let timeout fire
-      jest.advanceTimersByTime(10000);
-
-      // Should only have emitted once (from failPhase)
-      expect(reportMetric).toHaveBeenCalledTimes(1);
-    });
+    expect(reportMetric).toHaveBeenCalledTimes(1);
+    expect(getMetric(MetricScenario.DatabaseLoad)).toEqual(
+      expect.objectContaining({ healthy: false, hasExpectedFailure: true, timedOut: false }),
+    );
   });
 
-  describe("completePhase behavior", () => {
-    it("emits healthy when all phases complete", () => {
-      scenarioMonitor.start(MetricScenario.ApplicationLoad);
+  it("emits healthy once at timeout after multiple expected failures", () => {
+    scenarioMonitor.start(MetricScenario.DatabaseLoad);
+    scenarioMonitor.failPhase(
+      MetricScenario.DatabaseLoad,
+      ApplicationMetricPhase.DatabasesFetched,
+      ErrorCategory.Expected,
+    );
+    scenarioMonitor.startPhase(MetricScenario.DatabaseLoad, ApplicationMetricPhase.CollectionsLoaded);
+    scenarioMonitor.failPhase(
+      MetricScenario.DatabaseLoad,
+      ApplicationMetricPhase.CollectionsLoaded,
+      ErrorCategory.Expected,
+    );
 
-      // Complete all required phases (PlatformConfigured + Interactive auto-started, deferred need start)
-      scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.PlatformConfigured);
-      scenarioMonitor.startPhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.ExplorerInitialized);
-      scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.ExplorerInitialized);
-      scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, CommonMetricPhase.Interactive);
+    jest.advanceTimersByTime(10000);
 
-      expect(reportMetric).toHaveBeenCalledWith(
-        expect.objectContaining({
-          scenario: MetricScenario.ApplicationLoad,
-          healthy: true,
-          timedOut: false,
-          completedPhases: expect.arrayContaining(["PlatformConfigured", "ExplorerInitialized", "Interactive"]),
-        }),
-      );
-    });
-
-    it("does not emit until all phases complete", () => {
-      scenarioMonitor.start(MetricScenario.ApplicationLoad);
-
-      // Complete only one non-deferred phase
-      scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.PlatformConfigured);
-
-      expect(reportMetric).not.toHaveBeenCalled();
-    });
+    expect(reportMetric).toHaveBeenCalledTimes(1);
+    expect(getMetric(MetricScenario.DatabaseLoad)).toEqual(
+      expect.objectContaining({ healthy: true, hasExpectedFailure: true, timedOut: true }),
+    );
   });
 
-  describe("scenario isolation", () => {
-    it("expected failure on one scenario does not affect others after completion", () => {
-      // Start both scenarios
-      scenarioMonitor.start(MetricScenario.ApplicationLoad);
-      scenarioMonitor.start(MetricScenario.DatabaseLoad);
+  it("keeps an expected-erroring required phase pending", () => {
+    scenarioMonitor.start(MetricScenario.ApplicationLoad);
+    scenarioMonitor.failPhase(
+      MetricScenario.ApplicationLoad,
+      ApplicationMetricPhase.PlatformConfigured,
+      ErrorCategory.Expected,
+    );
+    scenarioMonitor.startPhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.ExplorerInitialized);
+    scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.ExplorerInitialized);
+    scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, CommonMetricPhase.Interactive);
 
-      // Complete ApplicationLoad (all phases including deferred)
-      scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.PlatformConfigured);
-      scenarioMonitor.startPhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.ExplorerInitialized);
-      scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.ExplorerInitialized);
-      scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, CommonMetricPhase.Interactive);
+    expect(reportMetric).not.toHaveBeenCalled();
 
-      // Now mark expected failure - should only affect DatabaseLoad
-      scenarioMonitor.markExpectedFailure();
+    jest.advanceTimersByTime(10000);
 
-      // Let DatabaseLoad timeout
-      jest.advanceTimersByTime(10000);
+    expect(getMetric(MetricScenario.ApplicationLoad)).toEqual(
+      expect.objectContaining({
+        healthy: true,
+        timedOut: true,
+        completedPhases: expect.not.arrayContaining([ApplicationMetricPhase.PlatformConfigured]),
+      }),
+    );
+  });
 
-      // ApplicationLoad emitted healthy on completion
-      // DatabaseLoad emits healthy on timeout (expected failure)
-      expect(reportMetric).toHaveBeenCalledTimes(2);
-      // Both should be healthy
-      const calls = (reportMetric as jest.Mock).mock.calls;
-      expect(calls[0][0].healthy).toBe(true);
-      expect(calls[1][0].healthy).toBe(true);
-    });
+  it("emits healthy with diagnostics when a phase succeeds after expected evidence", () => {
+    scenarioMonitor.start(MetricScenario.ApplicationLoad);
+    scenarioMonitor.markExpectedFailure(MetricScenario.ApplicationLoad, ApplicationMetricPhase.PlatformConfigured);
+
+    completeApplicationLoad();
+
+    expect(reportMetric).toHaveBeenCalledTimes(1);
+    expect(getMetric(MetricScenario.ApplicationLoad)).toEqual(
+      expect.objectContaining({
+        healthy: true,
+        hasExpectedFailure: true,
+        timedOut: false,
+        completedPhases: expect.arrayContaining([
+          ApplicationMetricPhase.PlatformConfigured,
+          ApplicationMetricPhase.ExplorerInitialized,
+          CommonMetricPhase.Interactive,
+        ]),
+      }),
+    );
+  });
+
+  it("keeps an unexpected result unhealthy when expected evidence arrives later", () => {
+    scenarioMonitor.start(MetricScenario.DatabaseLoad);
+    scenarioMonitor.failPhase(MetricScenario.DatabaseLoad, ApplicationMetricPhase.DatabasesFetched);
+    scenarioMonitor.markExpectedFailure(MetricScenario.DatabaseLoad, ApplicationMetricPhase.CollectionsLoaded);
+
+    jest.advanceTimersByTime(10000);
+
+    expect(reportMetric).toHaveBeenCalledTimes(1);
+    expect(getMetric(MetricScenario.DatabaseLoad)).toEqual(
+      expect.objectContaining({ healthy: false, hasExpectedFailure: false, timedOut: false }),
+    );
+  });
+
+  it("treats hidden-at-start and hidden-later timeouts as healthy expected outcomes", () => {
+    documentHidden = true;
+    scenarioMonitor.start(MetricScenario.ApplicationLoad);
+
+    documentHidden = false;
+    scenarioMonitor.start(MetricScenario.DatabaseLoad);
+    documentHidden = true;
+    document.dispatchEvent(new Event("visibilitychange"));
+    documentHidden = false;
+
+    jest.advanceTimersByTime(10000);
+
+    expect(getMetric(MetricScenario.ApplicationLoad)).toEqual(
+      expect.objectContaining({ healthy: true, hasExpectedFailure: true, timedOut: true }),
+    );
+    expect(getMetric(MetricScenario.DatabaseLoad)).toEqual(
+      expect.objectContaining({ healthy: true, hasExpectedFailure: true, timedOut: true }),
+    );
+  });
+
+  it("emits unhealthy when an unexpected failure occurs while hidden", () => {
+    documentHidden = true;
+    scenarioMonitor.start(MetricScenario.DatabaseLoad);
+
+    scenarioMonitor.failPhase(MetricScenario.DatabaseLoad, ApplicationMetricPhase.DatabasesFetched);
+
+    expect(reportMetric).toHaveBeenCalledTimes(1);
+    expect(getMetric(MetricScenario.DatabaseLoad)).toEqual(
+      expect.objectContaining({ healthy: false, hasExpectedFailure: true, timedOut: false }),
+    );
+  });
+
+  it("emits unhealthy on a visible timeout without expected evidence", () => {
+    scenarioMonitor.start(MetricScenario.ApplicationLoad);
+
+    jest.advanceTimersByTime(10000);
+
+    expect(getMetric(MetricScenario.ApplicationLoad)).toEqual(
+      expect.objectContaining({ healthy: false, hasExpectedFailure: false, timedOut: true }),
+    );
+  });
+
+  it("does not double emit when callbacks race after timeout", () => {
+    scenarioMonitor.start(MetricScenario.ApplicationLoad);
+    scenarioMonitor.markExpectedFailure(MetricScenario.ApplicationLoad, ApplicationMetricPhase.PlatformConfigured);
+    jest.advanceTimersByTime(10000);
+
+    completeApplicationLoad();
+    scenarioMonitor.failPhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.PlatformConfigured);
+
+    expect(reportMetric).toHaveBeenCalledTimes(1);
+    expect(getMetric(MetricScenario.ApplicationLoad)).toEqual(
+      expect.objectContaining({ healthy: true, timedOut: true }),
+    );
+  });
+
+  it("reset removes visibility listeners and clears scenario state", () => {
+    const removeEventListener = jest.spyOn(document, "removeEventListener");
+    scenarioMonitor.start(MetricScenario.ApplicationLoad);
+    scenarioMonitor.markExpectedFailure(MetricScenario.ApplicationLoad, ApplicationMetricPhase.PlatformConfigured);
+
+    scenarioMonitor.reset();
+
+    expect(removeEventListener).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+
+    scenarioMonitor.start(MetricScenario.ApplicationLoad);
+    jest.advanceTimersByTime(10000);
+
+    expect(reportMetric).toHaveBeenCalledTimes(1);
+    expect(getMetric(MetricScenario.ApplicationLoad)).toEqual(
+      expect.objectContaining({ healthy: false, hasExpectedFailure: false, timedOut: true }),
+    );
+    removeEventListener.mockRestore();
   });
 });

--- a/src/Metrics/ScenarioMonitor.ts
+++ b/src/Metrics/ScenarioMonitor.ts
@@ -1,9 +1,11 @@
 import type { PhaseTimings, WebVitals } from "Metrics/Constants";
 import { Metric, onCLS, onFCP, onINP, onLCP, onTTFB } from "web-vitals";
+import { stringifyError } from "../Common/stringifyError";
 import { configContext } from "../ConfigContext";
 import { Action } from "../Shared/Telemetry/TelemetryConstants";
 import { traceFailure, traceMark, traceStart, traceSuccess } from "../Shared/Telemetry/TelemetryProcessor";
 import { userContext } from "../UserContext";
+import { ErrorCategory } from "./ErrorClassification";
 import MetricScenario, { reportMetric } from "./MetricEvents";
 import { scenarioConfigs } from "./MetricScenarioConfigs";
 import { MetricPhase, ScenarioConfig, ScenarioContextSnapshot } from "./ScenarioConfig";
@@ -23,12 +25,27 @@ interface InternalScenarioContext {
   timeoutId?: number;
   emitted: boolean;
   hasExpectedFailure: boolean; // Flag for expected failures (auth, firewall, etc.)
+  expectedFailurePhases: Set<MetricPhase>;
+  documentWasHidden: boolean;
 }
 
 class ScenarioMonitor {
   private contexts = new Map<MetricScenario, InternalScenarioContext>();
   private vitals: WebVitals = {};
   private vitalsInitialized = false;
+  private visibilityListenerAttached = false;
+
+  private readonly handleVisibilityChange = () => {
+    if (!document.hidden) {
+      return;
+    }
+
+    this.contexts.forEach((ctx) => {
+      if (!ctx.emitted) {
+        this.markDocumentHidden(ctx);
+      }
+    });
+  };
 
   constructor() {
     this.initializeVitals();
@@ -85,7 +102,15 @@ class ScenarioMonitor {
       phases: new Map<MetricPhase, PhaseContext>(),
       emitted: false,
       hasExpectedFailure: false,
+      expectedFailurePhases: new Set<MetricPhase>(),
+      documentWasHidden: false,
     };
+
+    this.contexts.set(scenario, ctx);
+    this.ensureVisibilityListener();
+    if (document.hidden) {
+      this.markDocumentHidden(ctx);
+    }
 
     // Start all required phases at scenario start time, except deferred ones
     const deferredSet = new Set(config.deferredPhases ?? []);
@@ -110,12 +135,17 @@ class ScenarioMonitor {
     });
 
     ctx.timeoutId = window.setTimeout(() => {
+      if (document.hidden) {
+        this.markDocumentHidden(ctx);
+      }
       const missingPhases = ctx.config.requiredPhases.filter((p) => !ctx.completed.has(p));
 
       this.devLog(
         `timeout: ${scenario} | missing=[${missingPhases.join(", ")}] | completed=[${Array.from(ctx.completed).join(
           ", ",
-        )}] | documentHidden=${document.hidden} | hasExpectedFailure=${ctx.hasExpectedFailure}`,
+        )}] | expected=[${Array.from(ctx.expectedFailurePhases).join(", ")}] | documentHidden=${
+          document.hidden
+        } | hasExpectedFailure=${ctx.hasExpectedFailure}`,
       );
 
       traceMark(Action.MetricsScenario, {
@@ -123,15 +153,15 @@ class ScenarioMonitor {
         scenario,
         missingPhases: missingPhases.join(","),
         completedPhases: Array.from(ctx.completed).join(","),
+        expectedFailurePhases: Array.from(ctx.expectedFailurePhases).join(","),
         documentHidden: document.hidden,
         hasExpectedFailure: ctx.hasExpectedFailure,
       });
 
-      // If an expected failure occurred (auth, firewall, etc.), emit healthy instead of unhealthy
-      const healthy = ctx.hasExpectedFailure;
+      // Expected-only timeouts are healthy. Visible timeouts without expected evidence are unhealthy.
+      const healthy = ctx.hasExpectedFailure && ctx.failed.size === 0;
       this.emit(ctx, healthy, true);
     }, config.timeoutMs);
-    this.contexts.set(scenario, ctx);
   }
 
   startPhase(scenario: MetricScenario, phase: MetricPhase) {
@@ -220,16 +250,14 @@ class ScenarioMonitor {
     this.tryEmitIfReady(ctx);
   }
 
-  failPhase(scenario: MetricScenario, phase: MetricPhase) {
+  failPhase(scenario: MetricScenario, phase: MetricPhase, category: ErrorCategory = ErrorCategory.Unexpected) {
     const ctx = this.contexts.get(scenario);
-    if (!ctx || ctx.emitted) {
+    if (!ctx || ctx.emitted || !ctx.config.requiredPhases.includes(phase)) {
       return;
     }
 
-    // If an expected failure was flagged (auth, firewall, etc.), treat as success.
-    if (ctx.hasExpectedFailure) {
-      this.devLog(`phase_fail: ${scenario}.${phase} — expected failure, completing as healthy`);
-      this.completePhase(scenario, phase);
+    if (category === ErrorCategory.Expected) {
+      this.markExpectedFailure(scenario, phase);
       return;
     }
 
@@ -267,20 +295,59 @@ class ScenarioMonitor {
 
   /**
    * Marks that an expected failure occurred (auth, firewall, permissions, etc.).
-   * When the scenario times out with this flag set, it will emit healthy instead of unhealthy.
-   * This is called automatically from handleError when an expected error is detected.
+   * Expected evidence is scoped to one active scenario and phase. It does not complete
+   * the phase; the phase remains pending until it genuinely succeeds or the scenario times out.
    */
-  markExpectedFailure() {
-    // Set the flag on all active (non-emitted) scenarios
-    this.contexts.forEach((ctx) => {
-      if (!ctx.emitted) {
-        ctx.hasExpectedFailure = true;
-        traceMark(Action.MetricsScenario, {
-          event: "expected_failure_marked",
-          scenario: ctx.scenario,
-        });
-      }
+  markExpectedFailure(scenario: MetricScenario, phase: MetricPhase) {
+    const ctx = this.contexts.get(scenario);
+    if (!ctx || ctx.emitted || !ctx.config.requiredPhases.includes(phase)) {
+      return;
+    }
+
+    ctx.hasExpectedFailure = true;
+    if (ctx.expectedFailurePhases.has(phase)) {
+      return;
+    }
+    ctx.expectedFailurePhases.add(phase);
+    this.devLog(`expected_failure: ${scenario}.${phase}`);
+    traceMark(Action.MetricsScenario, {
+      event: "expected_failure_marked",
+      scenario,
+      phase,
     });
+  }
+
+  private markDocumentHidden(ctx: InternalScenarioContext) {
+    if (ctx.documentWasHidden) {
+      return;
+    }
+
+    ctx.documentWasHidden = true;
+    ctx.hasExpectedFailure = true;
+    this.devLog(`expected_failure: ${ctx.scenario} | document hidden`);
+    traceMark(Action.MetricsScenario, {
+      event: "expected_failure_marked",
+      scenario: ctx.scenario,
+      reason: "document_hidden",
+    });
+  }
+
+  private ensureVisibilityListener() {
+    if (this.visibilityListenerAttached) {
+      return;
+    }
+
+    document.addEventListener("visibilitychange", this.handleVisibilityChange);
+    this.visibilityListenerAttached = true;
+  }
+
+  private removeVisibilityListenerIfIdle() {
+    if (!this.visibilityListenerAttached || Array.from(this.contexts.values()).some((ctx) => !ctx.emitted)) {
+      return;
+    }
+
+    document.removeEventListener("visibilitychange", this.handleVisibilityChange);
+    this.visibilityListenerAttached = false;
   }
 
   private tryEmitIfReady(ctx: InternalScenarioContext) {
@@ -348,6 +415,7 @@ class ScenarioMonitor {
       durationMs: finalSnapshot.durationMs,
       completedPhases: finalSnapshot.completed.join(","),
       failedPhases: finalSnapshot.failedPhases?.join(","),
+      expectedFailurePhases: Array.from(ctx.expectedFailurePhases).join(","),
       lcp: finalSnapshot.vitals?.lcp,
       inp: finalSnapshot.vitals?.inp,
       cls: finalSnapshot.vitals?.cls,
@@ -384,10 +452,17 @@ class ScenarioMonitor {
       startTimeISO: finalSnapshot.startTimeISO,
       endTimeISO: finalSnapshot.endTimeISO,
       vitals: finalSnapshot.vitals,
+    }).catch((error: unknown) => {
+      traceFailure(Action.MetricsScenario, {
+        event: "scenario_report_failure",
+        scenario: ctx.scenario,
+        error: error instanceof Error ? stringifyError(error) : String(error),
+      });
     });
 
     // Cleanup performance entries
     this.cleanupPerformanceEntries(ctx);
+    this.removeVisibilityListenerIfIdle();
   }
 
   private cleanupPerformanceEntries(ctx: InternalScenarioContext) {
@@ -444,8 +519,14 @@ class ScenarioMonitor {
       if (ctx.timeoutId) {
         clearTimeout(ctx.timeoutId);
       }
+      this.cleanupPerformanceEntries(ctx);
     });
     this.contexts.clear();
+    if (this.visibilityListenerAttached) {
+      document.removeEventListener("visibilitychange", this.handleVisibilityChange);
+      this.visibilityListenerAttached = false;
+    }
+    this.vitals = {};
   }
 }
 

--- a/src/Utils/AuthorizationUtils.ts
+++ b/src/Utils/AuthorizationUtils.ts
@@ -9,8 +9,6 @@ import * as Logger from "../Common/Logger";
 import { configContext } from "../ConfigContext";
 import { DatabaseAccount } from "../Contracts/DataModels";
 import * as ViewModels from "../Contracts/ViewModels";
-import { isExpectedError } from "../Metrics/ErrorClassification";
-import { scenarioMonitor } from "../Metrics/ScenarioMonitor";
 import { trace, traceFailure, traceStart, traceSuccess } from "../Shared/Telemetry/TelemetryProcessor";
 import { UserContext, userContext } from "../UserContext";
 
@@ -158,10 +156,6 @@ export async function acquireMsalTokenForAccount(
         errorMessage: stringifyError(error),
       });
       traceFailure(Action.AcquireMsalToken, { error: stringifyError(error) }, msalStartKey);
-      // Mark expected failure for health metrics so timeout emits healthy
-      if (isExpectedError(error)) {
-        scenarioMonitor.markExpectedFailure();
-      }
       throw error;
     }
   } else {
@@ -205,10 +199,6 @@ export async function acquireTokenWithMsal(
           acquireTokenType: "interactive",
           errorMessage: JSON.stringify(interactiveError),
         });
-        // Mark expected failure for health metrics so timeout emits healthy
-        if (isExpectedError(interactiveError)) {
-          scenarioMonitor.markExpectedFailure();
-        }
         throw interactiveError;
       }
     } else {
@@ -217,10 +207,6 @@ export async function acquireTokenWithMsal(
         acquireTokenType: "silent",
         errorMessage: JSON.stringify(silentError),
       });
-      // Mark expected failure for health metrics so timeout emits healthy
-      if (isExpectedError(silentError)) {
-        scenarioMonitor.markExpectedFailure();
-      }
       throw silentError;
     }
   }

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -47,6 +47,7 @@ import {
   HostedExplorerChildFrame,
   ResourceToken,
 } from "../HostedExplorerChildFrame";
+import { classifyError } from "../Metrics/ErrorClassification";
 import MetricScenario from "../Metrics/MetricEvents";
 import { ApplicationMetricPhase } from "../Metrics/ScenarioConfig";
 import { scenarioMonitor } from "../Metrics/ScenarioMonitor";
@@ -83,6 +84,8 @@ export function useKnockoutExplorer(platform: Platform): Explorer {
   useEffect(() => {
     const effect = async () => {
       if (platform) {
+        scenarioMonitor.start(MetricScenario.ApplicationLoad);
+
         //Updating phoenix feature flags for MPAC based of config context
         if (configContext.isPhoenixEnabled === true) {
           userContext.features.phoenixNotebooks = true;
@@ -101,7 +104,11 @@ export function useKnockoutExplorer(platform: Platform): Explorer {
             explorer = await configureFabric();
           }
         } catch (error) {
-          scenarioMonitor.failPhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.PlatformConfigured);
+          scenarioMonitor.failPhase(
+            MetricScenario.ApplicationLoad,
+            ApplicationMetricPhase.PlatformConfigured,
+            classifyError(error),
+          );
           throw error;
         }
         scenarioMonitor.completePhase(MetricScenario.ApplicationLoad, ApplicationMetricPhase.PlatformConfigured);
@@ -363,6 +370,11 @@ async function configureHostedWithAAD(config: AAD): Promise<Explorer> {
         authority: `${configContext.AAD_ENDPOINT}${cachedTenantId}`,
       });
     } catch (authError) {
+      scenarioMonitor.failPhase(
+        MetricScenario.ApplicationLoad,
+        ApplicationMetricPhase.PlatformConfigured,
+        classifyError(authError),
+      );
       logConsoleError("Failed to acquire authorization token: " + authError);
     }
   }
@@ -682,14 +694,18 @@ export async function fetchAndUpdateKeys(subscriptionId: string, resourceGroup: 
   });
   let keys;
   try {
-    keys = await listKeys(subscriptionId, resourceGroup, account);
-    Logger.logInfo(`Keys fetched for ${userContext.apiType} account ${account}`, "Explorer/fetchAndUpdateKeys");
-    updateUserContext({
-      masterKey: keys.primaryMasterKey,
-    });
-    traceSuccess(Action.FetchAccountKeys, { accountName: account }, startKey);
-  } catch (error) {
-    if (error.code === "AuthorizationFailed") {
+    try {
+      keys = await listKeys(subscriptionId, resourceGroup, account);
+      Logger.logInfo(`Keys fetched for ${userContext.apiType} account ${account}`, "Explorer/fetchAndUpdateKeys");
+      updateUserContext({
+        masterKey: keys.primaryMasterKey,
+      });
+      traceSuccess(Action.FetchAccountKeys, { accountName: account }, startKey);
+    } catch (error) {
+      if (error.code !== "AuthorizationFailed") {
+        throw error;
+      }
+
       keys = await getReadOnlyKeys(subscriptionId, resourceGroup, account);
       Logger.logInfo(
         `Read only Keys fetched for ${userContext.apiType} account ${account}`,
@@ -699,15 +715,20 @@ export async function fetchAndUpdateKeys(subscriptionId: string, resourceGroup: 
         masterKey: keys.primaryReadonlyMasterKey,
       });
       traceSuccess(Action.FetchAccountKeys, { accountName: account, fallbackToReadOnly: true }, startKey);
-    } else {
-      logConsoleError(`Error occurred fetching keys for the account." ${error.message}`);
-      Logger.logError(
-        `Error during fetching keys or updating user context: ${error} for ${userContext.apiType} account ${account}`,
-        "Explorer/fetchAndUpdateKeys",
-      );
-      traceFailure(Action.FetchAccountKeys, { accountName: account, error: error.message }, startKey);
-      throw error;
     }
+  } catch (error) {
+    logConsoleError(`Error occurred fetching keys for the account." ${error.message}`);
+    Logger.logError(
+      `Error during fetching keys or updating user context: ${error} for ${userContext.apiType} account ${account}`,
+      "Explorer/fetchAndUpdateKeys",
+    );
+    traceFailure(Action.FetchAccountKeys, { accountName: account, error: error.message }, startKey);
+    scenarioMonitor.failPhase(
+      MetricScenario.ApplicationLoad,
+      ApplicationMetricPhase.PlatformConfigured,
+      classifyError(error),
+    );
+    throw error;
   }
 }
 
@@ -810,6 +831,11 @@ async function configurePortal(): Promise<Explorer> {
                 updateUserContext({ aadToken: aadToken });
                 useDataPlaneRbac.setState({ aadTokenUpdated: true });
               } catch (authError) {
+                scenarioMonitor.failPhase(
+                  MetricScenario.ApplicationLoad,
+                  ApplicationMetricPhase.PlatformConfigured,
+                  classifyError(authError),
+                );
                 Logger.logWarning(
                   `Failed to silently acquire authorization token from MSAL: ${authError} for ${userContext.apiType} account ${account}`,
                   "Explorer/configurePortal",

--- a/src/hooks/useKnockoutExplorer.ts
+++ b/src/hooks/useKnockoutExplorer.ts
@@ -456,7 +456,7 @@ async function configureHostedWithAAD(config: AAD): Promise<Explorer> {
     if (userContext.features.enableAadDataPlane) {
       console.warn(e);
     } else {
-      throw new Error(`List keys failed: ${e.message}`);
+      throw e;
     }
   }
   updateUserContext({


### PR DESCRIPTION
## Why this change

The existing Data Explorer health signal was producing incidents that were not consistently actionable. We reviewed the frontend state machine, Portal Backend telemetry, the Geneva metric and production monitor, and historical ICM behavior before changing the semantics.

### Evidence from Portal Backend/Kusto

A roughly 45-day retained sample showed that unhealthy events were dominated by scenario timeouts rather than explicit unexpected failures:

| Platform / scenario | Unhealthy rate | Unhealthy events reported as timeouts |
|---|---:|---:|
| Portal / DatabaseLoad | 1.453% | 70.58% |
| Portal / ApplicationLoad | 0.211% | 100% |
| Hosted / DatabaseLoad | 1.025% | 91.26% |
| Hosted / ApplicationLoad | 0.369% | 48.71% |

The five-minute windows used by the current Geneva monitor were also highly sensitive to sparse traffic:

- Portal had 26 windows at or above the 10% unhealthy threshold; only 16 had at least 20 samples and only one had at least 50.
- Hosted had 125 windows at or above 10%; **105 of those windows were caused by a single unhealthy event**. Only five had at least 20 samples and one had at least 50.

### Evidence from Geneva/ICM

The production monitor evaluates a five-minute window every three minutes, alerts above 10%, aggregates only by Platform, has no minimum event floor or persistence, and does not automatically mitigate.

Across approximately 180 days of ICM history we found 22 direct production incidents, evenly split between Portal and Hosted. At review time, 15 remained active, 14 were unacknowledged, and none were marked customer-impacting. This is consistent with a signal that is too sensitive to isolated events and expected environmental conditions.

### Frontend causes identified

- Expected authentication, authorization, firewall, and policy failures were stored globally and could affect unrelated active scenarios.
- Once any expected failure was present, a later phase failure could be treated as successful completion.
- Expected-failed phases were marked complete even though the phase had not actually succeeded.
- Background/hidden-tab timeouts could be interpreted as product failures.
- Real errors were not consistently passed to the scenario boundary for classification.

## New health semantics

The monitor now applies explicit scenario-local precedence:

1. **Any unexpected failure → Unhealthy immediately.**
2. **Otherwise, expected-only evidence → Healthy with diagnostics.**
3. **Otherwise, all required phases complete → Healthy.**
4. **Otherwise, a visible timeout → Unhealthy.**

Expected evidence is non-terminal: it does not complete a phase and cannot hide a later unexpected failure.

### Why not every timeout is Unhealthy

A timeout means the scenario did not complete all required phases within ten seconds; it does not identify the cause. For operational health, a visible and unexplained timeout remains **Unhealthy**. The exceptions are cases where the timeout is explained by a condition that is not evidence of a Data Explorer service regression:

| Timeout context | Health result | Rationale |
|---|---|---|
| Visible page with no expected blocker | **Unhealthy** | The application had a fair opportunity to complete and did not. |
| Any unexpected phase failure | **Unhealthy immediately** | Concrete failure evidence always overrides visibility or expected evidence. |
| Expected authorization, firewall, or policy condition only | **Healthy with diagnostics** | The user flow did not complete, but the condition is not an actionable Data Explorer service failure. |
| Page was hidden/backgrounded with no unexpected failure | **Healthy with diagnostics** | Browser timer throttling and suspended work make the ten-second deadline unreliable. |

This distinction is between **user-flow completion** and **operational service health**. Expected and hidden-page timeouts remain observable through `timedOut`, `hasExpectedFailure`, phase diagnostics, and telemetry; they are not silently discarded. Treating every timeout as Unhealthy would reintroduce the sparse-window alert noise observed in Geneva, where a single event caused 105 of 125 Hosted windows above the current 10% threshold.

## What changed

- Scope expected-failure evidence to one scenario and phase.
- Classify errors at the ApplicationLoad and DatabaseLoad boundaries.
- Keep expected-failed phases pending until real completion or timeout.
- Ensure unexpected failures override expected evidence.
- Treat hidden-page-only timeouts as Healthy diagnostic events.
- Guarantee exactly one terminal event per scenario.
- Clean up visibility listeners and performance entries between runs.
- Trace failures to report the final metric instead of silently dropping rejected promises.
- Preserve the original ARM error through hosted key retrieval so `AuthorizationFailed` remains correctly classified.

## What is intentionally not included

- Login monitoring and changes to Entra or connection-string authentication are deferred.
- The Portal Backend route and authentication policy are unchanged in this PR.
- Geneva monitor thresholds and scenario-specific monitor definitions are being handled separately so frontend semantics can be validated before production cutover.

## Validation

- 45 targeted Jest tests passed, including scenario isolation, expected/unexpected precedence, hidden and visible timeouts, race behavior, reset cleanup, and exactly-once emission.
- TypeScript and strict TypeScript compilation passed.
- Prettier and ESLint passed with no new errors.
- Authenticated Hosted Explorer happy path produced one Healthy terminal event for ApplicationLoad and DatabaseLoad.
- Browser-level ARM fault injection verified:
  - `listKeys` and `readonlykeys` returning 403 `AuthorizationFailed` produce one Healthy timed-out ApplicationLoad result with expected diagnostics.
  - `listKeys` returning an unexpected 500 produces one immediate Unhealthy result and no later duplicate timeout event.
- An independent adversarial review found no high-confidence correctness issues.

## Rollout expectation

This PR improves the meaning of the emitted frontend signal. The companion Geneva rollout should initially run scenario-specific monitors alongside the existing production monitor, validate volume and threshold behavior in staging, and only then replace the blended Platform-only monitor.