### PR TITLE
Update CloudShell API version to 2025-09-01-preview

### DIFF
--- a/src/Explorer/Tabs/CloudShellTab/Data/CloudShellClient.test.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/Data/CloudShellClient.test.tsx
@@ -85,7 +85,7 @@ describe("CloudShellClient", () => {
         host: MOCK_ARM_ENDPOINT,
         path: "/providers/Microsoft.Portal/userSettings/cloudconsole",
         method: "GET",
-        apiVersion: "2023-02-01-preview",
+        apiVersion: "2025-09-01-preview",
       });
       expect(result).toEqual(mockSettings);
     });
@@ -100,7 +100,7 @@ describe("CloudShellClient", () => {
         host: MOCK_ARM_ENDPOINT,
         path: "/providers/Microsoft.Portal/userSettings/cloudconsole",
         method: "GET",
-        apiVersion: "2023-02-01-preview",
+        apiVersion: "2025-09-01-preview",
       });
     });
   });
@@ -116,7 +116,7 @@ describe("CloudShellClient", () => {
         host: MOCK_ARM_ENDPOINT,
         path: "/providers/Microsoft.Portal/userSettings/cloudconsole",
         method: "PUT",
-        apiVersion: "2023-02-01-preview",
+        apiVersion: "2025-09-01-preview",
         body: {
           properties: {
             preferredOsType: OsType.Linux,
@@ -144,7 +144,7 @@ describe("CloudShellClient", () => {
         host: MOCK_ARM_ENDPOINT,
         path: "/providers/Microsoft.Portal/userSettings/cloudconsole",
         method: "PUT",
-        apiVersion: "2023-02-01-preview",
+        apiVersion: "2025-09-01-preview",
         body: {
           properties: {
             preferredOsType: OsType.Linux,
@@ -247,7 +247,7 @@ describe("CloudShellClient", () => {
         host: MOCK_ARM_ENDPOINT,
         path: "providers/Microsoft.Portal/consoles/default",
         method: "PUT",
-        apiVersion: "2023-02-01-preview",
+        apiVersion: "2025-09-01-preview",
         customHeaders: {
           "x-ms-console-preferred-location": "eastus",
         },
@@ -271,7 +271,7 @@ describe("CloudShellClient", () => {
         host: MOCK_ARM_ENDPOINT,
         path: "providers/Microsoft.Portal/consoles/default",
         method: "PUT",
-        apiVersion: "2023-02-01-preview",
+        apiVersion: "2025-09-01-preview",
         customHeaders: {
           "x-ms-console-preferred-location": "eastus",
         },

--- a/src/Explorer/Tabs/CloudShellTab/Data/CloudShellClient.tsx
+++ b/src/Explorer/Tabs/CloudShellTab/Data/CloudShellClient.tsx
@@ -26,7 +26,7 @@ export const getUserSettings = async (): Promise<CloudShellSettings> => {
     host: configContext.ARM_ENDPOINT,
     path: `/providers/Microsoft.Portal/userSettings/cloudconsole`,
     method: "GET",
-    apiVersion: "2023-02-01-preview",
+    apiVersion: "2025-09-01-preview",
   });
 };
 
@@ -56,7 +56,7 @@ export const putEphemeralUserSettings = async (
     host: configContext.ARM_ENDPOINT,
     path: `/providers/Microsoft.Portal/userSettings/cloudconsole`,
     method: "PUT",
-    apiVersion: "2023-02-01-preview",
+    apiVersion: "2025-09-01-preview",
     body: ephemeralSettings,
     timeoutMs: CLOUDSHELL_ARM_TIMEOUT_MS,
   });
@@ -92,7 +92,7 @@ export const provisionConsole = async (consoleLocation: string): Promise<Provisi
     host: configContext.ARM_ENDPOINT,
     path: `providers/Microsoft.Portal/consoles/default`,
     method: "PUT",
-    apiVersion: "2023-02-01-preview",
+    apiVersion: "2025-09-01-preview",
     customHeaders: {
       "x-ms-console-preferred-location": consoleLocation,
     },


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/2570?feature.someFeatureFlagYouMightNeed=true)


## Summary

Updates Cloud Shell ARM calls from `2023-02-01-preview` to `2025-09-01-preview` and adjusts the associated unit tests.

## Background

This change supports a larger backend rewrite driven by SFI requirements. Due to SFI timelines, the 2023 API version will no longer be supported after September 30.
