### PR TITLE
Fix js-yaml Dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2697,9 +2697,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -13020,9 +13020,9 @@
       }
     },
     "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dependencies": {
         "argparse": "^2.0.1"
       },


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

## Description

Fixes Dependabot alert 432 for CVE-2026-59869 (GHSA-52cp-r559-cp3m), a high-severity denial-of-service vulnerability in `js-yaml` merge-key processing.

Updates the two transitive `js-yaml` copies used by ESLint from 4.1.1 to patched version 4.3.1. The direct `js-yaml` 3.x dependency remains at 3.15.1, which is already patched.

## Validation

- `npm run build`
- `npm run test:debug`
  - 193 test suites passed, 1 skipped
  - 1,947 tests passed, 5 skipped
  - 189 snapshots passed
- Confirmed GHSA-52cp-r559-cp3m is absent from `npm audit`

