### PR TITLE
Update preview site URL

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,1 @@
-[Preview this branch](https://dataexplorer-preview.azurewebsites.net/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)
+[Preview this branch](https://dataexplorer-preview.portal.cosmos.azure.com/pull/EDIT_THIS_NUMBER_IN_THE_PR_DESCRIPTION?feature.someFeatureFlagYouMightNeed=true)

--- a/preview/.azure/config
+++ b/preview/.azure/config
@@ -1,7 +1,0 @@
-[defaults]
-group = dataexplorer-preview
-sku = P1v2
-appserviceplan = dataexplorer-preview
-location = westus2
-web = dataexplorer-preview
-

--- a/preview/README.md
+++ b/preview/README.md
@@ -4,8 +4,8 @@ Cosmos Explorer Preview makes it possible to try a working version of any commit
 
 Initial support is for Hosted (Connection string only) or the Azure Portal. Examples:
 
-Connection string URLs: https://dataexplorer-preview.azurewebsites.net/commit/COMMIT_SHA/hostedExplorer.html
-Portal URLs: https://ms.portal.azure.com/?dataExplorerSource=https://dataexplorer-preview.azurewebsites.net/commit/COMMIT_SHA/explorer.html#home
+Connection string URLs: https://dataexplorer-preview.portal.cosmos.azure.com/commit/COMMIT_SHA/hostedExplorer.html
+Portal URLs: https://ms.portal.azure.com/?dataExplorerSource=https://dataexplorer-preview.portal.cosmos.azure.com/commit/COMMIT_SHA/explorer.html#home
 
 In both cases replace `COMMIT_SHA` with the commit you want to view. It must have already completed its build on GitHub Actions.
 

--- a/preview/config.json
+++ b/preview/config.json
@@ -1,4 +1,4 @@
 {
   "PROXY_PATH": "/proxy",
-  "msalRedirectURI": "https://dataexplorer-preview.azurewebsites.net/"
+  "msalRedirectURI": "https://dataexplorer-preview.portal.cosmos.azure.com/"
 }

--- a/preview/index.js
+++ b/preview/index.js
@@ -4,7 +4,7 @@ const port = process.env.PORT || 3000;
 const fetch = require("node-fetch");
 
 const backendEndpoint = "https://cdb-ms-mpac-pbe.cosmos.azure.com";
-const previewSiteEndpoint = "https://dataexplorer-preview.azurewebsites.net";
+const previewSiteEndpoint = "https://dataexplorer-preview.portal.cosmos.azure.com";
 const previewStorageWebsiteEndpoint = "_REPLACE_STORAGE_WEBSITE_ENDPOINT_";
 const githubApiUrl = "https://api.github.com/repos/Azure/cosmos-explorer";
 const azurePortalMpacEndpoint = "https://ms.portal.azure.com/";

--- a/src/ConfigContext.ts
+++ b/src/ConfigContext.ts
@@ -80,7 +80,7 @@ let configContext: Readonly<ConfigContext> = {
     `^https:\\/\\/cosmos-db-dataexplorer-germanycentral\\.azurewebsites\\.de$`,
     `^https:\\/\\/.*\\.fabric\\.microsoft\\.com$`,
     `^https:\\/\\/.*\\.powerbi\\.com$`,
-    `^https:\\/\\/dataexplorer-preview\\.azurewebsites\\.net$`,
+    `^https:\\/\\/dataexplorer-preview\\.portal\\.cosmos\\.azure\\.com$`,
     `^https:\\/\\/explorer\\.cosmos\\.sovcloud-api\\.fr$`,
     `^https:\\/\\/portal\\.sovcloud-azure\\.fr$`,
     `^https:\\/\\/explorer\\.cosmos\\.sovcloud-api\\.de$`,

--- a/src/Utils/EndpointUtils.ts
+++ b/src/Utils/EndpointUtils.ts
@@ -88,7 +88,9 @@ export const allowedHostedExplorerEndpoints: ReadonlyArray<string> = [
   ...(process.env.NODE_ENV === "development" ? ["https://localhost:12900"] : []),
 ];
 
-export const allowedMsalRedirectEndpoints: ReadonlyArray<string> = ["https://dataexplorer-preview.portal.cosmos.azure.com/"];
+export const allowedMsalRedirectEndpoints: ReadonlyArray<string> = [
+  "https://dataexplorer-preview.portal.cosmos.azure.com/",
+];
 
 export const allowedJunoOrigins: ReadonlyArray<string> = [
   JunoEndpoints.Test,

--- a/src/Utils/EndpointUtils.ts
+++ b/src/Utils/EndpointUtils.ts
@@ -88,7 +88,7 @@ export const allowedHostedExplorerEndpoints: ReadonlyArray<string> = [
   ...(process.env.NODE_ENV === "development" ? ["https://localhost:12900"] : []),
 ];
 
-export const allowedMsalRedirectEndpoints: ReadonlyArray<string> = ["https://dataexplorer-preview.azurewebsites.net/"];
+export const allowedMsalRedirectEndpoints: ReadonlyArray<string> = ["https://dataexplorer-preview.portal.cosmos.azure.com/"];
 
 export const allowedJunoOrigins: ReadonlyArray<string> = [
   JunoEndpoints.Test,

--- a/web.config
+++ b/web.config
@@ -30,7 +30,7 @@
         <clear />
         <add name="X-Xss-Protection" value="1; mode=block" />
         <add name="X-Content-Type-Options" value="nosniff" />
-        <add name="Content-Security-Policy" value="frame-ancestors 'self' portal.azure.com *.portal.azure.com portal.azure.us portal.azure.cn portal.microsoftazure.de df.onecloud.azure-test.net *.fabric.microsoft.com *.powerbi.com *.analysis-df.windows.net dataexplorer-preview.azurewebsites.net portal.sovcloud-azure.fr portal.sovcloud-azure.de portal.sovcloud-azure.sg" />
+        <add name="Content-Security-Policy" value="frame-ancestors 'self' portal.azure.com *.portal.azure.com portal.azure.us portal.azure.cn portal.microsoftazure.de df.onecloud.azure-test.net *.fabric.microsoft.com *.powerbi.com *.analysis-df.windows.net dataexplorer-preview.portal.cosmos.azure.com portal.sovcloud-azure.fr portal.sovcloud-azure.de portal.sovcloud-azure.sg" />
       </customHeaders>
       <redirectHeaders>
         <clear />


### PR DESCRIPTION
[Preview this branch](https://dataexplorer-preview.portal.cosmos.azure.com/pull/2572?feature.someFeatureFlagYouMightNeed=true)

- Update Cosmos Explorer Preview URLs from `dataexplorer-preview.azurewebsites.net` to `dataexplorer-preview.portal.cosmos.azure.com`.
- Align the preview app's MSAL redirect URI, proxy origin, documentation, PR template, CSP allowlist, and endpoint validation with the new hostname.
- Remove the retired Azure CLI configuration for the preview App Service deployment.
