### PR TITLE
Serialize CI runs that share the E2E environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,11 @@ on:
       - master
       - hotfix/**
       - release/**
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 permissions:
+  actions: read
   id-token: write
   contents: read
 jobs:
@@ -157,8 +161,20 @@ jobs:
           name: mpac-package
           path: "bin/Release/*.nupkg"
 
+  e2e-queue:
+    name: "Wait for E2E Environment"
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Wait for earlier CI runs
+        uses: softprops/turnstyle@3805450be63b8c80577dc253e8c17e9132036df4 # v3.3.3
+        with:
+          same-branch-only: false
+          poll-interval-seconds: 30
+
   playwright-tests:
     name: "Run Playwright Tests (Shard ${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})"
+    needs: [e2e-queue]
     runs-on: ubuntu-latest
     env:
       NODE_TLS_REJECT_UNAUTHORIZED: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
         with:
           same-branch-only: false
           poll-interval-seconds: 30
+          initial-wait-seconds: 30
 
   playwright-tests:
     name: "Run Playwright Tests (Shard ${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - hotfix/**
       - release/**
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 permissions:
   actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,8 @@ jobs:
     name: "Wait for E2E Environment"
     runs-on: ubuntu-latest
     timeout-minutes: 360
+    permissions:
+      actions: read
     steps:
       - name: Wait for earlier CI runs
         uses: softprops/turnstyle@3805450be63b8c80577dc253e8c17e9132036df4 # v3.3.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,8 @@ jobs:
     timeout-minutes: 360
     permissions:
       actions: read
+    outputs:
+      run-attempt: ${{ steps.admission.outputs.run-attempt }}
     steps:
       - name: Wait for earlier CI runs
         uses: softprops/turnstyle@3805450be63b8c80577dc253e8c17e9132036df4 # v3.3.3
@@ -173,6 +175,10 @@ jobs:
           same-branch-only: false
           poll-interval-seconds: 30
           initial-wait-seconds: 30
+      - name: Record admitted run attempt
+        id: admission
+        shell: bash
+        run: echo "run-attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
 
   playwright-tests:
     name: "Run Playwright Tests (Shard ${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})"
@@ -190,6 +196,16 @@ jobs:
         shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
         shardTotal: [20]
     steps:
+      - name: Verify queue admission for this attempt
+        id: queue-admission
+        shell: bash
+        env:
+          E2E_QUEUE_RUN_ATTEMPT: ${{ needs.e2e-queue.outputs.run-attempt }}
+        run: |
+          if [[ -z "$E2E_QUEUE_RUN_ATTEMPT" || "$E2E_QUEUE_RUN_ATTEMPT" != "$GITHUB_RUN_ATTEMPT" ]]; then
+            echo "::error::The E2E queue did not admit this workflow attempt. Use 'Re-run all jobs' so the queue runs again before any Playwright shard."
+            exit 1
+          fi
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Use Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -248,14 +264,14 @@ jobs:
       - name: Run test shard ${{ matrix['shardIndex'] }} of ${{ matrix['shardTotal']}}
         run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers=3
       - name: "Re-auth for upload (refresh OIDC token)"
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.queue-admission.outcome == 'success' }}
         uses: Azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
         with:
           client-id: ${{ secrets.E2ETESTS_CLIENT_ID }}
           tenant-id: ${{ secrets.E2ETESTS_TENANT_ID }}
           subscription-id: ${{ secrets.E2ETESTS_SUBSCRIPTION_ID }}
       - name: Upload shard blob-report to Azure Storage
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.queue-admission.outcome == 'success' }}
         env:
           KEY: ${{ github.run_id }}-${{ github.run_attempt }}
           SHARD: ${{ matrix.shardIndex }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 permissions:
-  actions: read
   id-token: write
   contents: read
 jobs:


### PR DESCRIPTION
## Summary

Coordinate Playwright execution across participating CI workflow runs to reduce concurrent use of the shared Cosmos DB E2E environment. Cancel superseded pull request runs and require queue admission for every workflow attempt.

## Why

The Playwright matrix maps each shard to a fixed set of test accounts. Although the 20 shards within one workflow are designed to run concurrently, separate workflow runs currently reuse those same accounts without coordination. When several pull requests or pushes run together, their tests can mutate and query the same account-level state, producing missing-resource, authentication, timeout, and stale-state failures.

## Workflow changes

### Cancel superseded pull request runs

The workflow now defines a concurrency group keyed by the workflow and pull request number, falling back to the unique workflow run ID for push events.

- A newer run for the same pull request cancels its older in-progress run.
- Runs for different pull requests remain independent.
- Push runs have distinct concurrency groups and are never canceled by this rule. Every commit pushed to `master`, `hotfix/**`, or `release/**` retains its own CI workflow; reaching E2E execution is still subject to queue success and timeout limits.

### Queue access to the E2E environment

A new `Wait for E2E Environment` job uses `softprops/turnstyle` to wait for earlier active CI runs before releasing the Playwright matrix.

- `same-branch-only: false` coordinates participating runs of this CI workflow across pull requests and push branches.
- The queue waits through an initial 30-second discovery window before concluding that no earlier run exists.
- After discovery, the queue is polled every 30 seconds while an earlier run remains active.
- The gate has a six-hour job timeout. If it fails or times out, dependent Playwright jobs do not run; the workflow fails rather than bypassing the queue. After addressing the backlog or queue failure, use **Re-run all jobs** to try again. This is not a guarantee of eventual E2E execution for every retained push.
- The action is pinned to the immutable commit for v3.3.3.
- The queue job explicitly grants only `actions: read`, so unspecified permissions such as `id-token` are disabled for the third-party action.

### Require queue admission for each run attempt

After Turnstyle succeeds, a separate step records `GITHUB_RUN_ATTEMPT` as a job output. Every Playwright shard compares that recorded value with its own current attempt before checkout, dependency installation, or Azure login.

- Initial attempts and full-workflow reruns proceed only after the queue succeeds for that same attempt.
- Re-running only failed Playwright jobs or an individual shard can reuse an older successful queue job. Its output is stale or missing, so the shard fails immediately with instructions to use **Re-run all jobs**.
- Shard re-authentication and report-upload steps are skipped when admission fails. Admitted shards still upload reports when their tests fail.
- No extra token permissions, action dependencies, or infrastructure are introduced. The Turnstyle job retains only `actions: read`.

This closes the partial-rerun bypass by rejecting unsafe reruns, not by automatically requeueing selected shards. Selective reruns without rerunning the queue are intentionally unsupported.

### Preserve existing parallelism

Only `playwright-tests` depends on the queue job. Compile, formatting, lint, unit-test, build, and package jobs continue to start without waiting for the shared E2E environment.

After a run reaches the front of the queue, all 20 Playwright shards still execute in parallel. Report merging continues to depend on completion of that matrix. The next workflow run begins its Playwright matrix only after the earlier workflow has completed.

## Expected behavior

- Repeated updates to one pull request retain only the newest CI run.
- Different pull requests can perform non-E2E checks concurrently, but their Playwright matrices execute one workflow at a time.
- Every `master`, hotfix, and release commit retains its own workflow run and waits for E2E access instead of being canceled by concurrency; a queue failure or six-hour timeout is still a failed run.
- Existing shard-level account distribution remains unchanged.

## Tradeoffs and rollout

The gate occupies one standard GitHub-hosted runner while waiting and can delay E2E feedback during busy periods. It waits for the earlier whole CI workflow, not just its Playwright jobs. The six-hour timeout can prevent a retained push from reaching E2E; preserving the workflow is not a guarantee of eventual execution.

Full-workflow reruns repeat already-successful shards and can recreate billable test resources. Cancellation of superseded PR runs and fewer contention-related retries may offset that work, but the net effect is not established. Queueing does not pause billing for existing Cosmos resources or lower their provisioned RU/s.

The guard applies only to workflow revisions containing it. Historical runs and branches using an older workflow remain outside this protection. During rollout, refresh active branches and avoid rerunning historical E2E jobs against the shared environment. Local test runs and the separate scheduled cleanup workflow are not serialized by this gate. This is not an account lease or per-run environment allocation.

## Follow-up changes

Post-creation changes preserve distinct push runs, add the initial 30-second discovery window, restrict Actions read access to the queue job, and reject Playwright reruns whose queue admission belongs to an earlier attempt. Re-authentication and shard uploads are also conditional on successful admission. Selective reruns are rejected rather than automatically requeued.

## Dependencies and integration

- No hard code dependency on [#2595](https://github.com/Azure/cosmos-explorer/pull/2595) through [#2600](https://github.com/Azure/cosmos-explorer/pull/2600); this PR targets master independently.
- [#2595](https://github.com/Azure/cosmos-explorer/pull/2595) complements the queue with an ownership and age rule for cleanup. The queue does not protect resources from the janitor, and that PR does not serialize workflows.
- [#2596](https://github.com/Azure/cosmos-explorer/pull/2596), [#2597](https://github.com/Azure/cosmos-explorer/pull/2597), [#2598](https://github.com/Azure/cosmos-explorer/pull/2598), and [#2599](https://github.com/Azure/cosmos-explorer/pull/2599) address test lifecycle, mocked interactions, matrix size/readiness, and command targeting. They remain useful independently and are not incorporated into this branch.
- [#2600](https://github.com/Azure/cosmos-explorer/pull/2600) also edits the CI workflow, in the compile job. Preserve both its E2E type-check step and this queue/admission logic. The compile job and Playwright matrix remain independent; a type-check failure does not prevent E2E startup.

The rollout requirement is to propagate the updated workflow to participating branches; it is not a dependency on merging the other test PRs first. Flake-rate improvement must be assessed from CI rather than inferred from serialization alone.
