### PR TITLE
Protect active E2E resources from scheduled cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "pack:prod": "webpack  --mode production",
     "pack:fast": "webpack  --mode development --progress",
     "copyToConsumers": "node copyToConsumers",
-    "test": "rimraf coverage && jest && node --test utils/cleanupDBs.test.js",
+    "test": "rimraf coverage && jest && node --test utils/*.test.js",
     "test:debug": "jest --runInBand",
     "test:e2e": "jest -c ./jest.config.playwright.js --detectOpenHandles",
     "test:file": "jest --coverage=false",

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "pack:prod": "webpack  --mode production",
     "pack:fast": "webpack  --mode development --progress",
     "copyToConsumers": "node copyToConsumers",
-    "test": "rimraf coverage && jest",
+    "test": "rimraf coverage && jest && node --test utils/cleanupDBs.test.js",
     "test:debug": "jest --runInBand",
     "test:e2e": "jest -c ./jest.config.playwright.js --detectOpenHandles",
     "test:file": "jest --coverage=false",

--- a/test/fx.ts
+++ b/test/fx.ts
@@ -23,7 +23,10 @@ export function generateUniqueName(baseName: string, options?: TestNameOptions):
   const timestamp = options?.timestampped === undefined ? true : options.timestampped;
   const prefixed = options?.prefixed === undefined ? true : options.prefixed;
 
-  const prefix = prefixed ? "t_" : "";
+  const runId = process.env.GITHUB_RUN_ID;
+  const runAttempt = process.env.GITHUB_RUN_ATTEMPT ?? "1";
+  const runPrefix = runId ? `${runId}_${runAttempt}_` : "";
+  const prefix = prefixed ? `t_${runPrefix}` : "";
   const suffix = timestamp ? `_${Date.now()}` : "";
   return `${prefix}${baseName}${crypto.randomBytes(length).toString("hex")}${suffix}`;
 }

--- a/test/fx.ts
+++ b/test/fx.ts
@@ -1,6 +1,7 @@
 import { DefaultAzureCredential } from "@azure/identity";
 import { Frame, Locator, Page, expect } from "@playwright/test";
-import crypto, { webcrypto } from "crypto";
+import { webcrypto } from "crypto";
+import { generateUniqueName as generateUniqueResourceName } from "../utils/testResourceName";
 import { TestContainerContext } from "./testData";
 
 // The @azure/cosmos client signs requests with globalThis.crypto (Web Crypto API).
@@ -19,16 +20,7 @@ export interface TestNameOptions {
 }
 
 export function generateUniqueName(baseName: string, options?: TestNameOptions): string {
-  const length = options?.length ?? 1;
-  const timestamp = options?.timestampped === undefined ? true : options.timestampped;
-  const prefixed = options?.prefixed === undefined ? true : options.prefixed;
-
-  const runId = process.env.GITHUB_RUN_ID;
-  const runAttempt = process.env.GITHUB_RUN_ATTEMPT ?? "1";
-  const runPrefix = runId ? `${runId}_${runAttempt}_` : "";
-  const prefix = prefixed ? `t_${runPrefix}` : "";
-  const suffix = timestamp ? `_${Date.now()}` : "";
-  return `${prefix}${baseName}${crypto.randomBytes(length).toString("hex")}${suffix}`;
+  return generateUniqueResourceName(baseName, options, process.env);
 }
 
 export function getAzureCLICredentials(): DefaultAzureCredential {

--- a/utils/cleanupDBs.js
+++ b/utils/cleanupDBs.js
@@ -5,7 +5,15 @@ const ms = require("ms");
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
 const resourceGroupName = process.env["E2ETESTS_RESOURCEGROUP_NAME"];
 
-const thirtyMinutesAgo = new Date(Date.now() - 1000 * 60 * 30).getTime();
+const cleanupMinimumAge = ms(process.env["E2E_CLEANUP_MINIMUM_AGE"] || "6h");
+if (!cleanupMinimumAge) {
+  throw new Error("E2E_CLEANUP_MINIMUM_AGE must be a valid duration");
+}
+const cleanupThreshold = Date.now() - cleanupMinimumAge;
+
+function shouldDeleteResource(name, timestamp, threshold = cleanupThreshold) {
+  return Boolean(name?.startsWith("t_") && timestamp && timestamp < threshold);
+}
 
 function friendlyTime(date) {
   try {
@@ -29,22 +37,27 @@ async function main() {
       for await (const database of mongoDatabases) {
         // Unfortunately Mongo does not provide a timestamp in ARM. There is no way to tell how old the DB is other thn encoding it in the ID :(
         const timestamp = Number(database.name.split("_").pop());
-        if (timestamp && timestamp < thirtyMinutesAgo) {
-          await client.mongoDBResources.beginDeleteMongoDBDatabaseAndWait(resourceGroupName, account.name, database.name);
+        if (shouldDeleteResource(database.name, timestamp)) {
+          await client.mongoDBResources.beginDeleteMongoDBDatabaseAndWait(
+            resourceGroupName,
+            account.name,
+            database.name,
+          );
           console.log(`DELETED: ${account.name} | ${database.name} | Age: ${friendlyTime(Date.now() - timestamp)}`);
         } else {
           console.log(`SKIPPED: ${account.name} | ${database.name} | Age: ${friendlyTime(Date.now() - timestamp)}`);
         }
       }
     } else if (account.capabilities.find((c) => c.name === "EnableCassandra")) {
-      const cassandraDatabases = client.cassandraResources.listCassandraKeyspaces(
-        resourceGroupName,
-        account.name,
-      );
+      const cassandraDatabases = client.cassandraResources.listCassandraKeyspaces(resourceGroupName, account.name);
       for await (const database of cassandraDatabases) {
         const timestamp = Number(database.resource.ts) * 1000;
-        if (timestamp && timestamp < thirtyMinutesAgo) {
-          await client.cassandraResources.beginDeleteCassandraKeyspaceAndWait(resourceGroupName, account.name, database.name);
+        if (shouldDeleteResource(database.name, timestamp)) {
+          await client.cassandraResources.beginDeleteCassandraKeyspaceAndWait(
+            resourceGroupName,
+            account.name,
+            database.name,
+          );
           console.log(`DELETED: ${account.name} | ${database.name} | Age: ${friendlyTime(Date.now() - timestamp)}`);
         } else {
           console.log(`SKIPPED: ${account.name} | ${database.name} | Age: ${friendlyTime(Date.now() - timestamp)}`);
@@ -54,7 +67,7 @@ async function main() {
       const tablesDatabase = client.tableResources.listTables(resourceGroupName, account.name);
       for await (const database of tablesDatabase) {
         const timestamp = Number(database.resource.ts) * 1000;
-        if (timestamp && timestamp < thirtyMinutesAgo) {
+        if (shouldDeleteResource(database.name, timestamp)) {
           await client.tableResources.beginDeleteTableAndWait(resourceGroupName, account.name, database.name);
           console.log(`DELETED: ${account.name} | ${database.name} | Age: ${friendlyTime(Date.now() - timestamp)}`);
         } else {
@@ -65,8 +78,12 @@ async function main() {
       const graphDatabases = client.gremlinResources.listGremlinDatabases(resourceGroupName, account.name);
       for await (const database of graphDatabases) {
         const timestamp = Number(database.resource.ts) * 1000;
-        if (timestamp && timestamp < thirtyMinutesAgo) {
-          await client.gremlinResources.beginDeleteGremlinDatabaseAndWait(resourceGroupName, account.name, database.name);
+        if (shouldDeleteResource(database.name, timestamp)) {
+          await client.gremlinResources.beginDeleteGremlinDatabaseAndWait(
+            resourceGroupName,
+            account.name,
+            database.name,
+          );
           console.log(`DELETED: ${account.name} | ${database.name} | Age: ${friendlyTime(Date.now() - timestamp)}`);
         } else {
           console.log(`SKIPPED: ${account.name} | ${database.name} | Age: ${friendlyTime(Date.now() - timestamp)}`);
@@ -92,7 +109,7 @@ async function deleteWithRetry(client, database, accountName) {
   while (attempt < maxRetries) {
     try {
       const timestamp = Number(database.resource.ts) * 1000;
-      if (timestamp && timestamp < thirtyMinutesAgo) {
+      if (shouldDeleteResource(database.name, timestamp)) {
         await client.sqlResources.beginDeleteSqlDatabaseAndWait(resourceGroupName, accountName, database.name);
         console.log(`DELETED: ${accountName} | ${database.name} | Age: ${friendlyTime(Date.now() - timestamp)}`);
       } else {
@@ -118,15 +135,19 @@ async function deleteWithRetry(client, database, accountName) {
 
 // Helper function to delay the retry attempts
 function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-main()
-  .then(() => {
-    console.log("Completed");
-    process.exit(0);
-  })
-  .catch((err) => {
-    console.error(err);
-    process.exit(1);
-  });
+if (require.main === module) {
+  main()
+    .then(() => {
+      console.log("Completed");
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}
+
+module.exports = { shouldDeleteResource };

--- a/utils/cleanupDBs.js
+++ b/utils/cleanupDBs.js
@@ -5,10 +5,21 @@ const ms = require("ms");
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
 const resourceGroupName = process.env["E2ETESTS_RESOURCEGROUP_NAME"];
 
-const cleanupMinimumAge = ms(process.env["E2E_CLEANUP_MINIMUM_AGE"] || "6h");
-if (!cleanupMinimumAge) {
-  throw new Error("E2E_CLEANUP_MINIMUM_AGE must be a valid duration");
+function parseCleanupMinimumAge(configuredAge) {
+  let parsedAge;
+  try {
+    parsedAge = ms(configuredAge === undefined ? "6h" : configuredAge);
+  } catch {
+    parsedAge = undefined;
+  }
+
+  if (!Number.isFinite(parsedAge) || parsedAge <= 0) {
+    throw new Error("E2E_CLEANUP_MINIMUM_AGE must be a positive duration");
+  }
+
+  return parsedAge;
 }
+const cleanupMinimumAge = parseCleanupMinimumAge(process.env["E2E_CLEANUP_MINIMUM_AGE"]);
 const cleanupThreshold = Date.now() - cleanupMinimumAge;
 
 function shouldDeleteResource(name, timestamp, threshold = cleanupThreshold) {
@@ -150,4 +161,4 @@ if (require.main === module) {
     });
 }
 
-module.exports = { shouldDeleteResource };
+module.exports = { parseCleanupMinimumAge, shouldDeleteResource };

--- a/utils/cleanupDBs.test.js
+++ b/utils/cleanupDBs.test.js
@@ -1,0 +1,23 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { shouldDeleteResource } = require("./cleanupDBs");
+
+const cleanupThreshold = Date.now();
+
+test("deletes owned test resources older than the threshold", () => {
+  assert.equal(shouldDeleteResource("t_12345_1_dbab_1000", cleanupThreshold - 1, cleanupThreshold), true);
+});
+
+test("keeps owned test resources at or newer than the threshold", () => {
+  assert.equal(shouldDeleteResource("t_12345_1_dbab_1000", cleanupThreshold, cleanupThreshold), false);
+  assert.equal(shouldDeleteResource("t_12345_1_dbab_1000", cleanupThreshold + 1, cleanupThreshold), false);
+});
+
+test("keeps resources that are not marked as test-owned", () => {
+  assert.equal(shouldDeleteResource("seeded-database", cleanupThreshold - 1, cleanupThreshold), false);
+});
+
+test("keeps resources without a valid name or timestamp", () => {
+  assert.equal(shouldDeleteResource(undefined, cleanupThreshold - 1, cleanupThreshold), false);
+  assert.equal(shouldDeleteResource("t_12345_1_dbab_1000", undefined, cleanupThreshold), false);
+});

--- a/utils/cleanupDBs.test.js
+++ b/utils/cleanupDBs.test.js
@@ -1,8 +1,22 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
-const { shouldDeleteResource } = require("./cleanupDBs");
+const { parseCleanupMinimumAge, shouldDeleteResource } = require("./cleanupDBs");
 
 const cleanupThreshold = Date.now();
+
+test("uses a six-hour cleanup age when no value is configured", () => {
+  assert.equal(parseCleanupMinimumAge(undefined), 6 * 60 * 60 * 1000);
+});
+
+test("accepts a finite positive cleanup age", () => {
+  assert.equal(parseCleanupMinimumAge("12h"), 12 * 60 * 60 * 1000);
+});
+
+test("rejects unsafe cleanup ages", () => {
+  for (const configuredAge of ["", "invalid", "0ms", "-1h", "Infinity"]) {
+    assert.throws(() => parseCleanupMinimumAge(configuredAge), /E2E_CLEANUP_MINIMUM_AGE must be a positive duration/);
+  }
+});
 
 test("deletes owned test resources older than the threshold", () => {
   assert.equal(shouldDeleteResource("t_12345_1_dbab_1000", cleanupThreshold - 1, cleanupThreshold), true);

--- a/utils/testResourceName.js
+++ b/utils/testResourceName.js
@@ -1,0 +1,16 @@
+const crypto = require("crypto");
+
+function generateUniqueName(baseName, options, environment = process.env) {
+  const length = options?.length ?? 1;
+  const timestamp = options?.timestampped === undefined ? true : options.timestampped;
+  const prefixed = options?.prefixed === undefined ? true : options.prefixed;
+
+  const runId = environment.GITHUB_RUN_ID;
+  const runAttempt = environment.GITHUB_RUN_ATTEMPT ?? "1";
+  const runPrefix = runId ? `${runId}_${runAttempt}_` : "";
+  const prefix = prefixed ? `t_${runPrefix}` : "";
+  const suffix = timestamp ? `_${Date.now()}` : "";
+  return `${prefix}${baseName}${crypto.randomBytes(length).toString("hex")}${suffix}`;
+}
+
+module.exports = { generateUniqueName };

--- a/utils/testResourceName.test.js
+++ b/utils/testResourceName.test.js
@@ -1,0 +1,52 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { generateUniqueName } = require("./testResourceName");
+
+const noRandomSuffix = { length: 0 };
+
+test("includes the workflow run and attempt in CI resource names", () => {
+  const name = generateUniqueName("db", noRandomSuffix, {
+    GITHUB_RUN_ID: "12345",
+    GITHUB_RUN_ATTEMPT: "2",
+  });
+
+  assert.match(name, /^t_12345_2_db_\d+$/);
+});
+
+test("defaults a missing workflow attempt to one", () => {
+  const name = generateUniqueName("db", noRandomSuffix, { GITHUB_RUN_ID: "12345" });
+
+  assert.match(name, /^t_12345_1_db_\d+$/);
+});
+
+test("preserves the local resource name format outside GitHub Actions", () => {
+  const name = generateUniqueName("db", noRandomSuffix, {});
+
+  assert.match(name, /^t_db_\d+$/);
+});
+
+test("omits the test and workflow prefixes when requested", () => {
+  const name = generateUniqueName(
+    "db",
+    { ...noRandomSuffix, prefixed: false },
+    {
+      GITHUB_RUN_ID: "12345",
+      GITHUB_RUN_ATTEMPT: "2",
+    },
+  );
+
+  assert.match(name, /^db_\d+$/);
+});
+
+test("omits the timestamp when requested", () => {
+  const name = generateUniqueName(
+    "db",
+    { ...noRandomSuffix, timestampped: false },
+    {
+      GITHUB_RUN_ID: "12345",
+      GITHUB_RUN_ATTEMPT: "2",
+    },
+  );
+
+  assert.equal(name, "t_12345_2_db");
+});


### PR DESCRIPTION
## Summary

Make dynamically created Cosmos DB E2E resources attributable to a GitHub Actions run. Restrict scheduled cleanup to the established test-name prefix and give resources a configurable minimum-age protection window.

## Problem

The cleanup script previously used a 30-minute age cutoff without requiring the test-name prefix, while skipping accounts ending in `-readonly`. Playwright workflow runs regularly exceed that duration, so the daily cleanup workflow could overlap an active run and delete databases, keyspaces, graphs, or tables that its tests were still using.

Generated resource names started with `t_` and ended with a timestamp, but they did not identify the workflow run that owned them. This made failures and abandoned resources harder to correlate with a specific run or rerun attempt.

## Changes

### Add workflow ownership to resource names

`generateUniqueName` now incorporates GitHub's built-in `GITHUB_RUN_ID` and `GITHUB_RUN_ATTEMPT` values when they are available.

A CI-created name now follows this shape:

```text
t_<run-id>_<attempt>_<base><random-suffix>_<creation-timestamp>
```

For example:

```text
t_34633311975_1_dbaf_1789154000000
```

The final timestamp segment is preserved so MongoDB cleanup can continue deriving resource age from the name when ARM does not provide a creation timestamp.

Local runs do not normally define `GITHUB_RUN_ID`, so their existing naming format remains unchanged. The existing `prefixed` and `timestampped` options also retain their behavior.

This naming applies centrally to dynamically generated SQL databases, Mongo databases, Gremlin databases, Cassandra keyspaces, and tables that use `generateUniqueName`.

### Require explicit test ownership before deletion

Cleanup eligibility is now centralized in `shouldDeleteResource`. A resource is eligible only when both conditions are true:

1. Its name starts with the established `t_` test-resource prefix.
2. Its age timestamp is present and older than the configured cleanup threshold.

MongoDB uses the final timestamp segment in the resource name. NoSQL, Gremlin, Cassandra, and Tables retain their existing ARM `resource.ts` timestamp source; this is not an active-workflow or last-test-activity check.

Resources without the `t_` marker are retained regardless of age. This protects seeded or manually named resources that do not use that prefix. The prefix is the deletion rule, not proof of ownership: a manually created resource named `t_...` is still eligible once old enough.

The existing behavior that skips accounts ending in `-readonly` remains unchanged.

### Increase the cleanup safety window

The minimum age changes from 30 minutes to six hours by default:

```text
E2E_CLEANUP_MINIMUM_AGE=6h
```

The threshold can be overridden through the `E2E_CLEANUP_MINIMUM_AGE` environment variable using durations accepted by the existing `ms` package, such as `12h` or `1d`.

Only an unset value uses the default. Empty, malformed, zero, negative, or non-finite durations fail immediately instead of producing an unsafe deletion threshold.

The same ownership and age policy is applied to MongoDB, Cassandra, Tables, Gremlin, and NoSQL resources. Existing NoSQL deletion retries and exponential backoff for HTTP 429 responses are unchanged.

### Make cleanup policy testable

The script now invokes Azure cleanup only when executed directly. Importing it no longer calls `main`, allowing the deletion predicate to be tested without authenticating to Azure or modifying resources.

A focused Node test suite covers:

- deleting an owned resource older than the threshold;
- retaining owned resources at or newer than the threshold;
- retaining resources without the test ownership prefix;
- retaining resources with missing names or timestamps;
- applying the default and accepting positive durations;
- rejecting empty, malformed, zero, negative, and non-finite durations.

The resource-name formatter is also extracted into a small utility while `test/fx.ts` retains its existing typed API. Five focused cases cover explicit CI run and attempt values, a missing attempt defaulting to `1`, local execution, `prefixed: false`, and `timestampped: false`.

The standard `npm test` command now runs all focused utility suites after Jest, so the cleanup and naming safety contracts are checked in normal CI without changing Jest's existing source and coverage scope.

## Impact and limitations

- Resources whose age timestamp is within the configured window are retained, regardless of whether their originating run has completed.
- CI-generated names carry the run and attempt IDs for attribution. Cleanup does not query GitHub or use those IDs to decide whether a run is active.
- Existing names using the legacy `t_` format remain eligible once old enough; no migration to the new name format is required.
- Runs that still use a resource beyond the age threshold are not protected by an active-run lease. Six hours is a minimum-age rule, not a guarantee that all active resources are safe indefinitely.
- Resources without the prefix remain untouched even if abandoned and need a separate ownership audit.

The daily cleanup schedule is unchanged (13:00 UTC). A resource that would have been deleted under the 30-minute cutoff but is younger than six hours at cleanup can survive another full day. Provisioned throughput remains billable while retained, even when idle. No per-test CI teardown or more frequent janitor is added.

## Follow-up changes

Post-creation changes reject unsafe duration overrides and add focused coverage for the extracted resource-name formatter. The standard test command includes the Node utility suites after Jest; this does not extend the TypeScript compiler's scope or change Jest's source coverage configuration.

## Dependencies and integration

- No hard code dependency on the other mitigation PRs; this branch targets master independently.
- [#2594](https://github.com/Azure/cosmos-explorer/pull/2594) coordinates participating CI workflows but does not include the janitor or local runs. This PR protects resources by prefix and age, not account isolation, throughput coordination, or workflow serialization.
- [#2596](https://github.com/Azure/cosmos-explorer/pull/2596) creates fresh throughput-bucket resources per test and still leaves CI deletion to the janitor. Its extra resource creation can combine with this longer retention to increase cost. Prompt, ownership-scoped CI teardown remains separate follow-up work.
- [#2599](https://github.com/Azure/cosmos-explorer/pull/2599) and [#2600](https://github.com/Azure/cosmos-explorer/pull/2600) also edit `test/fx.ts`, but change command selection and typing rather than resource-name generation. Preserve all three behaviors when integrating.
- [#2600](https://github.com/Azure/cosmos-explorer/pull/2600) also edits `package.json`. Retain both this PR's Node utility-test extension and its `compile:e2e` script; neither replaces the other.
- [#2598](https://github.com/Azure/cosmos-explorer/pull/2598) reduces work against the seeded read-only account. This janitor continues to skip `-readonly` accounts and does not isolate their data.

There is no required merge order. The naming, cleanup, queue, and per-test isolation changes address distinct risks and should not be described as interchangeable fixes.
