### PR TITLE
Stabilize throughput bucket E2E tests

### DIFF
--- a/test/sql/scaleAndSettings/throughputbucket.spec.ts
+++ b/test/sql/scaleAndSettings/throughputbucket.spec.ts
@@ -6,12 +6,11 @@ test.describe("Throughput bucket settings", () => {
   let context: TestContainerContext = null!;
   let explorer: DataExplorer = null!;
 
-  test.beforeAll("Create Test Database", async () => {
+  test.beforeEach("Create Test Database", async () => {
     context = await createTestSQLContainer();
   });
 
-  test.beforeEach("Open Throughput Bucket Settings", async ({ browser }) => {
-    const page = await browser.newPage();
+  test.beforeEach("Open Throughput Bucket Settings", async ({ page }) => {
     explorer = await DataExplorer.open(page, TestAccount.SQL);
 
     // Click Scale & Settings and open Throughput Bucket Settings tab
@@ -22,7 +21,7 @@ test.describe("Throughput bucket settings", () => {
 
   // Delete database only if not running in CI
   if (!process.env.CI) {
-    test.afterAll("Delete Test Database", async () => {
+    test.afterEach("Delete Test Database", async () => {
       await context?.dispose();
     });
   }
@@ -61,12 +60,12 @@ test.describe("Throughput bucket settings", () => {
   test("Set throughput percentage for bucket #1", async () => {
     // Set throughput percentage for bucket 1 (inactive) - Should be disabled
     const bucket1PercentageInput = explorer.frame.getByTestId("bucket-1-percentage-input");
-    expect(bucket1PercentageInput).toBeDisabled();
+    await expect(bucket1PercentageInput).toBeDisabled();
 
     // Activate bucket 1
     const bucket1Toggle = explorer.frame.getByTestId("bucket-1-active-toggle");
     await bucket1Toggle.click();
-    expect(bucket1PercentageInput).toBeEnabled();
+    await expect(bucket1PercentageInput).toBeEnabled();
     await bucket1PercentageInput.fill("40");
 
     await explorer.commandBarButton(CommandBarButton.Save).click();
@@ -84,7 +83,7 @@ test.describe("Throughput bucket settings", () => {
     await defaultThroughputBucketDropdown.click();
 
     const bucket1Option = explorer.frame.getByRole("option", { name: "Bucket 1" });
-    expect(bucket1Option).toBeDisabled();
+    await expect(bucket1Option).toBeDisabled();
 
     // Activate bucket 1
     const bucket1Toggle = explorer.frame.getByTestId("bucket-1-active-toggle");
@@ -92,7 +91,7 @@ test.describe("Throughput bucket settings", () => {
 
     // Open dropdown again
     await defaultThroughputBucketDropdown.click();
-    expect(bucket1Option).toBeEnabled();
+    await expect(bucket1Option).toBeEnabled();
 
     // Select bucket 1 as default
     await bucket1Option.click();


### PR DESCRIPTION
## Summary

Isolate each throughput-bucket E2E test from persisted state left by other cases and ensure Playwright locator assertions are awaited before subsequent interactions.

## Problem

The throughput-bucket suite creates a Cosmos DB database and container in `beforeAll`. Tests assigned to the same worker group can reuse that container across these mutations:

- activating bucket 2;
- activating buckets 1 and 2;
- setting bucket 1's throughput percentage;
- selecting bucket 1 as the default bucket.

These operations update the container's persisted throughput offer. Several cases assume a default configuration with no active buckets, which can be invalid when an earlier case in the same group has changed it. Playwright's fully parallel execution, sharding, and worker restarts already cause `beforeAll` to run more than once; the baseline is not one resource for the entire suite or exactly one per browser. Per-test setup removes reliance on that grouping for a clean starting state.

The suite also invoked four Playwright locator assertions without `await`. Locator assertions are asynchronous and auto-retry until their expectation timeout. Without awaiting them, execution can continue before the control reaches the expected enabled or disabled state, allowing the next click or fill operation to race the UI update.

This suite was a frequent source of retry-recovered failures across Firefox, WebKit, Chrome, and Edge.

## Changes

### Create fresh Cosmos resources for every test

Database and container setup moves from `beforeAll` to `beforeEach`. Each case now receives a newly generated database containing its own `testcontainer` and starts from the default throughput-bucket configuration.

This removes dependencies on:

- which test ran previously;
- mutations saved by another test;
- retry order;
- browser-project scheduling;
- partial state left by a failed case.

The two setup hooks remain ordered: Playwright first creates the test container, then opens Data Explorer and navigates to that container's Throughput Buckets tab.

### Match cleanup to resource ownership

Local cleanup moves from `afterAll` to `afterEach`, matching the new per-test setup lifecycle. Each local test deletes the database it created after completing.

The existing CI behavior remains unchanged: CI does not synchronously delete these databases during the test run, leaving them to the scheduled E2E cleanup workflow. This avoids adding slow Cosmos deletion operations to every CI case.

### Use Playwright's managed page fixture

The setup hook now consumes Playwright's built-in `page` fixture instead of creating an unmanaged page through `browser.newPage()`.

This gives Playwright responsibility for page and browser-context disposal after every case and retry. It also ensures the page consistently receives project-level options from `playwright.config.ts`.

### Await asynchronous locator assertions

The following assertions now use `await`:

- bucket 1 percentage input is disabled before activation;
- bucket 1 percentage input becomes enabled after activation;
- bucket 1 is disabled as a default option before activation;
- bucket 1 becomes enabled as a default option after activation.

Awaiting these assertions makes each one a synchronization point. Playwright waits for the expected UI state before the test fills the input or selects the option, and assertion failures are attributed to the correct test step.

## Expected impact

- Each successful setup gives its test a fresh container with the default bucket configuration.
- Each retry performs its own setup. The old `beforeAll` could also rerun after worker restart; the improvement is explicit per-test ownership, not a claim that all old retries reused failed state.
- Test order no longer affects throughput-bucket assumptions.
- UI interactions wait for enabled and disabled transitions to complete.
- Browser pages and contexts are consistently released after each case.
- All four tests continue to run in Firefox, WebKit, Chrome, and Edge, preserving the existing 16-case browser matrix.

## Tradeoffs and remaining limitations

Four tests across four browser projects require 16 first-attempt setups when all run. The number of additional resources relative to `beforeAll` depends on worker grouping, shard placement, and retries; it is not an unconditional increase from four to 16. Retries and interrupted setups can leave additional resources.

The unchanged `createTestSQLContainer` helper provisions a dedicated 4,000-RU/s container. Bucket percentages allocate that existing throughput rather than adding RU/s. Per-test resource creation can increase setup time and retained billable capacity because CI deletion remains deferred to the janitor.

Fresh containers isolate test-owned bucket configuration, not account-level capacity, throttling, authentication, or offer-propagation timing. The awaited locator assertions synchronize UI enabled/disabled state; this PR does not add backend throughput-state polling or prove that every previously observed flake is eliminated.

## Dependencies and integration

- No hard code dependency on another mitigation PR; this change uses the existing resource helper and targets master independently.
- [#2594](https://github.com/Azure/cosmos-explorer/pull/2594) addresses overlap between participating workflow runs. Fresh container names do not replace that coordination because tests still use shared accounts.
- [#2595](https://github.com/Azure/cosmos-explorer/pull/2595) adds run/attempt attribution through the existing naming helper and extends cleanup's minimum age. It is compatible with both old and new names, but its longer retention amplifies the cost of resources left by this suite. Neither PR adds prompt CI teardown.
- [#2599](https://github.com/Azure/cosmos-explorer/pull/2599) changes the global-command helper, not this suite's bucket lifecycle. It does not supply throughput-state polling or replace these awaits.
- [#2600](https://github.com/Azure/cosmos-explorer/pull/2600) adds static checking for this suite and its imports. It does not add runtime synchronization or make E2E jobs wait for compilation.
- [#2597](https://github.com/Azure/cosmos-explorer/pull/2597) and [#2598](https://github.com/Azure/cosmos-explorer/pull/2598) address different tests; neither is a prerequisite.

No other PR in this series changes this spec directly. There is no required merge order; resource lifecycle and retention should be considered together when evaluating CI cost and stability.
