### PR TITLE
Stabilize container copy permissions E2E test

### DIFF
--- a/test/sql/containercopy/permissionsScreen.spec.ts
+++ b/test/sql/containercopy/permissionsScreen.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect, Frame, Locator, Page, test } from "@playwright/test";
-import { set } from "lodash";
 import { ContainerCopy, getAccountName, TestAccount } from "../../fx";
 
 const VISIBLE_TIMEOUT_MS = 30 * 1000;
@@ -103,9 +102,14 @@ test.describe("Container Copy - Permission Screen Verification", () => {
     await expect(permissionScreen.getByText("Online container copy", { exact: true })).toBeVisible();
     await expect(permissionScreen.getByText("Cross-account container copy", { exact: true })).toBeVisible();
 
-    // Setup API mocking for the source account
+    // Mock source account updates and refreshes used by the permission actions.
     await page.route(`**/Microsoft.DocumentDB/databaseAccounts/${sourceAccountName}**`, async (route) => {
       const mockData = {
+        id: new URL(route.request().url()).pathname,
+        name: sourceAccountName,
+        location: "East US",
+        type: "Microsoft.DocumentDB/databaseAccounts",
+        kind: "GlobalDocumentDB",
         identity: {
           type: "SystemAssigned",
           principalId: "00-11-22-33",
@@ -118,20 +122,17 @@ test.describe("Container Copy - Permission Screen Verification", () => {
           capabilities: [{ name: "EnableOnlineContainerCopy" }],
         },
       };
-      if (route.request().method() === "GET") {
-        const response = await route.fetch();
-        const actualData = await response.json();
-        const mergedData = { ...actualData };
-
-        set(mergedData, "identity", mockData.identity);
-        set(mergedData, "properties.defaultIdentity", mockData.properties.defaultIdentity);
-        set(mergedData, "properties.backupPolicy", mockData.properties.backupPolicy);
-        set(mergedData, "properties.capabilities", mockData.properties.capabilities);
-
+      if (route.request().method() === "PATCH") {
         await route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify(mergedData),
+          body: JSON.stringify({ status: "Succeeded" }),
+        });
+      } else if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(mockData),
         });
       } else {
         await route.continue();
@@ -157,16 +158,16 @@ test.describe("Container Copy - Permission Screen Verification", () => {
 
     const pitrBtn = accordionPanel.getByTestId("pointInTimeRestore:PrimaryBtn");
     await expect(pitrBtn).toBeVisible();
-    await pitrBtn.click({ force: true });
 
     // Verify new page opens with correct URL pattern
-    page.context().on("page", async (newPage) => {
-      const expectedUrlEndPattern = new RegExp(
-        `/providers/Microsoft.(DocumentDB|DocumentDb)/databaseAccounts/${sourceAccountName}/backupRestore`,
-      );
-      expect(newPage.url()).toMatch(expectedUrlEndPattern);
-      await newPage.close();
-    });
+    const newPagePromise = page.context().waitForEvent("page");
+    await pitrBtn.click({ force: true });
+    const newPage = await newPagePromise;
+    const expectedUrlEndPattern = new RegExp(
+      `/providers/Microsoft.(DocumentDB|DocumentDb)/databaseAccounts/${sourceAccountName}/backupRestore`,
+    );
+    await expect(newPage).toHaveURL(expectedUrlEndPattern);
+    await newPage.close();
 
     const loadingOverlay = frame.locator("[data-test='loading-overlay']");
     await expect(loadingOverlay).toBeVisible();
@@ -216,46 +217,6 @@ test.describe("Container Copy - Permission Screen Verification", () => {
       });
     });
 
-    await page.route(`**/Microsoft.DocumentDB/databaseAccounts/${sourceAccountName}**`, async (route) => {
-      const mockData = {
-        identity: {
-          type: "SystemAssigned",
-          principalId: "00-11-22-33",
-        },
-        properties: {
-          defaultIdentity: "SystemAssignedIdentity",
-          backupPolicy: {
-            type: "Continuous",
-          },
-          capabilities: [{ name: "EnableOnlineContainerCopy" }],
-        },
-      };
-
-      if (route.request().method() === "PATCH") {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({ status: "Succeeded" }),
-        });
-      } else if (route.request().method() === "GET") {
-        const response = await route.fetch();
-        const actualData = await response.json();
-        const mergedData = { ...actualData };
-        set(mergedData, "identity", mockData.identity);
-        set(mergedData, "properties.defaultIdentity", mockData.properties.defaultIdentity);
-        set(mergedData, "properties.backupPolicy", mockData.properties.backupPolicy);
-        set(mergedData, "properties.capabilities", mockData.properties.capabilities);
-
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify(mergedData),
-        });
-      } else {
-        await route.continue();
-      }
-    });
-
     // Verify cross-account permissions functionality
     const expandedCrossAccordionHeader = permissionScreen
       .getByTestId("permission-group-container-crossAccountConfigs")
@@ -283,12 +244,28 @@ test.describe("Container Copy - Permission Screen Verification", () => {
     await expect(yesButton).toBeVisible();
     await expect(noButton).toBeVisible();
 
+    const identityUpdatePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PATCH" &&
+        response.url().includes(`/databaseAccounts/${sourceAccountName}`) &&
+        response.url().includes("api-version=2025-04-15"),
+    );
+    const accountRefreshPromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === "GET" &&
+        response.url().includes(`/databaseAccounts/${sourceAccountName}`) &&
+        response.url().includes("api-version=2025-05-01-preview"),
+    );
     await yesButton.click({ force: true });
+    const [identityUpdateResponse, accountRefreshResponse] = await Promise.all([
+      identityUpdatePromise,
+      accountRefreshPromise,
+    ]);
+    expect(identityUpdateResponse.ok()).toBe(true);
+    expect(accountRefreshResponse.ok()).toBe(true);
 
-    // Verify loading states
-    await expect(loadingOverlay).toBeVisible();
-    await expect(loadingOverlay).toBeHidden({ timeout: 10 * 1000 });
-    await expect(popover).toBeHidden({ timeout: 10 * 1000 });
+    // Verify the refreshed account state completes the permission section.
+    await expect(popover).toBeHidden({ timeout: VISIBLE_TIMEOUT_MS });
 
     // Cancel the panel to clean up
     await panel.getByRole("button", { name: "Cancel" }).click({ force: true });

--- a/test/sql/containercopy/permissionsScreen.spec.ts
+++ b/test/sql/containercopy/permissionsScreen.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect, Frame, Locator, Page, test } from "@playwright/test";
-import { ContainerCopy, getAccountName, TestAccount } from "../../fx";
+import { ContainerCopy, getAccountName, resourceGroupName, subscriptionId, TestAccount } from "../../fx";
 
 const VISIBLE_TIMEOUT_MS = 30 * 1000;
 
@@ -160,11 +160,11 @@ test.describe("Container Copy - Permission Screen Verification", () => {
     await expect(pitrBtn).not.toBeVisible();
     await page.unroute(sourceAccountRoute);
 
-    // Setup additional API mocks for role assignments and permissions
-    // In the redesigned flow, role assignments are checked on the SOURCE account (current account = sourceAccountName).
-    // The destination account (selectedAccountName) manages identity; source account holds the role assignments.
+    // Setup additional API mocks for role assignments and permissions.
+    const targetAccountScope = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${targetAccountName}`;
+    const targetRoleDefinitionId = `${targetAccountScope}/sqlRoleDefinitions/77-88-99`;
     await page.route(
-      `**/Microsoft.DocumentDB/databaseAccounts/${sourceAccountName}/sqlRoleAssignments*`,
+      `**/Microsoft.DocumentDB/databaseAccounts/${targetAccountName}/sqlRoleAssignments*`,
       async (route) => {
         await route.fulfill({
           status: 200,
@@ -172,8 +172,14 @@ test.describe("Container Copy - Permission Screen Verification", () => {
           body: JSON.stringify({
             value: [
               {
-                principalId: "00-11-22-33",
-                roleDefinitionId: `Microsoft.DocumentDB/databaseAccounts/${sourceAccountName}/77-88-99`,
+                id: `${targetAccountScope}/sqlRoleAssignments/mock-role-assignment`,
+                name: "mock-role-assignment",
+                type: "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+                properties: {
+                  principalId: "00-11-22-33",
+                  roleDefinitionId: targetRoleDefinitionId,
+                  scope: `${targetAccountScope}/`,
+                },
               },
             ],
           }),
@@ -181,20 +187,25 @@ test.describe("Container Copy - Permission Screen Verification", () => {
       },
     );
 
-    await page.route("**/Microsoft.DocumentDB/databaseAccounts/*/77-88-99**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          value: [
-            {
-              // Built-in Cosmos DB Data Contributor role (read-write), required by checkTargetHasReadWriteRoleOnSource
-              name: "00000000-0000-0000-0000-000000000002",
-            },
-          ],
-        }),
-      });
-    });
+    await page.route(
+      `**/Microsoft.DocumentDB/databaseAccounts/${targetAccountName}/sqlRoleDefinitions/77-88-99*`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            id: targetRoleDefinitionId,
+            name: "00000000-0000-0000-0000-000000000002",
+            type: "Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions",
+            assignableScopes: [targetAccountScope],
+            permissions: [],
+            resourceGroup: resourceGroupName,
+            roleName: "Cosmos DB Built-in Data Contributor",
+            typePropertiesType: "BuiltInRole",
+          }),
+        });
+      },
+    );
 
     // Return the completed identity state only for the managed-identity action.
     await page.route(sourceAccountRoute, async (route) => {
@@ -272,13 +283,25 @@ test.describe("Container Copy - Permission Screen Verification", () => {
         response.url().includes(`/databaseAccounts/${sourceAccountName}`) &&
         response.url().includes("api-version=2025-05-01-preview"),
     );
+    const roleAssignmentsPromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === "GET" &&
+        response.url().includes(`/databaseAccounts/${targetAccountName}/sqlRoleAssignments`) &&
+        response.url().includes("api-version=2025-04-15"),
+    );
+    const roleDefinitionPromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === "GET" &&
+        response.url().includes(`/databaseAccounts/${targetAccountName}/sqlRoleDefinitions/77-88-99`) &&
+        response.url().includes("api-version=2025-04-15"),
+    );
     await yesButton.click({ force: true });
-    const [identityUpdateResponse, accountRefreshResponse] = await Promise.all([
-      identityUpdatePromise,
-      accountRefreshPromise,
-    ]);
+    const [identityUpdateResponse, accountRefreshResponse, roleAssignmentsResponse, roleDefinitionResponse] =
+      await Promise.all([identityUpdatePromise, accountRefreshPromise, roleAssignmentsPromise, roleDefinitionPromise]);
     expect(identityUpdateResponse.ok()).toBe(true);
     expect(accountRefreshResponse.ok()).toBe(true);
+    expect(roleAssignmentsResponse.ok()).toBe(true);
+    expect(roleDefinitionResponse.ok()).toBe(true);
 
     // Verify the refreshed account state completes the permission section.
     await expect(popover).toBeHidden({ timeout: VISIBLE_TIMEOUT_MS });

--- a/test/sql/containercopy/permissionsScreen.spec.ts
+++ b/test/sql/containercopy/permissionsScreen.spec.ts
@@ -102,37 +102,15 @@ test.describe("Container Copy - Permission Screen Verification", () => {
     await expect(permissionScreen.getByText("Online container copy", { exact: true })).toBeVisible();
     await expect(permissionScreen.getByText("Cross-account container copy", { exact: true })).toBeVisible();
 
-    // Mock source account updates and refreshes used by the permission actions.
-    await page.route(`**/Microsoft.DocumentDB/databaseAccounts/${sourceAccountName}**`, async (route) => {
-      const mockData = {
-        id: new URL(route.request().url()).pathname,
-        name: sourceAccountName,
-        location: "East US",
-        type: "Microsoft.DocumentDB/databaseAccounts",
-        kind: "GlobalDocumentDB",
-        identity: {
-          type: "SystemAssigned",
-          principalId: "00-11-22-33",
-        },
-        properties: {
-          defaultIdentity: "SystemAssignedIdentity",
-          backupPolicy: {
-            type: "Continuous",
-          },
-          capabilities: [{ name: "EnableOnlineContainerCopy" }],
-        },
-      };
-      if (route.request().method() === "PATCH") {
+    const sourceAccountRoute = `**/Microsoft.DocumentDB/databaseAccounts/${sourceAccountName}**`;
+
+    // Keep PITR polling deterministic without changing the source account state.
+    await page.route(sourceAccountRoute, async (route) => {
+      if (route.request().method() === "GET" && route.request().url().includes("api-version=2025-05-01-preview")) {
         await route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify({ status: "Succeeded" }),
-        });
-      } else if (route.request().method() === "GET") {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify(mockData),
+          body: JSON.stringify({ properties: { backupPolicy: { type: "Periodic" } } }),
         });
       } else {
         await route.continue();
@@ -180,6 +158,7 @@ test.describe("Container Copy - Permission Screen Verification", () => {
 
     await expect(refreshBtn).toBeVisible({ timeout: 5000 });
     await expect(pitrBtn).not.toBeVisible();
+    await page.unroute(sourceAccountRoute);
 
     // Setup additional API mocks for role assignments and permissions
     // In the redesigned flow, role assignments are checked on the SOURCE account (current account = sourceAccountName).
@@ -215,6 +194,43 @@ test.describe("Container Copy - Permission Screen Verification", () => {
           ],
         }),
       });
+    });
+
+    // Return the completed identity state only for the managed-identity action.
+    await page.route(sourceAccountRoute, async (route) => {
+      const mockData = {
+        id: new URL(route.request().url()).pathname,
+        name: sourceAccountName,
+        location: "East US",
+        type: "Microsoft.DocumentDB/databaseAccounts",
+        kind: "GlobalDocumentDB",
+        identity: {
+          type: "SystemAssigned",
+          principalId: "00-11-22-33",
+        },
+        properties: {
+          defaultIdentity: "SystemAssignedIdentity",
+          backupPolicy: {
+            type: "Continuous",
+          },
+          capabilities: [{ name: "EnableOnlineContainerCopy" }],
+        },
+      };
+      if (route.request().method() === "PATCH") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ status: "Succeeded" }),
+        });
+      } else if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(mockData),
+        });
+      } else {
+        await route.continue();
+      }
     });
 
     // Verify cross-account permissions functionality


### PR DESCRIPTION
## Summary

Stabilize the container-copy permission-screen E2E test by mocking the managed-identity update and subsequent permission-revalidation requests, separating request handlers by phase, and synchronizing popup and response events. Initial account state and discovery remain integration dependencies.

## Problem

The permission-screen test repeatedly failed across browser projects and sometimes exhausted all Playwright retries. The observed failures varied between attempts:

- the managed-identity confirmation popover did not appear;
- the popover remained visible after clicking **Yes**;
- the loading overlay appeared or disappeared between browser frames;
- the account refresh or permission revalidation did not complete within the assertion timeout.

The production identity update and revalidation flow performs four requests:

1. PATCH the source Cosmos account using API version `2025-04-15`.
2. GET the refreshed source account using API version `2025-05-01-preview`.
3. GET role assignments from the selected target account for the source account's managed identity.
4. GET each referenced role definition and revalidate the permission sections.

The previous test mocked the PATCH but called `route.fetch()` for the source-account GET, leaving its most timing-sensitive interaction dependent on live ARM latency and provisioned account state. Its RBAC mocks also targeted the source account instead of the selected target account and returned assignment fields outside the production `properties` object. Permission revalidation could therefore escape to live ARM before the confirmation UI closed.

The test also registered overlapping source-account route handlers, making request handling dependent on route-registration order.

## Changes

### Scope source-account requests by test phase

The source-account route is installed separately for each interaction phase:

- During Point-in-Time Restore polling, account GETs return the unchanged `Periodic` backup policy. This keeps polling deterministic without mutating shared copy-job state or completing permission sections early.
- After the PITR timeout is observed, that route is removed.
- Target-account role-assignment and role-definition mocks are installed before any identity-completion response can trigger permission revalidation.
- Immediately before the managed-identity action, a new handler returns the successful PATCH response and the complete post-update source account on the follow-up GET.

This prevents PITR polling from consuming the synthetic post-identity account while preserving deterministic identity mutation behavior. The unused Lodash `set` import remains removed.

### Mock target-account permission revalidation

The role-assignment mock now intercepts the selected target account, matching the account used by production permission validation. Its response uses the ARM resource shape expected by `RbacUtils`, including:

- `principalId`, `roleDefinitionId`, and `scope` under `properties`;
- a complete role-assignment resource ID;
- a complete target-account role-definition resource ID.

The referenced role definition is returned as a direct ARM resource with the built-in Cosmos DB Data Contributor role name. This allows revalidation to complete without a live target-account request.

### Synchronize all update and revalidation requests

Before clicking **Yes**, the test registers response waits for the exact production requests:

- PATCH to the source account with API version `2025-04-15`;
- GET of the source account with API version `2025-05-01-preview`;
- GET of role assignments from the selected target account with API version `2025-04-15`;
- GET of the referenced target-account role definition with API version `2025-04-15`.

The waits are established before the click so immediate mocked responses cannot be missed. The test awaits all four responses and checks that each succeeded before asserting on the resulting UI state.

The response predicates check the HTTP method, account URL fragments, and API versions, with role-resource fragments for RBAC responses. They narrow the waits to the expected flow; they are not full-URL equality checks.

### Assert the durable permission result

The previous test asserted that a loading overlay became visible and then hidden before checking that the popover disappeared. Loading indicators are transient and can complete between browser frames, particularly when network requests are mocked.

The test now verifies the durable user-visible result: after the account refresh and permission revalidation complete, the confirmation popover is removed. The assertion uses the existing 30-second visibility timeout to allow React state and validation to settle.

This removes the managed-identity loading-overlay transition assertion, not the earlier PITR loading-state assertions. It does not establish live ARM update behavior or new component-level loading coverage.

### Register the PITR popup wait before clicking

The Point-in-Time Restore flow previously clicked the button before attaching a page event listener. A synchronously opened page could therefore be missed, and assertions inside the event callback were not awaited by the test.

The test now:

1. creates a `waitForEvent("page")` promise;
2. clicks the PITR button;
3. awaits the new page;
4. awaits the expected backup/restore URL;
5. closes the page.

This makes popup creation and URL validation part of the test's actual completion criteria.

## Expected impact

- Once the managed-identity phase is reached, the mocked update, refresh, and target-account revalidation requests do not depend on live ARM response timing or returned payloads.
- Duplicate route-order behavior is eliminated.
- Fast PATCH, GET, role-assignment, and role-definition responses cannot escape Playwright's event waits.
- React permission revalidation is checked through its completed UI state instead of transient loading frames.
- PITR popup assertions can no longer execute outside the owning test.
- Existing Firefox, WebKit, Chrome, and Edge coverage remains unchanged.

## Remaining integration behavior

Resource Graph discovery still calls `route.fetch()` and modifies the returned account metadata. Authentication, provisioned account availability, and target-account selection therefore remain live dependencies. The initial source account comes from the live Explorer account context before the phase-specific routes are installed. If identity, backup, or copy prerequisites are already satisfied, the expected incomplete-permissions UI can differ. Fully deterministic initial prerequisite state is not implemented here.

The synthetic post-update identity, continuous-backup policy, and online-copy capability are browser responses. They do not enable those features on the real account. No production code, provisioned throughput, or real backup configuration is changed by this PR.

## Follow-up changes

Post-creation changes separate PITR polling from identity completion, remove the PITR handler before installing the completion handler, and correct RBAC interception to the selected target account. Role assignments now put principal, role-definition ID, and scope under `properties`; the referenced role definition is a direct resource rather than a list wrapper. Target RBAC handlers are installed before the synthetic identity state can trigger revalidation, and all four response waits are registered before confirmation.

## Dependencies and integration

- No hard code dependency on [#2594](https://github.com/Azure/cosmos-explorer/pull/2594), [#2595](https://github.com/Azure/cosmos-explorer/pull/2595), [#2596](https://github.com/Azure/cosmos-explorer/pull/2596), [#2598](https://github.com/Azure/cosmos-explorer/pull/2598), [#2599](https://github.com/Azure/cosmos-explorer/pull/2599), or [#2600](https://github.com/Azure/cosmos-explorer/pull/2600). No other PR in this series edits this spec.
- [#2594](https://github.com/Azure/cosmos-explorer/pull/2594) can reduce interference from other participating CI runs, but cannot normalize the live initial prerequisites or cover local runs and historical workflow revisions.
- [#2595](https://github.com/Azure/cosmos-explorer/pull/2595) addresses cleanup ownership, not account identity, backup policy, or RBAC state. [#2596](https://github.com/Azure/cosmos-explorer/pull/2596) isolates an unrelated throughput-bucket suite.
- [#2598](https://github.com/Azure/cosmos-explorer/pull/2598) and [#2599](https://github.com/Azure/cosmos-explorer/pull/2599) address document coverage/readiness and command targeting. They do not provide these mocks or complete initial-state isolation.
- [#2600](https://github.com/Azure/cosmos-explorer/pull/2600) statically checks the spec and imports; it cannot validate mocked ARM payloads against live service behavior or prove UI synchronization.

There is no required merge order. Request mocking reduces selected integration dependencies; it is not evidence that the whole permissions workflow is fully isolated or that all observed flakes are fixed.
