### PR TITLE
Reduce the SQL document test matrix

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
   projects: [
     {
       name: "firefox",
+      grepInvert: /@document-chrome-only/,
       use: {
         ...devices["Desktop Firefox"],
         launchOptions: {
@@ -50,6 +51,7 @@ export default defineConfig({
     },
     {
       name: "webkit",
+      grepInvert: /@document-chrome-only/,
       use: {
         ...devices["Desktop Safari"],
       },
@@ -66,6 +68,7 @@ export default defineConfig({
     },
     {
       name: "Microsoft Edge",
+      grepInvert: /@document-chrome-only/,
       use: {
         ...devices["Desktop Edge"],
         channel: "msedge",

--- a/test/sql/document.spec.ts
+++ b/test/sql/document.spec.ts
@@ -21,6 +21,26 @@ let documentsTab: DocumentsTab = null!;
 const chromeOnlyDocumentTag = "@document-chrome-only";
 const crossBrowserSmokeDocumentId = "singlePartitionKey";
 
+const waitForDocumentToLoad = async (documentId: string): Promise<void> => {
+  await expect
+    .poll(
+      async () => {
+        const resultText = await documentsTab.resultsEditor.text();
+        if (!resultText) {
+          return undefined;
+        }
+
+        try {
+          return JSON.parse(resultText)?.id;
+        } catch {
+          return undefined;
+        }
+      },
+      { timeout: ONE_MINUTE_MS },
+    )
+    .toBe(documentId);
+};
+
 for (const { name, databaseId, containerId, documents } of documentTestCases) {
   test.describe(`Test SQL Documents with ${name}`, () => {
     // test.skip(true, "Temporarily disabling all tests in this spec file");
@@ -50,7 +70,7 @@ for (const { name, databaseId, containerId, documents } of documentTestCases) {
           await expect(span).toBeVisible();
 
           await span.click();
-          await expect(documentsTab.resultsEditor.locator).toBeAttached({ timeout: 60 * 1000 });
+          await waitForDocumentToLoad(docId);
 
           const resultText = await documentsTab.resultsEditor.text();
           const resultData = JSON.parse(resultText!);
@@ -66,7 +86,7 @@ for (const { name, databaseId, containerId, documents } of documentTestCases) {
 
           await span.click();
           let newDocumentId;
-          await expect(documentsTab.resultsEditor.locator).toBeAttached({ timeout: 60 * 1000 });
+          await waitForDocumentToLoad(docId);
           await retry(async () => {
             const newDocumentButton = await explorer.waitForCommandBarButton("New Item", 5000);
             await expect(newDocumentButton).toBeVisible();
@@ -95,7 +115,7 @@ for (const { name, databaseId, containerId, documents } of documentTestCases) {
           await newSpan.waitFor();
 
           await newSpan.click();
-          await expect(documentsTab.resultsEditor.locator).toBeAttached({ timeout: 60 * 1000 });
+          await waitForDocumentToLoad(newDocumentId);
 
           const deleteButton = await explorer.waitForCommandBarButton("Delete", 5000);
           await deleteButton.click();

--- a/test/sql/document.spec.ts
+++ b/test/sql/document.spec.ts
@@ -18,6 +18,9 @@ import { documentTestCases } from "./testCases";
 let explorer: DataExplorer = null!;
 let documentsTab: DocumentsTab = null!;
 
+const chromeOnlyDocumentTag = "@document-chrome-only";
+const crossBrowserSmokeDocumentId = "singlePartitionKey";
+
 for (const { name, databaseId, containerId, documents } of documentTestCases) {
   test.describe(`Test SQL Documents with ${name}`, () => {
     // test.skip(true, "Temporarily disabling all tests in this spec file");
@@ -39,8 +42,9 @@ for (const { name, databaseId, containerId, documents } of documentTestCases) {
 
     for (const document of documents) {
       const { documentId: docId, partitionKeys, skipCreateDelete } = document;
+      const testDetails = { tag: docId === crossBrowserSmokeDocumentId ? [] : [chromeOnlyDocumentTag] };
       test.describe(`Document ID: ${docId}`, () => {
-        test(`should load and view document ${docId}`, async () => {
+        test(`should load and view document ${docId}`, testDetails, async () => {
           const span = documentsTab.documentsListPane.getByText(docId, { exact: true }).nth(0);
           await span.waitFor();
           await expect(span).toBeVisible();
@@ -55,14 +59,14 @@ for (const { name, databaseId, containerId, documents } of documentTestCases) {
         });
 
         const testOrSkip = skipCreateDelete ? test.skip : test;
-        testOrSkip(`should be able to create and delete new document from ${docId}`, async ({ page }) => {
+        testOrSkip(`should be able to create and delete new document from ${docId}`, testDetails, async () => {
           const span = documentsTab.documentsListPane.getByText(docId, { exact: true }).nth(0);
           await span.waitFor();
           await expect(span).toBeVisible();
 
           await span.click();
           let newDocumentId;
-          await page.waitForTimeout(5000);
+          await expect(documentsTab.resultsEditor.locator).toBeAttached({ timeout: 60 * 1000 });
           await retry(async () => {
             const newDocumentButton = await explorer.waitForCommandBarButton("New Item", 5000);
             await expect(newDocumentButton).toBeVisible();


### PR DESCRIPTION
## Summary

Reduce the SQL document Playwright matrix while preserving the complete data-shape suite in Chrome and representative document workflows in every configured browser.

## Why

`test/sql/document.spec.ts` currently generates 88 tests for each of Firefox, WebKit, Chrome, and Edge, for 352 discovered tests in one file. Most of those tests repeat the same partition-key data semantics while reopening Explorer and discovering the same seeded read-only database.

This duplicates expensive UI and account-tree work across browsers, increases load on the shared SQL read-only account, and enlarges the surface for setup timeouts and missing-tree-node failures without adding equivalent browser-specific coverage.

## Changes

### Keep the full document matrix in Chrome

All document cases except the representative `singlePartitionKey` case now carry an `@document-chrome-only` Playwright tag. The Chrome project has no exclusion and continues to run every existing document case, including normal, empty, null, missing, nested, hierarchical, quoted, and whitespace partition-key values.

### Preserve cross-browser smoke coverage

Firefox, WebKit, and Edge exclude the `@document-chrome-only` tag through their project configuration. Each still exercises:

- Loading and viewing a document with a standard partition key
- Creating and deleting a document with that partition key
- Uploading valid document data
- Rejecting invalid uploaded JSON

The upload tests remain untagged and continue to run in all four browsers.

### Replace the fixed readiness delay

The create/delete workflow no longer waits an unconditional five seconds after selecting a document. A shared helper now polls the Monaco editor content until its parsed `id` matches the selected document before either reading it or opening New Item. The same content-based wait is used after selecting a newly created document before deletion.

This ties readiness to the document selection that just occurred instead of the persistent editor host, allowing ready content to proceed immediately while giving slower document loads a meaningful condition and timeout.

## Expected impact

The discovered matrix for this file changes from:

- 88 tests in each of four browsers
- 352 tests total

To:

- 88 tests in Chrome
- 4 tests each in Firefox, WebKit, and Edge
- 100 tests total

This removes 252 discovered entries, a 71.6% reduction. Those totals include existing skipped cases: excluding them, the matrix has 340 eligible executions before and 97 after, a reduction of 243 before retries. Existing skip conditions are unchanged. The removed executions include 117 create/delete cases and 126 view cases. The smaller matrix should reduce Explorer startups, shared-account requests, and exposure to account-tree timing failures; these counts are not a measured reduction in flake probability, runtime, or Azure spending.

## Tradeoffs and remaining limitations

Unusual partition-key combinations no longer run in Firefox, WebKit, or Edge. A defect specific to one of those browsers and an omitted data shape can be missed entirely; Chrome coverage cannot detect a defect exclusive to another browser. Representative view/create/delete and both upload workflows remain cross-browser.

This change reduces requests against the seeded SQL read-only account but does not isolate it or lower its provisioned capacity. Fewer requests do not automatically reduce a provisioned-throughput bill. Retries, actual request charges, and report sizes still determine execution-level resource use.

Per-run seeded data and account-pool leasing remain separate infrastructure work. The document-content wait checks the selected ID, not backend throughput propagation or account-tree readiness. Existing application and environment failures can still occur.

## Follow-up changes

The post-creation readiness correction replaces editor-host attachment checks with polling of parsed Monaco content until the selected document ID matches. It is used before reading a selected document, before opening New Item, and after selecting the newly created document for deletion. Missing or incomplete JSON keeps the poll pending. The fixed five-second delay is removed; the shared content wait has a one-minute timeout.

## Dependencies and integration

- No hard code dependency on another mitigation PR; the tag filtering and content wait target master independently.
- [#2600](https://github.com/Azure/cosmos-explorer/pull/2600) also edits `test/sql/document.spec.ts`, replacing raw New Item, Save, and Delete command labels with enum members. Preserve those typed arguments together with this PR's tags and selected-content waits. Do not restore the fixed delay or attachment-only checks when resolving surrounding context.
- [#2600](https://github.com/Azure/cosmos-explorer/pull/2600) includes `playwright.config.ts` in type-checking; this PR changes that file's browser filters. Type-checking does not change the selected matrix or establish browser behavior.
- [#2594](https://github.com/Azure/cosmos-explorer/pull/2594) coordinates participating workflow runs but does not give this suite private seeded data. [#2595](https://github.com/Azure/cosmos-explorer/pull/2595) continues to skip the `-readonly` account and does not clean or isolate its seeded documents.
- [#2596](https://github.com/Azure/cosmos-explorer/pull/2596), [#2597](https://github.com/Azure/cosmos-explorer/pull/2597), and [#2599](https://github.com/Azure/cosmos-explorer/pull/2599) address other lifecycle, permission, and command-selection risks; none supplies the readiness condition in this PR.

There is no required merge order. Retaining the content wait and [#2600](https://github.com/Azure/cosmos-explorer/pull/2600)'s type corrections together is an integration requirement, not a branch dependency.
