### PR TITLE
Stabilize global E2E command selection

### DIFF
--- a/test/fx.ts
+++ b/test/fx.ts
@@ -497,13 +497,18 @@ export class DataExplorer {
     return new DocumentsTab(this.frame, tabId, tab, documentsTab);
   }
 
-  /** Select the primary global command button.
-   *
-   * There's only a single "primary" button, but we still require you to pass the label to confirm you're selecting the right button.
-   */
+  /** Select a global command from either the primary button or the overflow menu. */
   async globalCommandButton(label: string): Promise<Locator> {
-    await this.frame.getByTestId("GlobalCommands").click();
-    return this.frame.getByRole("menuitem", { name: label });
+    const globalCommands = this.frame.getByTestId("GlobalCommands");
+    const primaryButton = globalCommands.getByRole("button", { name: label, exact: true });
+    if (await primaryButton.isVisible()) {
+      return primaryButton;
+    }
+
+    await globalCommands.locator('button[aria-haspopup="menu"]:visible').click();
+    const menuItem = this.frame.getByRole("menuitem", { name: label, exact: true });
+    await menuItem.waitFor();
+    return menuItem;
   }
 
   /** Select the command bar button with the specified label */


### PR DESCRIPTION
## Summary

Make Playwright global-command targeting explicit: return the matching visible primary button, or open the menu through its trigger before selecting a secondary command. This removes wrapper hit-testing ambiguity without claiming to resolve every panel-opening timeout.

## Why

A recent Microsoft Edge shard exposed three failures in `test/sql/scaleAndSettings/sharedThroughput.spec.ts` while opening the **New Container** panel:

- one test failed after all retries;
- two related tests recovered only after retries;
- every failure timed out waiting for `Panel:New Container` to become visible;
- the affected shard took 46 minutes.

The affected attempts did not reach their shared-throughput assertions. They timed out between the global command action and visibility of the New Container panel. That symptom motivates improving command targeting, but does not by itself prove that wrapper hit testing caused the failures.

`DataExplorer.globalCommandButton()` previously clicked the `GlobalCommands` wrapper and then returned a matching menu item. That wrapper contains multiple interactive controls in the current sidebar implementation:

- the primary action button;
- the split-button menu trigger;
- a responsive overflow-menu trigger;
- menu items after the menu opens.

Clicking the wrapper relies on browser layout and hit testing to determine which child receives the event. It also treats primary commands such as **New Container** as though they must always be selected from the overflow menu. This leaves panel navigation sensitive to browser-specific rendering and timing.

## Changes

### Select primary commands directly

`globalCommandButton()` now looks inside `GlobalCommands` for a visible button whose accessible name exactly matches the requested command.

When the requested command is the primary action, such as **New Container**, **New Collection**, **New Graph**, or **New Table**, the helper returns that button directly. The calling test then clicks the actual control that owns the action.

### Open secondary commands through the explicit menu trigger

If no matching primary button is visible, the helper selects the visible button with `aria-haspopup="menu"` and opens the overflow menu explicitly.

It then locates the requested menu item by exact accessible name and waits for that item before returning it. Secondary commands such as **New Database** retain their menu-based behavior without depending on a click against the surrounding layout container.

### Keep the fix at the shared abstraction

The shared-throughput test retains its existing call pattern. The correction is implemented in `test/fx.ts`, where command selection is owned, rather than duplicating a test-local New Container workaround.

## Expected impact

- New Container panel navigation no longer depends on where a browser places the clickable center of the global-command wrapper.
- Edge should invoke the same primary command control as Firefox, WebKit, and Chrome.
- Correctly targeted commands remove one avoidable source of navigation failure. A panel can still time out before throughput assertions when downstream loading or environment operations fail.
- Other suites using the same helper also receive deterministic primary-command selection:
  - SQL New Container
  - Mongo New Collection
  - Gremlin New Graph
  - Cassandra New Table
- Secondary commands continue to use the overflow menu through an explicit trigger.

## Tradeoffs and remaining limitations

The helper relies on accurate accessible button names and menu semantics. It checks primary-button visibility at the time of lookup and otherwise uses the visible menu trigger; it does not add a readiness poll for an asynchronously appearing primary button. Label, responsive-layout, or accessibility changes may require selector updates.

The production `Explorer.onNewCollectionClicked` path awaits `loadAllOffers` or `loadDatabaseOffers` before opening the New Container panel. A slow or failed offer request can produce the same panel-visibility timeout even after the correct command is clicked. This PR does not change those requests, add backend throughput-state polling, or establish the root cause of the observed Edge failures.

Only the shared test helper changes. Existing manual/autoscale test values, resource creation and disposal, browser coverage, and production behavior remain unchanged. Any reduction in retries, timeouts, or Azure cost is an expected benefit to assess in CI, not an established result.

## Dependencies and integration

- No hard code dependency on another mitigation PR; this branch targets master independently and changes only `DataExplorer.globalCommandButton` in `test/fx.ts`.
- [#2595](https://github.com/Azure/cosmos-explorer/pull/2595) also edits that helper file, extracting resource-name generation. Preserve its delegation and this PR's command selection; they solve unrelated problems.
- [#2600](https://github.com/Azure/cosmos-explorer/pull/2600) adds an explicit fallback return and a New Item enum member in the same file. Preserve those type corrections. Its compiler check cannot prove that rendered buttons, menu triggers, or offer-loading behavior match expectations.
- [#2594](https://github.com/Azure/cosmos-explorer/pull/2594) can reduce cross-workflow contention among participating runs, but is not a prerequisite and does not remove offer-loading latency.
- [#2596](https://github.com/Azure/cosmos-explorer/pull/2596) isolates throughput-bucket configuration, not the shared-throughput suite or account offer loading. It does not supply a missing backend synchronization fix here.
- [#2597](https://github.com/Azure/cosmos-explorer/pull/2597) and [#2598](https://github.com/Azure/cosmos-explorer/pull/2598) address permission mocks and document workflows, with no required ordering relative to this helper change.

There is no required merge order. Shared-file overlap is an integration consideration, not a requirement to stack these branches or a claim that their combined runtime behavior is already established.
