### PR TITLE
Type-check Playwright E2E tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - run: npm ci
       - run: npm run compile
       - run: npm run compile:strict
+      - run: npm run compile:e2e
   format:
     runs-on: ubuntu-latest
     name: "Check Format"

--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
     "build:ase": "gulp build:ase",
     "selfServeDocs": "typedoc",
     "compile": "tsc",
+    "compile:e2e": "tsc -p ./tsconfig.test.json",
     "compile:contracts": "tsc -p ./tsconfig.contracts.json",
     "compile:strict": "tsc -p ./tsconfig.strict.json",
     "format": "prettier --write \"{src,test}/**/*.{ts,tsx,html}\" \"*.{js,html}\"",

--- a/test/README.md
+++ b/test/README.md
@@ -4,6 +4,21 @@ This directory contains end-to-end tests for Cosmos Data Explorer.
 These tests **require** that you either deploy, or have access to, several Cosmos test Accounts.
 The tests run in [Playwright](https://playwright.dev/), using the official Playwright test framework.
 
+## Type-checking
+
+After installing dependencies, run this command from the repository root:
+
+```shell
+npm run compile:e2e
+```
+
+This checks all test TypeScript files and `playwright.config.ts` without emitting files,
+starting a browser, or connecting to Azure. It also loads the application declarations
+needed by code imported from the tests. CI runs this check in the Compile TypeScript job.
+
+`npm run compile` checks the application, not the E2E suite. Playwright's `--list` option
+checks test discovery but does not replace TypeScript type-checking.
+
 ## Required Resources
 
 To run all the tests, you need:

--- a/test/fx.ts
+++ b/test/fx.ts
@@ -118,6 +118,7 @@ function tryGetStandardName(accountType: TestAccount) {
       : `${process.env.DE_TEST_ACCOUNT_PREFIX}-`;
     return `${actualPrefix}${accountType.toLocaleLowerCase()}`;
   }
+  return undefined;
 }
 
 // Maps a base API account type to its dedicated connection string (account key) account.
@@ -474,6 +475,7 @@ export enum CommandBarButton {
   ExecuteQuery = "Execute Query",
   UploadItem = "Upload Item",
   NewDocument = "New Document",
+  NewItem = "New Item",
   View = "View",
 }
 

--- a/test/sql/document.spec.ts
+++ b/test/sql/document.spec.ts
@@ -64,7 +64,7 @@ for (const { name, databaseId, containerId, documents } of documentTestCases) {
           let newDocumentId;
           await page.waitForTimeout(5000);
           await retry(async () => {
-            const newDocumentButton = await explorer.waitForCommandBarButton("New Item", 5000);
+            const newDocumentButton = await explorer.waitForCommandBarButton(CommandBarButton.NewItem, 5000);
             await expect(newDocumentButton).toBeVisible();
             await expect(newDocumentButton).toBeEnabled();
             await newDocumentButton.click();
@@ -79,7 +79,7 @@ for (const { name, databaseId, containerId, documents } of documentTestCases) {
             };
 
             await documentsTab.resultsEditor.setText(JSON.stringify(newDocument));
-            const saveButton = await explorer.waitForCommandBarButton("Save", 5000);
+            const saveButton = await explorer.waitForCommandBarButton(CommandBarButton.Save, 5000);
             await saveButton.click({ timeout: 5000 });
             await expect(saveButton).toBeHidden({ timeout: 5000 });
           }, 3);
@@ -93,7 +93,7 @@ for (const { name, databaseId, containerId, documents } of documentTestCases) {
           await newSpan.click();
           await expect(documentsTab.resultsEditor.locator).toBeAttached({ timeout: 60 * 1000 });
 
-          const deleteButton = await explorer.waitForCommandBarButton("Delete", 5000);
+          const deleteButton = await explorer.waitForCommandBarButton(CommandBarButton.Delete, 5000);
           await deleteButton.click();
 
           const deleteDialogButton = await explorer.waitForDialogButton("Delete", 5000);

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["./test/**/*"],
+  "include": ["./test/**/*", "./playwright.config.ts", "./src/**/*.d.ts"],
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "commonjs",
+    "lib": ["es2022", "dom"],
+    "types": ["jest", "node"]
   }
 }


### PR DESCRIPTION
## Summary

Add a dedicated TypeScript check for the Playwright E2E suite and runner configuration, enforce it in the existing CI compile job, and fix the baseline test-code errors that prevented enabling it.

## Why

The application TypeScript configuration includes `src` and `utils`, but not the E2E `test` directory. A successful `npm run compile` therefore does not establish that the Playwright tests and shared helpers are type-correct.

Playwright transforms TypeScript for execution without performing a full TypeScript type-check. Test discovery with `--list` is useful for confirming test selection, but it does not close this validation gap either.

The repository already has `tsconfig.test.json`, but CI does not invoke it and its inputs omit environment and application declarations required by the test dependency graph.

## Changes

### Complete the E2E compiler configuration

Extend the existing test configuration to include:

- All sources under `test/**/*`, including shared fixtures and helpers.
- `playwright.config.ts`, covering runner options and browser projects.
- Application declaration files under `src/**/*.d.ts`, including asset-module declarations and browser-interface extensions needed by imported application code.

Add Node types for APIs such as `process`, `Buffer`, `fs`, and `crypto`, while retaining the existing Jest types. Set the library definitions to `es2022` and `dom` to describe modern JavaScript and browser APIs used by the tests and their imports in the Node 22 CI environment.

These changes affect compile-time definitions only. They do not install polyfills, change the JavaScript emit target, or alter application runtime behavior. CommonJS mode and inherited checks, including `noImplicitAny`, `noImplicitReturns`, and `noEmit`, remain in place. No test exclusions or type-check suppressions are added. The small configuration file is also normalized from CRLF to LF.

### Fix four baseline test-code errors

- Add an explicit `return undefined` to `tryGetStandardName()` when no account prefix is configured. This preserves the existing JavaScript fall-through behavior while satisfying `noImplicitReturns`.
- Add `CommandBarButton.NewItem = "New Item"` to the existing command enum.
- Replace the document test's raw `"New Item"`, `"Save"`, and `"Delete"` arguments with the corresponding enum members required by `waitForCommandBarButton()`.

The command labels and generated selectors remain identical. The helper's argument type is not broadened to accept arbitrary strings.

### Add a reusable command and CI enforcement

Expose `compile:e2e` as an npm script that runs `tsc -p ./tsconfig.test.json`.

The existing **Compile TypeScript** job now runs E2E compilation after the application and strict-subset checks. E2E type errors fail that job without requiring browser installation, a development server, or Azure credentials for the type-check itself.

Document the command and its distinction from application compilation and Playwright discovery in `test/README.md`.

## Expected impact

- Catch incompatible helper arguments, missing environment types, invalid runner options, and other static errors in E2E code through CI compilation.
- Give contributors a single E2E type-check command with the same configuration used by CI.
- Improve confidence in test changes independently of whether a live browser run reaches the affected code path.
- Retain existing test selection, browser coverage, runtime command labels, and compiler safeguards.

## Scope and limitations

This is a static correctness gate, not a fix for runtime flakiness. It cannot establish that selectors match rendered controls, asynchronous waits are sufficient, Azure authentication works, or test assertions are correct. Browser execution remains necessary.

The compile job gains an additional TypeScript pass, including application dependencies imported by tests. No new job, permission, dependency, or infrastructure is introduced. The lockfile is unchanged.

Other CI jobs continue to run independently; Playwright shards are not newly made dependent on the compile job. Existing local `build` scripts are unchanged, so E2E compilation remains an explicit command outside this CI job. This change preserves the repository's current strictness settings rather than enabling full strict mode for the E2E suite.

## Dependencies and integration

This PR addresses the static-checking gap identified during the review of [#2594](https://github.com/Azure/cosmos-explorer/pull/2594) through [#2599](https://github.com/Azure/cosmos-explorer/pull/2599). It was added after the runtime mitigations, targets master independently, and does not incorporate their branches. None is a hard prerequisite and there is no required merge order. Landing this check early is useful for subsequent integration, not necessary for the other PRs' runtime behavior.

Preserve these complementary changes when integrating shared files:

| Related PR | Shared files | Changes to retain together |
| --- | --- | --- |
| [#2594](https://github.com/Azure/cosmos-explorer/pull/2594) | `.github/workflows/ci.yml` | Its queue, current-attempt admission guard, and conditional uploads alongside this PR's compile-job step. |
| [#2595](https://github.com/Azure/cosmos-explorer/pull/2595) | `package.json`, `test/fx.ts` | Its Node utility-test command and resource-name formatter delegation alongside `compile:e2e`, the explicit fallback return, and the command enum addition. |
| [#2598](https://github.com/Azure/cosmos-explorer/pull/2598) | `test/sql/document.spec.ts` | Its Chrome-only tags and selected-document content waits alongside typed New Item, Save, and Delete arguments. Do not restore the older fixed delay or attachment-only wait from unchanged diff context. |
| [#2599](https://github.com/Azure/cosmos-explorer/pull/2599) | `test/fx.ts` | Its primary-button/menu-trigger targeting alongside the separate typing fixes. |

[#2596](https://github.com/Azure/cosmos-explorer/pull/2596) and [#2597](https://github.com/Azure/cosmos-explorer/pull/2597) do not share changed files with this PR, but their specs and imports become part of the E2E compiler's scope when integrated. Type-checking does not provide per-test resource isolation, validate mocked ARM service contracts, or prove the runtime synchronization in those changes.

Playwright jobs remain independent of the compile job, including when combined with [#2594](https://github.com/Azure/cosmos-explorer/pull/2594). A failed type-check can coexist with already-running browser tests and does not automatically prevent Azure resource creation. This PR itself performs no browser execution or Azure operations.

CI status checks remain the validation source of truth. Independent PR checks do not establish combined runtime behavior; use CI on the integrated changes before attributing a flake-rate improvement to the series.
