### PR TITLE
Avoid opening tab path tooltips during automatic focus

### DIFF
--- a/src/Explorer/Tabs/Tabs.tsx
+++ b/src/Explorer/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import { Spinner, SpinnerSize, TooltipHost } from "@fluentui/react";
+import { ITooltipHost, Spinner, SpinnerSize, TooltipHost } from "@fluentui/react";
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from "@fluentui/react-components";
 import { CollectionTabKind } from "Contracts/ViewModels";
 import Explorer from "Explorer/Explorer";
@@ -74,6 +74,7 @@ export const Tabs = ({ explorer }: TabsProps): JSX.Element => {
 function TabNav({ tab, active, tabKind }: { tab?: Tab; active: boolean; tabKind?: ReactTabKind }) {
   const [hovering, setHovering] = useState(false);
   const focusTab = useRef<HTMLLIElement>() as MutableRefObject<HTMLLIElement>;
+  const tabTooltip = useRef<ITooltipHost>(null);
   const tabId = tab ? tab.tabId : "";
 
   const getReactTabTitle = (): ko.Observable<string> => {
@@ -85,6 +86,7 @@ function TabNav({ tab, active, tabKind }: { tab?: Tab; active: boolean; tabKind?
   useEffect(() => {
     if (active && focusTab.current) {
       focusTab.current.focus();
+      tabTooltip.current?.dismiss();
     }
   }, [active]);
   const liElement = (
@@ -98,7 +100,7 @@ function TabNav({ tab, active, tabKind }: { tab?: Tab; active: boolean; tabKind?
     >
       <span className="tabNavContentContainer">
         <div className="tab_Content">
-          <TooltipHost content={useObservable(tab?.tabPath || ko.observable(""))}>
+          <TooltipHost componentRef={tabTooltip} content={useObservable(tab?.tabPath || ko.observable(""))}>
             <span
               className="contentWrapper"
               onClick={() => {

--- a/src/Explorer/Tabs/useTabs.test.ts
+++ b/src/Explorer/Tabs/useTabs.test.ts
@@ -1,11 +1,69 @@
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { DocumentsTabV2 } from "Explorer/Tabs/DocumentsTabV2/DocumentsTabV2";
 import * as ko from "knockout";
+import React from "react";
 import * as ViewModels from "../../Contracts/ViewModels";
 import { updateUserContext } from "../../UserContext";
 import { useTabs } from "../../hooks/useTabs";
 import { container } from "../Controls/Settings/TestUtils";
 import DocumentId from "../Tree/DocumentId";
 import { NewQueryTab } from "./QueryTab/QueryTab";
+import { Tabs } from "./Tabs";
+import TabsBase from "./TabsBase";
+
+describe("Tab path tooltips", () => {
+  const renderActiveTab = () => {
+    const tab = Object.assign(
+      new TabsBase({ tabKind: ViewModels.CollectionTabKind.Query, title: "Query 1", tabPath: "" }),
+      { render: () => React.createElement("button", null, "Execute Query") },
+    );
+    tab.tabPath = ko.observable("t_34646986695_1_dbc3_1789160465183>testcontainer>Query 1");
+    useTabs.setState({ openedTabs: [tab], activeTab: tab });
+    return render(React.createElement(Tabs, { explorer: container }));
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    useTabs.setState({ openedTabs: [], openedReactTabs: [], activeTab: undefined, activeReactTab: undefined });
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    useTabs.setState({ openedTabs: [], activeTab: undefined });
+  });
+
+  it("focuses an activated tab without opening its path tooltip", () => {
+    const view = renderActiveTab();
+    expect(document.activeElement).toBe(view.getByRole("tab", { name: "Query 1" }));
+
+    act(() => jest.advanceTimersByTime(1000));
+    expect(document.querySelector(".ms-Tooltip")).toBeNull();
+  });
+
+  it.each(["hover", "focus"])("keeps the path tooltip available on later %s and dismissible with Escape", (trigger) => {
+    const view = renderActiveTab();
+    const tab = view.getByRole("tab", { name: "Query 1" });
+    act(() => jest.advanceTimersByTime(1000));
+
+    if (trigger === "hover") {
+      fireEvent.mouseEnter(tab);
+    } else {
+      act(() => {
+        view.getByRole("button", { name: "Execute Query" }).focus();
+        tab.focus();
+      });
+    }
+
+    act(() => jest.advanceTimersByTime(1000));
+    expect(document.querySelector(".ms-Tooltip")?.textContent).toContain("testcontainer>Query 1");
+
+    fireEvent.keyDown(tab, { key: "Escape", keyCode: 27, which: 27 });
+    expect(document.querySelector(".ms-Tooltip")).toBeNull();
+    expect(document.activeElement).toBe(tab);
+  });
+});
 
 describe("useTabs tests", () => {
   let database: ViewModels.Database;

--- a/test/sql/indexAdvisor.spec.ts
+++ b/test/sql/indexAdvisor.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { CommandBarButton, DataExplorer, TestAccount } from "../fx";
+import { CommandBarButton, DataExplorer, generateUniqueName, TestAccount } from "../fx";
 import { createTestSQLContainer, TestContainerContext } from "../testData";
 
 // Test container context for setup and cleanup
@@ -10,7 +10,10 @@ let CONTAINER_ID: string;
 
 // Set up test database and container with data before all tests
 test.beforeAll(async () => {
-  testContainer = await createTestSQLContainer({ includeTestData: true });
+  testContainer = await createTestSQLContainer({
+    includeTestData: true,
+    databaseName: generateUniqueName("db_tab_tooltip_with_a_long_resource_name"),
+  });
   DATABASE_ID = testContainer.database.id;
   CONTAINER_ID = testContainer.container.id;
 });


### PR DESCRIPTION
## Summary

Prevent automatic tab activation from opening a path tooltip over nearby controls, while preserving tab focus, normal hover/focus tooltips, and Escape dismissal.

## Problem

`TabNav` focuses a tab when it becomes active. Fluent UI's `TooltipHost` handles that programmatic focus like user focus and schedules the path tooltip to open after its delay. The resulting callout can cover controls below the tab strip, even though the user did not request a tooltip. A normal Playwright click then waits for the target to receive pointer events while the tooltip remains in the way.

This became visible during the investigation of the longer run-owned resource names in [#2595](https://github.com/Azure/cosmos-explorer/pull/2595). CI logs explicitly identify the path tooltip as intercepting clicks:

- [Execute Query in Chrome](https://github.com/Azure/cosmos-explorer/actions/runs/34646986695/job/103420018811).
- [Container Policies in Edge](https://github.com/Azure/cosmos-explorer/actions/runs/34646986695/job/103420018840).
- [The same obstruction on an earlier naming-PR commit](https://github.com/Azure/cosmos-explorer/actions/runs/34644561411/job/103412113368).

The latest investigated #2595 run contains 27 terminally failed cases with tooltip-interception evidence across all four browser projects. Its other failures include authentication and throttling errors, so this PR does not attribute the entire failed run to tooltips.

## Changes

### Cancel the activation-triggered popup

Keep a component ref to the tab-path `TooltipHost`. Immediately after the existing activation effect focuses the tab, call `dismiss()` on that host. Fluent UI's dismissal clears the pending open and close timers and hides an already-visible tooltip, so it also handles the delayed popup before it renders.

The dismissal runs only in the existing effect when a tab is active. It does not remove focus, disable pointer events, suppress all tooltips, change tooltip positioning, or replace Fluent UI. Later hover and focus events can still open the tooltip, and Escape retains its dismissal behavior. Error and warning tooltips are unchanged.

### Cover the focus lifecycle

Extend the existing tab unit-test file with regressions for:

- automatic activation preserving tab focus without opening a path tooltip after the delay;
- later mouse hover still exposing the path;
- later focus still exposing the path;
- Escape dismissing the tooltip without moving focus away from the tab.

The tests render the real `Tabs` component with a long database/container path and use fake timers to cover the delayed-open behavior.

### Exercise long paths in the existing E2E workflow

Give the Index Advisor suite a longer, uniquely generated database name through the existing `databaseName` option. Its existing workflow already opens a query tab and clicks Execute Query, which is one of the controls identified in the CI obstruction. All configured browsers retain that coverage.

No extra test database, container, scenario, dependency, or infrastructure is introduced. The suite's throughput, data population, and disposal behavior remain unchanged; only its resource-name length changes.

## Expected impact and limitations

The fix removes unwanted tooltip opening caused by automatic activation, reducing the chance that newly opened or activated tabs obstruct the next command. Intentionally displayed hover/focus tooltips remain available and can still occupy space over adjacent UI; this is not a blanket guarantee that every tooltip can never overlap another control.

This PR does not address New Container offer-loading delays, shared-account contention, expired credentials, or report-classification errors. CI results remain the source of truth for integration behavior and any reduction in the observed failures.

## Dependencies and integration

This branch targets master independently and has no hard code dependency on [#2595](https://github.com/Azure/cosmos-explorer/pull/2595) or the other CI mitigation PRs. Its long-name E2E setup uses the existing naming API, and remains compatible with #2595's run/attempt attribution.

Land this fix before, or together with, #2595 to address the activation-triggered obstruction exposed by longer names. This is an integration recommendation, not a requirement to stack the branches. The queue, cleanup, permissions, document matrix, command targeting, and E2E type-check changes remain separate.